### PR TITLE
Add warning to w_truncate to remove corresponding file-system data

### DIFF
--- a/lib/cmds/w_truncate.py
+++ b/lib/cmds/w_truncate.py
@@ -24,9 +24,18 @@ log = logging.getLogger('w_truncate')
 
 import westpa
 
+warning_string = '''\
+NOTE: w_truncate only deletes iteration groups from the HDF5 data store.
+It is recommended that any iteration data saved to the file system (e.g. in the
+traj_segs directory) is deleted or moved for the corresponding iterations.
+'''
+
 parser = argparse.ArgumentParser('w_truncate', description='''\
-Remove all iterations after a certain point in a  
-''')
+Remove all iterations after a certain point in a WESTPA simulation.
+''',
+epilog=warning_string)
+
+
 westpa.rc.add_args(parser)
 parser.add_argument('-n', '--iter', dest='n_iter', type=int,
                     help='Truncate this iteration and those following.')
@@ -44,6 +53,7 @@ dm.del_iter_summary(n_iter)
 dm.current_iteration = n_iter - 1
 
 print('simulation data truncated after iteration {}'.format(dm.current_iteration))
+print('\n' + warning_string)
 
 dm.flush_backing()
 dm.close_backing()


### PR DESCRIPTION
This addresses the issue reported in westpa/west_tools#4 and gives explicit recommendations to the user to remove file-system data corresponding to truncated iterations. 