### PR TITLE
Force users to explicitly set WEST_ROOT in examples

### DIFF
--- a/lib/examples/nacl_amb/env.sh
+++ b/lib/examples/nacl_amb/env.sh
@@ -11,7 +11,11 @@ export CPPTRAJ=$(which cpptraj)
 
 # Inform WEST where to find Python and our other scripts where to find WEST
 export WEST_PYTHON=$(which python2.7)
-export WEST_ROOT=$(readlink -f $PWD/../../..)
+
+if [[ -z "$WEST_ROOT" ]]; then
+    echo "Must set environ variable WEST_ROOT"
+    exit
+fi
 
 # Explicitly name our simulation root directory
 if [[ -z "$WEST_SIM_ROOT" ]]; then

--- a/lib/examples/nacl_gmx/env.sh
+++ b/lib/examples/nacl_gmx/env.sh
@@ -15,7 +15,10 @@ fi
 
 # Inform WEST where to find Python and our other scripts where to find WEST
 export WEST_PYTHON=$(which python2.7)
-export WEST_ROOT=$(readlink -f $PWD/../../..)
+if [[ -z "$WEST_ROOT" ]]; then
+    echo "Must set environ variable WEST_ROOT"
+    exit
+fi
 
 # Explicitly name our simulation root directory
 if [[ -z "$WEST_SIM_ROOT" ]]; then

--- a/lib/examples/nacl_namd/env.sh
+++ b/lib/examples/nacl_namd/env.sh
@@ -6,7 +6,10 @@ export NAMD=$(which namd2)
 
 # Inform WEST where to find Python and our other scripts where to find WEST
 export WEST_PYTHON=$(which python2.7)
-export WEST_ROOT=$(readlink -f $PWD/../../..)
+if [[ -z "$WEST_ROOT" ]]; then
+    echo "Must set environ variable WEST_ROOT"
+    exit
+fi
 
 # Explicitly name our simulation root directory
 if [[ -z "$WEST_SIM_ROOT" ]]; then

--- a/lib/examples/nacl_openmm/env.sh
+++ b/lib/examples/nacl_openmm/env.sh
@@ -1,6 +1,9 @@
 # Inform WEST where to find Python and our other scripts where to find WEST
 export WEST_PYTHON=$(which python2.7)
-export WEST_ROOT=$(readlink -f $PWD/../../..)
+if [[ -z "$WEST_ROOT" ]]; then
+    echo "Must set environ variable WEST_ROOT"
+    exit
+fi
 
 # Explicitly name our simulation root directory
 if [[ -z "$WEST_SIM_ROOT" ]]; then

--- a/lib/examples/odld/env.sh
+++ b/lib/examples/odld/env.sh
@@ -1,4 +1,8 @@
-export WEST_ROOT=$(readlink -f $PWD/../../..)
+if [[ -z "$WEST_ROOT" ]]; then
+    echo "Must set environ variable WEST_ROOT"
+    exit
+fi
+
 export WEST_PYTHON=$(which python2.7)
 export WM_WORK_MANAGER=serial
 


### PR DESCRIPTION
On OSX `readlink` doesn't use `-f` flag for the same purpose as on Linux, so users attempting to use the `env.sh` script in all of the examples will get an error. 

I modified all of the `env.sh` scripts to bail if `WEST_ROOT` wasn't set, giving a message that the user should specify it. An alternative option would have been to use python as in the `west` shell script to make it platform agnostic. I chose not to take that path because I could imagine a user copying an example directory to a new location, and then the assumed position in the file hierarchy would not hold. The same is not true of the `west` script, which should always live in the same place. 