### PR TITLE
Minor subheader mismatch fix and an auto generated API test

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,7 @@ import os
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
 autoclass_content = "both"
 autodoc_member_order = "bysource"
-autodoc_default_flags = ["members", "show-inheritence"]
+autodoc_default_flags = ["members", "undoc-members", "show-inheritence"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,6 +29,9 @@ import os
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+autoclass_content = "both"
+autodoc_member_order = "bysource"
+autodoc_default_flags = ["members", "show-inheritence"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -4,11 +4,6 @@ WESTPA MODULES API
 WESTPA
 ######
 .. automodule:: westpa
-   :members: rc, binning, yamlcfg
-
-RC
-##
-  .. autoclass:: westpa.rc
 
 Binning
 #######
@@ -17,3 +12,7 @@ Binning
 YAMLCFG
 ########
   .. automodule:: westpa.yamlcfg
+
+RC
+##
+  .. autoclass:: westpa.rc

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -4,15 +4,16 @@ WESTPA MODULES API
 WESTPA
 ######
 .. automodule:: westpa
-
-Binning
-#######
-.. automodule:: westpa.binning
+   :members: rc, binning, yamlcfg
 
 RC
 ##
-.. automodule:: westpa.rc
+  .. autoclass:: westpa.rc
+
+Binning
+#######
+  .. automodule:: westpa.binning
 
 YAMLCFG
 ########
-.. automodule:: westpa.yamlcfg
+  .. automodule:: westpa.yamlcfg

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -1,8 +1,20 @@
 API
 ===
 
+Binning
+#######
+.. autoclass:: westpa.binning.NoMapper
+
+.. autoclass:: westpa.binning.RectilinearBinMapper
+
+.. autoclass:: westpa.binning.RecursiveBinMapper
+
+WESTPA Modules
+###############
 .. automodule:: westpa
 
-.. automodule:: westpa.binning 
+.. automodule:: westpa.binning
 
-.. autoclass:: westpa.rc
+.. automodule:: westpa.rc
+
+.. automodule:: westpa.yamlcfg

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -4,11 +4,5 @@ API
 .. automodule:: westpa.binning 
    :members:
 
-
-.. autoclass:: westpa.binning 
-
-.. autoclass:: westpa.binning.RectilinearBinMapper
-   
-  .. automethod:: assign
-
-.. autoclass:: westpa.binning.RecursiveBinMapper
+.. automodule:: westpa.rc
+   :members:

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -2,7 +2,10 @@ API
 ===
 
 .. autoclass:: westpa.binning 
+.. automodule:: westpa.binning 
 
 .. autoclass:: westpa.binning.RectilinearBinMapper
+   
+  .. automethod:: assign
 
 .. autoclass:: westpa.binning.RecursiveBinMapper

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -1,20 +1,18 @@
-API
-===
+WESTPA MODULES API
+==================
+
+WESTPA
+######
+.. automodule:: westpa
 
 Binning
 #######
-.. autoclass:: westpa.binning.NoMapper
-
-.. autoclass:: westpa.binning.RectilinearBinMapper
-
-.. autoclass:: westpa.binning.RecursiveBinMapper
-
-WESTPA Modules
-###############
-.. automodule:: westpa
-
 .. automodule:: westpa.binning
 
+RC
+##
 .. automodule:: westpa.rc
 
+YAMLCFG
+########
 .. automodule:: westpa.yamlcfg

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -1,0 +1,4 @@
+API
+===
+
+.. autoclass:: westpa.binning.RectilinearBinMapper

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -1,4 +1,8 @@
 API
 ===
 
+.. autoclass:: westpa.binning 
+
 .. autoclass:: westpa.binning.RectilinearBinMapper
+
+.. autoclass:: westpa.binning.RecursiveBinMapper

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -2,10 +2,7 @@ API
 ===
 
 .. automodule:: westpa
-   :members:
 
 .. automodule:: westpa.binning 
-   :members:
 
 .. autoclass:: westpa.rc
-   :members:

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -1,18 +1,16 @@
 WESTPA MODULES API
 ==================
 
-WESTPA
-######
-.. automodule:: westpa
-
 Binning
 #######
-  .. automodule:: westpa.binning
+.. automodule:: westpa.binning.assign
+
+.. automodule:: westpa.binning.bins
 
 YAMLCFG
 ########
-  .. automodule:: westpa.yamlcfg
+.. automodule:: westpa.yamlcfg
 
 RC
 ##
-  .. autoclass:: westpa.rc
+.. autoclass:: westpa._rc.WESTRC

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -1,8 +1,11 @@
 API
 ===
 
-.. autoclass:: westpa.binning 
 .. automodule:: westpa.binning 
+   :members:
+
+
+.. autoclass:: westpa.binning 
 
 .. autoclass:: westpa.binning.RectilinearBinMapper
    

--- a/doc/development/api.rst
+++ b/doc/development/api.rst
@@ -1,8 +1,11 @@
 API
 ===
 
+.. automodule:: westpa
+   :members:
+
 .. automodule:: westpa.binning 
    :members:
 
-.. automodule:: westpa.rc
+.. autoclass:: westpa.rc
    :members:

--- a/doc/readme_sphinx.rst
+++ b/doc/readme_sphinx.rst
@@ -66,7 +66,7 @@ Getting started
 ---------------
 
 Checklist
-"""""""""
+#########
 
 A one-page checklist for new users can be found in the following page: 
 
@@ -98,7 +98,7 @@ Getting help
 ------------
 
 FAQ
-"""
+###
 
 Responses to frequently asked questions (FAQ) can be found in the following page: 
 

--- a/doc/sphinx_index.rst
+++ b/doc/sphinx_index.rst
@@ -52,3 +52,4 @@ Development
     Code and documentation style guide <development/style_guide>
     Source code management             <development/source_code>
     Building the documentation         <development/documentation>
+    API                                <development/api>


### PR DESCRIPTION
I made a slight error with a subheader in the previous pull request which is fixed. I also started a [test page](https://asinansaglam.github.io/westpa/development/api.html) for the API documentation using [Sphinx autodoc extension](http://www.sphinx-doc.org/en/stable/ext/autodoc.html#module-sphinx.ext.autodoc). 

Currently only includes binning and yamlcfg modules and WESTRC class. Also includes every member of each, even ones without documentation at the moment. 