### PR TITLE
Fix the w.trace method from w_ipa

### DIFF
--- a/lib/west_tools/w_ipa.py
+++ b/lib/west_tools/w_ipa.py
@@ -562,7 +562,7 @@ class WIPI(WESTParallelTool):
                     key = []
             except:
                 pass
-            for iter in reversed(range(1, self.iteration)):
+            for iter in reversed(range(1, self.iteration+1)):
                 iter_group = self.data_reader.get_iter_group(iter)
                 particles = self.data_reader.data_manager.get_iter_summary(int(iter))['n_particles']
                 current['pcoord'].append(iter_group['pcoord'][seg_id, :, :])


### PR DESCRIPTION
Due to an off-by-one error, the w.trace method from w_ipa previously traced segments from the previous iteration, rather than the current iteration.  This is fixed now.