### PR TITLE
Fix for multiple-level recursions with recursive binmapper

### DIFF
--- a/lib/west_tools/westpa/binning/assign.py
+++ b/lib/west_tools/westpa/binning/assign.py
@@ -407,7 +407,7 @@ class RecursiveBinMapper(BinMapper):
         if self._recursion_map[ibin]:
             # recursively add; this doesn't change anything for us except our
             # total bin count, which has been accounted for above
-            self._recursion_targets[ibin].add_mapper(mapper, replaces_bin_at)
+            self._recursion_targets[ibin].add_mapper(mapper, replaces_bin_at[0])
         else:
             # replace a bin on our mapper
             self._recursion_map[ibin] = True


### PR DESCRIPTION
While this fix works for me, I am requesting a code review since I am not familiar with this part of the code.

Multiple level-recursions with multi-dimensional progress coordinates did not work previously; on the first call to `add_mapper`, `replaces_bin_at` is expanded to 2 dimensions, causing a `ValueError` on the second call to `add_mapper`, where WESTPA enforced that `replaces_bin_at.shape[1]` is less than two. To fix this, in multi-level recursions we now instead pass `replaces_bin_at` to `add_mapper`, with the extra dimension removed.

For example, if we call `my_mapper.add_binmapper(mapper, [0,0])`, and `[0,0]` falls within a bin already replaced with new binmapper, then previously we called `self.recursion_targets[ibin].add_binmapper(mapper, [[0,0]])`, which would generate an error in the second `elif` statement of `add_mapper`.  Instead, we now call `self.recursion_targets[ibin].add_binmapper(mapper, [0,0])`.