### PR TITLE
Na+/Cl- Tutorials now use "processes" work manager by default.

### DIFF
--- a/lib/examples/nacl_amb/run.sh
+++ b/lib/examples/nacl_amb/run.sh
@@ -3,4 +3,4 @@
 source env.sh
 
 rm -f west.log
-$WEST_ROOT/bin/w_run "$@" &> west.log
+$WEST_ROOT/bin/w_run --work-manager processes "$@" &> west.log

--- a/lib/examples/nacl_gmx/run.sh
+++ b/lib/examples/nacl_gmx/run.sh
@@ -8,4 +8,4 @@
 source env.sh
 
 rm -f west.log
-$WEST_ROOT/bin/w_run "$@" &> west.log
+$WEST_ROOT/bin/w_run --work-manager processes "$@" &> west.log

--- a/lib/examples/nacl_gmx_5.0.4/run.sh
+++ b/lib/examples/nacl_gmx_5.0.4/run.sh
@@ -3,4 +3,4 @@
 source env.sh
 
 rm -f west.log
-$WEST_ROOT/bin/w_run "$@" &> west.log
+$WEST_ROOT/bin/w_run --work-manager processes "$@" &> west.log

--- a/lib/examples/nacl_namd/run.sh
+++ b/lib/examples/nacl_namd/run.sh
@@ -3,4 +3,4 @@
 source env.sh
 
 rm -f west.log
-$WEST_ROOT/bin/w_run "$@" &> west.log
+$WEST_ROOT/bin/w_run --work-manager processes "$@" &> west.log


### PR DESCRIPTION
Na+/Cl- tutorials now use the processes work manager by default. This is important for the following reasons:

- Na+/Cl- tutorials already stated that WESTPA would use all available processors by default.
- The Na+/Cl- tutorials can be slow to run in serial mode (the default).
- With the introductory tutorials, we should highlight how WESTPA can easily run simulations in parallel.