### PR TITLE
Fixed Amber Example

### DIFF
--- a/lib/examples/nacl_amb/aux_functions.py
+++ b/lib/examples/nacl_amb/aux_functions.py
@@ -1,34 +1,5 @@
-from __future__ import division, print_function; __metaclass__ = type
-import os, sys, math, itertools
+#!/usr/bin/env python
 import numpy
-import west
-from west import WESTSystem
-from westpa.binning import RectilinearBinMapper
-
-import logging
-log = logging.getLogger(__name__)
-log.debug('loading module %r' % __name__)
-
-class System(WESTSystem):
-    """
-    System for sodium chloride association
-    """
-
-    def initialize(self):
-        """
-        Initializes system
-        """
-        self.pcoord_ndim  = 1
-        self.pcoord_len   = 6
-        self.pcoord_dtype = numpy.float32
-        binbounds         = [ 0.00, 2.80, 2.88, 3.00, 3.10, 3.29, 3.79, 3.94,
-                              4.12, 4.39, 5.43, 5.90, 6.90, 7.90, 8.90, 9.90,
-                             10.90,11.90,12.90,13.90,14.90,15.90,float('inf')]
-        self.bin_mapper   = RectilinearBinMapper([binbounds])
-
-        self.bin_target_counts      = numpy.empty((self.bin_mapper.nbins,),
-                                        numpy.int)
-        self.bin_target_counts[...] = 24
 
 def coord_loader(fieldname, coord_filename, segment, single_point=False):
     """

--- a/lib/examples/nacl_amb/env.sh
+++ b/lib/examples/nacl_amb/env.sh
@@ -1,7 +1,12 @@
 # This file defines where WEST and Amber can be found
 # Modify to taste
 
-# Inform WEST where to find Amber
+# Inform WEST where to find Amber.
+# If AMBERHOME isn't set, it's unlikely that the libraries can be found, regardless of whether cpptraj/pmemd exist in the path.
+if [[ -z "$AMBERHOME" ]]; then
+    echo "AMBERHOME environ variable not set.  Source amber.sh, or modify env.sh such that WESTPA knows where AMBER is."
+    exit
+fi
 export PATH=$AMBERHOME/bin:$PATH
 
 # Set environment variables for Amber for convenience

--- a/lib/examples/nacl_amb/env.sh
+++ b/lib/examples/nacl_amb/env.sh
@@ -2,7 +2,6 @@
 # Modify to taste
 
 # Inform WEST where to find Amber
-export AMBERHOME=/path/to/amberhome
 export PATH=$AMBERHOME/bin:$PATH
 
 # Set environment variables for Amber for convenience

--- a/lib/examples/nacl_amb/env.sh
+++ b/lib/examples/nacl_amb/env.sh
@@ -1,4 +1,4 @@
-# This file defines where WEST and Amber can be found
+# This file defines where WEST and Amber can be found.
 # Modify to taste
 
 # Inform WEST where to find Amber.
@@ -7,6 +7,7 @@ if [[ -z "$AMBERHOME" ]]; then
     echo "AMBERHOME environ variable not set.  Source amber.sh, or modify env.sh such that WESTPA knows where AMBER is."
     exit
 fi
+
 export PATH=$AMBERHOME/bin:$PATH
 
 # Set environment variables for Amber for convenience
@@ -17,7 +18,7 @@ export CPPTRAJ=$(which cpptraj)
 export WEST_PYTHON=$(which python2.7)
 
 if [[ -z "$WEST_ROOT" ]]; then
-    echo "Must set environ variable WEST_ROOT"
+    echo "Please set the environment variable WEST_ROOT"
     exit
 fi
 

--- a/lib/examples/nacl_amb/west.cfg
+++ b/lib/examples/nacl_amb/west.cfg
@@ -3,8 +3,23 @@
 ---
 west: 
   system:
-    driver:      system.System
-    module_path: $WEST_SIM_ROOT
+    driver: west.WESTSystem
+    system_options:
+      # Dimensionality of your progress coordinate
+      pcoord_ndim: 1
+      # Number of data points per iteration
+      pcoord_len: 6
+      # Data type for your progress coordinate 
+      pcoord_dtype: !!python/name:numpy.float32
+      bins:
+        type: RectilinearBinMapper
+        # The edges of the bins 
+        boundaries:         
+          -  [ 0.00, 2.80, 2.88, 3.00, 3.10, 3.29, 3.79, 3.94,
+               4.12, 4.39, 5.43, 5.90, 6.90, 7.90, 8.90, 9.90,
+               10.90,11.90,12.90,13.90,14.90,15.90, 'inf']
+      # Number walkers per bin
+      bin_target_counts: 24
   propagation:
     max_total_iterations: 10
     max_run_wallclock:    6:00:00
@@ -31,10 +46,10 @@ west:
       PROPAGATION_DEBUG: 1
     datasets:
       - name:    coord
-        loader:  system.coord_loader
+        loader:  aux_functions.coord_loader
         enabled: true
       - name:    log
-        loader:  system.log_loader
+        loader:  aux_functions.log_loader
         enabled: true
     propagator:
       executable: $WEST_SIM_ROOT/westpa_scripts/runseg.sh


### PR DESCRIPTION
Removed export of AMBERHOME line in env.sh in Na/Cl example.  Instead, it checks to see if the environment variable exists, and fails out with an error message if it doesn't.

While cpptraj/pmemd may exist on the path, if amberhome isn't set, it's unlikely that the libraries are in the LD_LIBRARY_PATH variable, and so it likely won't work.