### PR TITLE
Compatibility with latest version of Anaconda (2-4.4.0)

### DIFF
--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -353,7 +353,7 @@ class WESTDataManager:
                                 
     def prepare_backing(self): #istates):
         '''Create new HDF5 file'''
-        self.we_h5file = h5py.File(self.we_h5filename, 'w', driver=self.we_h5file_driver, flags="NPY_ARRAY_FORCECAST")
+        self.we_h5file = h5py.File(self.we_h5filename, 'w', driver=self.we_h5file_driver)
         
         with self.flushing_lock():
             self.we_h5file['/'].attrs['west_file_format_version'] = file_format_version

--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -222,7 +222,7 @@ class WESTDataManager:
             config.require_type_if_present(['west', 'data', entry], type_)
             
         self.we_h5filename = config.get_path(['west', 'data', 'west_data_file'], default=self.default_we_h5filename)
-        self.we_h5file_driver = config.get_choice(['data', 'west_data_file_driver'], [None, 'sec2', 'family'],
+        self.we_h5file_driver = config.get_choice(['west', 'data', 'west_data_file_driver'], [None, 'sec2', 'family'],
                                                   default=self.default_we_h5file_driver,
                                                   value_transform=(lambda x: x.lower() if x else None))
         self.iter_prec = config.get(['west', 'data', 'iter_prec'], self.default_iter_prec)

--- a/src/west/sim_manager.py
+++ b/src/west/sim_manager.py
@@ -438,7 +438,7 @@ class WESimManager:
         for _i in xrange(n_istates_needed):
             # Select a basis state according to its weight
             ibstate = numpy.digitize([random.random()], self.next_iter_bstate_cprobs)
-            basis_state = self.next_iter_bstates[ibstate]
+            basis_state = self.next_iter_bstates[ibstate[0]]
             initial_state = self.data_manager.create_initial_states(1, n_iter=self.n_iter+1)[0]
             initial_state.iter_created = self.n_iter
             initial_state.basis_state_id = basis_state.state_id


### PR DESCRIPTION
Updates in this pull request accommodate changes to h5py and numpy in the latest version 4.4.0 of Anaconda Python, which previously would cause WESTPA simulations not to initialize or run.  These updates are also compatible with previous versions of Anaconda; my tests with Anaconda 4.3.1 and 4.1.11 have been successful, though I cannot guarantee compatibility with versions intermediate or previous to those.  

This update also resolves an error when attempting to use the sec2 or family drivers for HDF5 files, which was present in both the present and previous versions of Anaconda.