### PR TITLE
Fixed routine for rate calculation from w_direct.

### DIFF
--- a/lib/west_tools/westpa/kinetics/_kinetics.c
+++ b/lib/west_tools/westpa/kinetics/_kinetics.c
@@ -895,7 +895,7 @@ struct __pyx_opt_args_6westpa_8kinetics_9_kinetics_sequence_macro_flux_to_rate {
   PyObject *stride;
 };
 
-/* "westpa/kinetics/_kinetics.pyx":602
+/* "westpa/kinetics/_kinetics.pyx":605
  * 
  * 
  * cdef class StreamingStats2D:             # <<<<<<<<<<<<<<
@@ -912,7 +912,7 @@ struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats2D {
 };
 
 
-/* "westpa/kinetics/_kinetics.pyx":720
+/* "westpa/kinetics/_kinetics.pyx":723
  * 
  * 
  * cdef class StreamingStats1D:             # <<<<<<<<<<<<<<
@@ -6592,7 +6592,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_sequence_macro_flux_to_rat
   Py_ssize_t __pyx_t_6;
   Py_ssize_t __pyx_t_7;
   int __pyx_t_8;
-  Py_ssize_t __pyx_t_9;
+  int __pyx_t_9;
   Py_ssize_t __pyx_t_10;
   Py_ssize_t __pyx_t_11;
   Py_ssize_t __pyx_t_12;
@@ -6620,12 +6620,20 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_sequence_macro_flux_to_rat
   Py_ssize_t __pyx_t_34;
   Py_ssize_t __pyx_t_35;
   Py_ssize_t __pyx_t_36;
-  int __pyx_t_37;
+  Py_ssize_t __pyx_t_37;
   Py_ssize_t __pyx_t_38;
   Py_ssize_t __pyx_t_39;
   Py_ssize_t __pyx_t_40;
   Py_ssize_t __pyx_t_41;
   Py_ssize_t __pyx_t_42;
+  Py_ssize_t __pyx_t_43;
+  Py_ssize_t __pyx_t_44;
+  Py_ssize_t __pyx_t_45;
+  Py_ssize_t __pyx_t_46;
+  Py_ssize_t __pyx_t_47;
+  Py_ssize_t __pyx_t_48;
+  Py_ssize_t __pyx_t_49;
+  Py_ssize_t __pyx_t_50;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
@@ -6824,8 +6832,8 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_sequence_macro_flux_to_rat
  * 
  *     # We want to modify this to be the SUM of fluxes up till this point, divided by the SUM of the population till then.
  *     with nogil:             # <<<<<<<<<<<<<<
+ *     #if True:
  *         for iiter in xrange(dataset.shape[0]):
- *             if iiter == 0:
  */
   {
       #ifdef WITH_THREAD
@@ -6834,64 +6842,76 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_sequence_macro_flux_to_rat
       #endif
       /*try:*/ {
 
-        /* "westpa/kinetics/_kinetics.pyx":406
- *     # We want to modify this to be the SUM of fluxes up till this point, divided by the SUM of the population till then.
+        /* "westpa/kinetics/_kinetics.pyx":407
  *     with nogil:
+ *     #if True:
  *         for iiter in xrange(dataset.shape[0]):             # <<<<<<<<<<<<<<
  *             if iiter == 0:
- *                 if pairwise:
+ *                 # We need to catch if we haven't entered the istate yet.
  */
         __pyx_t_6 = (__pyx_v_dataset.shape[0]);
         for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
           __pyx_v_iiter = __pyx_t_7;
 
-          /* "westpa/kinetics/_kinetics.pyx":407
- *     with nogil:
+          /* "westpa/kinetics/_kinetics.pyx":408
+ *     #if True:
  *         for iiter in xrange(dataset.shape[0]):
  *             if iiter == 0:             # <<<<<<<<<<<<<<
- *                 if pairwise:
- *                     _psum[0] = pops[0, istate] / (pops[0,istate] + pops[0,jstate])
+ *                 # We need to catch if we haven't entered the istate yet.
+ *                 if pairwise and (pops[0,istate] + pops[0,jstate]) != 0.0:
  */
           __pyx_t_8 = ((__pyx_v_iiter == 0) != 0);
           if (__pyx_t_8) {
 
-            /* "westpa/kinetics/_kinetics.pyx":408
- *         for iiter in xrange(dataset.shape[0]):
+            /* "westpa/kinetics/_kinetics.pyx":410
  *             if iiter == 0:
- *                 if pairwise:             # <<<<<<<<<<<<<<
+ *                 # We need to catch if we haven't entered the istate yet.
+ *                 if pairwise and (pops[0,istate] + pops[0,jstate]) != 0.0:             # <<<<<<<<<<<<<<
  *                     _psum[0] = pops[0, istate] / (pops[0,istate] + pops[0,jstate])
  *                 else:
  */
-            __pyx_t_8 = (__pyx_v_pairwise != 0);
+            __pyx_t_9 = (__pyx_v_pairwise != 0);
+            if (__pyx_t_9) {
+            } else {
+              __pyx_t_8 = __pyx_t_9;
+              goto __pyx_L10_bool_binop_done;
+            }
+            __pyx_t_10 = 0;
+            __pyx_t_11 = __pyx_v_istate;
+            __pyx_t_12 = 0;
+            __pyx_t_13 = __pyx_v_jstate;
+            __pyx_t_9 = ((((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_10 * __pyx_v_pops.strides[0]) ) + __pyx_t_11 * __pyx_v_pops.strides[1]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_12 * __pyx_v_pops.strides[0]) ) + __pyx_t_13 * __pyx_v_pops.strides[1]) )))) != 0.0) != 0);
+            __pyx_t_8 = __pyx_t_9;
+            __pyx_L10_bool_binop_done:;
             if (__pyx_t_8) {
 
-              /* "westpa/kinetics/_kinetics.pyx":409
- *             if iiter == 0:
- *                 if pairwise:
+              /* "westpa/kinetics/_kinetics.pyx":411
+ *                 # We need to catch if we haven't entered the istate yet.
+ *                 if pairwise and (pops[0,istate] + pops[0,jstate]) != 0.0:
  *                     _psum[0] = pops[0, istate] / (pops[0,istate] + pops[0,jstate])             # <<<<<<<<<<<<<<
  *                 else:
  *                     _psum[0] = pops[0, istate]
  */
-              __pyx_t_9 = 0;
-              __pyx_t_10 = __pyx_v_istate;
-              __pyx_t_11 = 0;
-              __pyx_t_12 = __pyx_v_istate;
-              __pyx_t_13 = 0;
-              __pyx_t_14 = __pyx_v_jstate;
-              __pyx_t_15 = 0;
-              *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_15 * __pyx_v__psum.strides[0]) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_9 * __pyx_v_pops.strides[0]) ) + __pyx_t_10 * __pyx_v_pops.strides[1]) ))) / ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_11 * __pyx_v_pops.strides[0]) ) + __pyx_t_12 * __pyx_v_pops.strides[1]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_13 * __pyx_v_pops.strides[0]) ) + __pyx_t_14 * __pyx_v_pops.strides[1]) )))));
+              __pyx_t_14 = 0;
+              __pyx_t_15 = __pyx_v_istate;
+              __pyx_t_16 = 0;
+              __pyx_t_17 = __pyx_v_istate;
+              __pyx_t_18 = 0;
+              __pyx_t_19 = __pyx_v_jstate;
+              __pyx_t_20 = 0;
+              *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_20 * __pyx_v__psum.strides[0]) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_14 * __pyx_v_pops.strides[0]) ) + __pyx_t_15 * __pyx_v_pops.strides[1]) ))) / ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_16 * __pyx_v_pops.strides[0]) ) + __pyx_t_17 * __pyx_v_pops.strides[1]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_18 * __pyx_v_pops.strides[0]) ) + __pyx_t_19 * __pyx_v_pops.strides[1]) )))));
 
-              /* "westpa/kinetics/_kinetics.pyx":408
- *         for iiter in xrange(dataset.shape[0]):
+              /* "westpa/kinetics/_kinetics.pyx":410
  *             if iiter == 0:
- *                 if pairwise:             # <<<<<<<<<<<<<<
+ *                 # We need to catch if we haven't entered the istate yet.
+ *                 if pairwise and (pops[0,istate] + pops[0,jstate]) != 0.0:             # <<<<<<<<<<<<<<
  *                     _psum[0] = pops[0, istate] / (pops[0,istate] + pops[0,jstate])
  *                 else:
  */
               goto __pyx_L9;
             }
 
-            /* "westpa/kinetics/_kinetics.pyx":411
+            /* "westpa/kinetics/_kinetics.pyx":413
  *                     _psum[0] = pops[0, istate] / (pops[0,istate] + pops[0,jstate])
  *                 else:
  *                     _psum[0] = pops[0, istate]             # <<<<<<<<<<<<<<
@@ -6899,73 +6919,85 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_sequence_macro_flux_to_rat
  *             else:
  */
             /*else*/ {
-              __pyx_t_16 = 0;
-              __pyx_t_17 = __pyx_v_istate;
-              __pyx_t_18 = 0;
-              *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_18 * __pyx_v__psum.strides[0]) )) = (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_16 * __pyx_v_pops.strides[0]) ) + __pyx_t_17 * __pyx_v_pops.strides[1]) )));
+              __pyx_t_21 = 0;
+              __pyx_t_22 = __pyx_v_istate;
+              __pyx_t_23 = 0;
+              *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_23 * __pyx_v__psum.strides[0]) )) = (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_21 * __pyx_v_pops.strides[0]) ) + __pyx_t_22 * __pyx_v_pops.strides[1]) )));
             }
             __pyx_L9:;
 
-            /* "westpa/kinetics/_kinetics.pyx":412
+            /* "westpa/kinetics/_kinetics.pyx":414
  *                 else:
  *                     _psum[0] = pops[0, istate]
  *                 _fluxsum[0] = dataset[0]             # <<<<<<<<<<<<<<
  *             else:
- *                 if pairwise:
+ *                 if pairwise and (pops[iiter,istate] + pops[iiter,jstate]) != 0.0:
  */
-            __pyx_t_19 = 0;
-            __pyx_t_20 = 0;
-            *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_20 * __pyx_v__fluxsum.strides[0]) )) = (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_dataset.data + __pyx_t_19 * __pyx_v_dataset.strides[0]) )));
+            __pyx_t_24 = 0;
+            __pyx_t_25 = 0;
+            *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_25 * __pyx_v__fluxsum.strides[0]) )) = (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_dataset.data + __pyx_t_24 * __pyx_v_dataset.strides[0]) )));
 
-            /* "westpa/kinetics/_kinetics.pyx":407
- *     with nogil:
+            /* "westpa/kinetics/_kinetics.pyx":408
+ *     #if True:
  *         for iiter in xrange(dataset.shape[0]):
  *             if iiter == 0:             # <<<<<<<<<<<<<<
- *                 if pairwise:
- *                     _psum[0] = pops[0, istate] / (pops[0,istate] + pops[0,jstate])
+ *                 # We need to catch if we haven't entered the istate yet.
+ *                 if pairwise and (pops[0,istate] + pops[0,jstate]) != 0.0:
  */
             goto __pyx_L8;
           }
 
-          /* "westpa/kinetics/_kinetics.pyx":414
+          /* "westpa/kinetics/_kinetics.pyx":416
  *                 _fluxsum[0] = dataset[0]
  *             else:
- *                 if pairwise:             # <<<<<<<<<<<<<<
+ *                 if pairwise and (pops[iiter,istate] + pops[iiter,jstate]) != 0.0:             # <<<<<<<<<<<<<<
  *                     _psum[iiter] = (pops[iiter, istate] / (pops[iiter,istate] + pops[iiter,jstate])) + _psum[iiter-1]
  *                 else:
  */
           /*else*/ {
-            __pyx_t_8 = (__pyx_v_pairwise != 0);
+            __pyx_t_9 = (__pyx_v_pairwise != 0);
+            if (__pyx_t_9) {
+            } else {
+              __pyx_t_8 = __pyx_t_9;
+              goto __pyx_L13_bool_binop_done;
+            }
+            __pyx_t_26 = __pyx_v_iiter;
+            __pyx_t_27 = __pyx_v_istate;
+            __pyx_t_28 = __pyx_v_iiter;
+            __pyx_t_29 = __pyx_v_jstate;
+            __pyx_t_9 = ((((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_26 * __pyx_v_pops.strides[0]) ) + __pyx_t_27 * __pyx_v_pops.strides[1]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_28 * __pyx_v_pops.strides[0]) ) + __pyx_t_29 * __pyx_v_pops.strides[1]) )))) != 0.0) != 0);
+            __pyx_t_8 = __pyx_t_9;
+            __pyx_L13_bool_binop_done:;
             if (__pyx_t_8) {
 
-              /* "westpa/kinetics/_kinetics.pyx":415
+              /* "westpa/kinetics/_kinetics.pyx":417
  *             else:
- *                 if pairwise:
+ *                 if pairwise and (pops[iiter,istate] + pops[iiter,jstate]) != 0.0:
  *                     _psum[iiter] = (pops[iiter, istate] / (pops[iiter,istate] + pops[iiter,jstate])) + _psum[iiter-1]             # <<<<<<<<<<<<<<
  *                 else:
  *                     _psum[iiter] = pops[iiter,istate] + _psum[iiter-1]
  */
-              __pyx_t_21 = __pyx_v_iiter;
-              __pyx_t_22 = __pyx_v_istate;
-              __pyx_t_23 = __pyx_v_iiter;
-              __pyx_t_24 = __pyx_v_istate;
-              __pyx_t_25 = __pyx_v_iiter;
-              __pyx_t_26 = __pyx_v_jstate;
-              __pyx_t_27 = (__pyx_v_iiter - 1);
-              __pyx_t_28 = __pyx_v_iiter;
-              *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_28 * __pyx_v__psum.strides[0]) )) = (((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_21 * __pyx_v_pops.strides[0]) ) + __pyx_t_22 * __pyx_v_pops.strides[1]) ))) / ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_23 * __pyx_v_pops.strides[0]) ) + __pyx_t_24 * __pyx_v_pops.strides[1]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_25 * __pyx_v_pops.strides[0]) ) + __pyx_t_26 * __pyx_v_pops.strides[1]) ))))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_27 * __pyx_v__psum.strides[0]) ))));
+              __pyx_t_30 = __pyx_v_iiter;
+              __pyx_t_31 = __pyx_v_istate;
+              __pyx_t_32 = __pyx_v_iiter;
+              __pyx_t_33 = __pyx_v_istate;
+              __pyx_t_34 = __pyx_v_iiter;
+              __pyx_t_35 = __pyx_v_jstate;
+              __pyx_t_36 = (__pyx_v_iiter - 1);
+              __pyx_t_37 = __pyx_v_iiter;
+              *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_37 * __pyx_v__psum.strides[0]) )) = (((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_30 * __pyx_v_pops.strides[0]) ) + __pyx_t_31 * __pyx_v_pops.strides[1]) ))) / ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_32 * __pyx_v_pops.strides[0]) ) + __pyx_t_33 * __pyx_v_pops.strides[1]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_34 * __pyx_v_pops.strides[0]) ) + __pyx_t_35 * __pyx_v_pops.strides[1]) ))))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_36 * __pyx_v__psum.strides[0]) ))));
 
-              /* "westpa/kinetics/_kinetics.pyx":414
+              /* "westpa/kinetics/_kinetics.pyx":416
  *                 _fluxsum[0] = dataset[0]
  *             else:
- *                 if pairwise:             # <<<<<<<<<<<<<<
+ *                 if pairwise and (pops[iiter,istate] + pops[iiter,jstate]) != 0.0:             # <<<<<<<<<<<<<<
  *                     _psum[iiter] = (pops[iiter, istate] / (pops[iiter,istate] + pops[iiter,jstate])) + _psum[iiter-1]
  *                 else:
  */
-              goto __pyx_L10;
+              goto __pyx_L12;
             }
 
-            /* "westpa/kinetics/_kinetics.pyx":417
+            /* "westpa/kinetics/_kinetics.pyx":419
  *                     _psum[iiter] = (pops[iiter, istate] / (pops[iiter,istate] + pops[iiter,jstate])) + _psum[iiter-1]
  *                 else:
  *                     _psum[iiter] = pops[iiter,istate] + _psum[iiter-1]             # <<<<<<<<<<<<<<
@@ -6973,82 +7005,82 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_sequence_macro_flux_to_rat
  *             if _psum[iiter] > 0 and _fluxsum[iiter] > 0:
  */
             /*else*/ {
-              __pyx_t_29 = __pyx_v_iiter;
-              __pyx_t_30 = __pyx_v_istate;
-              __pyx_t_31 = (__pyx_v_iiter - 1);
-              __pyx_t_32 = __pyx_v_iiter;
-              *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_32 * __pyx_v__psum.strides[0]) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_29 * __pyx_v_pops.strides[0]) ) + __pyx_t_30 * __pyx_v_pops.strides[1]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_31 * __pyx_v__psum.strides[0]) ))));
+              __pyx_t_38 = __pyx_v_iiter;
+              __pyx_t_39 = __pyx_v_istate;
+              __pyx_t_40 = (__pyx_v_iiter - 1);
+              __pyx_t_41 = __pyx_v_iiter;
+              *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_41 * __pyx_v__psum.strides[0]) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_pops.data + __pyx_t_38 * __pyx_v_pops.strides[0]) ) + __pyx_t_39 * __pyx_v_pops.strides[1]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_40 * __pyx_v__psum.strides[0]) ))));
             }
-            __pyx_L10:;
+            __pyx_L12:;
 
-            /* "westpa/kinetics/_kinetics.pyx":418
+            /* "westpa/kinetics/_kinetics.pyx":420
  *                 else:
  *                     _psum[iiter] = pops[iiter,istate] + _psum[iiter-1]
  *                 _fluxsum[iiter] = dataset[iiter] + _fluxsum[iiter-1]             # <<<<<<<<<<<<<<
  *             if _psum[iiter] > 0 and _fluxsum[iiter] > 0:
  *                 _rates[iiter] = _fluxsum[iiter] / _psum[iiter]
  */
-            __pyx_t_33 = __pyx_v_iiter;
-            __pyx_t_34 = (__pyx_v_iiter - 1);
-            __pyx_t_35 = __pyx_v_iiter;
-            *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_35 * __pyx_v__fluxsum.strides[0]) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_dataset.data + __pyx_t_33 * __pyx_v_dataset.strides[0]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_34 * __pyx_v__fluxsum.strides[0]) ))));
+            __pyx_t_42 = __pyx_v_iiter;
+            __pyx_t_43 = (__pyx_v_iiter - 1);
+            __pyx_t_44 = __pyx_v_iiter;
+            *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_44 * __pyx_v__fluxsum.strides[0]) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_dataset.data + __pyx_t_42 * __pyx_v_dataset.strides[0]) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_43 * __pyx_v__fluxsum.strides[0]) ))));
           }
           __pyx_L8:;
 
-          /* "westpa/kinetics/_kinetics.pyx":419
+          /* "westpa/kinetics/_kinetics.pyx":421
  *                     _psum[iiter] = pops[iiter,istate] + _psum[iiter-1]
  *                 _fluxsum[iiter] = dataset[iiter] + _fluxsum[iiter-1]
  *             if _psum[iiter] > 0 and _fluxsum[iiter] > 0:             # <<<<<<<<<<<<<<
  *                 _rates[iiter] = _fluxsum[iiter] / _psum[iiter]
  *             else:
  */
-          __pyx_t_36 = __pyx_v_iiter;
-          __pyx_t_37 = (((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_36 * __pyx_v__psum.strides[0]) ))) > 0.0) != 0);
-          if (__pyx_t_37) {
+          __pyx_t_45 = __pyx_v_iiter;
+          __pyx_t_9 = (((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_45 * __pyx_v__psum.strides[0]) ))) > 0.0) != 0);
+          if (__pyx_t_9) {
           } else {
-            __pyx_t_8 = __pyx_t_37;
-            goto __pyx_L12_bool_binop_done;
+            __pyx_t_8 = __pyx_t_9;
+            goto __pyx_L16_bool_binop_done;
           }
-          __pyx_t_38 = __pyx_v_iiter;
-          __pyx_t_37 = (((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_38 * __pyx_v__fluxsum.strides[0]) ))) > 0.0) != 0);
-          __pyx_t_8 = __pyx_t_37;
-          __pyx_L12_bool_binop_done:;
+          __pyx_t_46 = __pyx_v_iiter;
+          __pyx_t_9 = (((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_46 * __pyx_v__fluxsum.strides[0]) ))) > 0.0) != 0);
+          __pyx_t_8 = __pyx_t_9;
+          __pyx_L16_bool_binop_done:;
           if (__pyx_t_8) {
 
-            /* "westpa/kinetics/_kinetics.pyx":420
+            /* "westpa/kinetics/_kinetics.pyx":422
  *                 _fluxsum[iiter] = dataset[iiter] + _fluxsum[iiter-1]
  *             if _psum[iiter] > 0 and _fluxsum[iiter] > 0:
  *                 _rates[iiter] = _fluxsum[iiter] / _psum[iiter]             # <<<<<<<<<<<<<<
  *             else:
  *                 _rates[iiter] = 0.0
  */
-            __pyx_t_39 = __pyx_v_iiter;
-            __pyx_t_40 = __pyx_v_iiter;
-            __pyx_t_41 = __pyx_v_iiter;
-            *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__rates.data + __pyx_t_41 * __pyx_v__rates.strides[0]) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_39 * __pyx_v__fluxsum.strides[0]) ))) / (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_40 * __pyx_v__psum.strides[0]) ))));
+            __pyx_t_47 = __pyx_v_iiter;
+            __pyx_t_48 = __pyx_v_iiter;
+            __pyx_t_49 = __pyx_v_iiter;
+            *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__rates.data + __pyx_t_49 * __pyx_v__rates.strides[0]) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__fluxsum.data + __pyx_t_47 * __pyx_v__fluxsum.strides[0]) ))) / (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__psum.data + __pyx_t_48 * __pyx_v__psum.strides[0]) ))));
 
-            /* "westpa/kinetics/_kinetics.pyx":419
+            /* "westpa/kinetics/_kinetics.pyx":421
  *                     _psum[iiter] = pops[iiter,istate] + _psum[iiter-1]
  *                 _fluxsum[iiter] = dataset[iiter] + _fluxsum[iiter-1]
  *             if _psum[iiter] > 0 and _fluxsum[iiter] > 0:             # <<<<<<<<<<<<<<
  *                 _rates[iiter] = _fluxsum[iiter] / _psum[iiter]
  *             else:
  */
-            goto __pyx_L11;
+            goto __pyx_L15;
           }
 
-          /* "westpa/kinetics/_kinetics.pyx":422
+          /* "westpa/kinetics/_kinetics.pyx":424
  *                 _rates[iiter] = _fluxsum[iiter] / _psum[iiter]
  *             else:
  *                 _rates[iiter] = 0.0             # <<<<<<<<<<<<<<
+ *             #print(_fluxsum[iiter], _psum[iiter], _rates[iiter], pops[iiter,istate], pops[iiter,jstate])
  * 
- *     return rates[iiter]
  */
           /*else*/ {
-            __pyx_t_42 = __pyx_v_iiter;
-            *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__rates.data + __pyx_t_42 * __pyx_v__rates.strides[0]) )) = 0.0;
+            __pyx_t_50 = __pyx_v_iiter;
+            *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v__rates.data + __pyx_t_50 * __pyx_v__rates.strides[0]) )) = 0.0;
           }
-          __pyx_L11:;
+          __pyx_L15:;
         }
       }
 
@@ -7056,8 +7088,8 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_sequence_macro_flux_to_rat
  * 
  *     # We want to modify this to be the SUM of fluxes up till this point, divided by the SUM of the population till then.
  *     with nogil:             # <<<<<<<<<<<<<<
+ *     #if True:
  *         for iiter in xrange(dataset.shape[0]):
- *             if iiter == 0:
  */
       /*finally:*/ {
         /*normal exit:*/{
@@ -7070,15 +7102,15 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_sequence_macro_flux_to_rat
       }
   }
 
-  /* "westpa/kinetics/_kinetics.pyx":424
- *                 _rates[iiter] = 0.0
+  /* "westpa/kinetics/_kinetics.pyx":427
+ *             #print(_fluxsum[iiter], _psum[iiter], _rates[iiter], pops[iiter,istate], pops[iiter,jstate])
  * 
  *     return rates[iiter]             # <<<<<<<<<<<<<<
  * 
  * """
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_4 = __Pyx_GetItemInt(__pyx_v_rates, __pyx_v_iiter, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(__pyx_t_4 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 424; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+  __pyx_t_4 = __Pyx_GetItemInt(__pyx_v_rates, __pyx_v_iiter, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 0, 0); if (unlikely(__pyx_t_4 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 427; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_r = __pyx_t_4;
   __pyx_t_4 = 0;
@@ -7254,7 +7286,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_22sequence_macro_flux_to_
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":440
+/* "westpa/kinetics/_kinetics.pyx":443
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * cpdef _fast_transition_state_copy(Py_ssize_t iiter,             # <<<<<<<<<<<<<<
@@ -7315,7 +7347,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("_fast_transition_state_copy", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":445
+  /* "westpa/kinetics/_kinetics.pyx":448
  *                                   object last_state):
  *     cdef:
  *         bint has_last_state = 0             # <<<<<<<<<<<<<<
@@ -7324,7 +7356,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
  */
   __pyx_v_has_last_state = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":452
+  /* "westpa/kinetics/_kinetics.pyx":455
  * 
  * 
  *     nsegs = parent_ids.shape[0]             # <<<<<<<<<<<<<<
@@ -7333,28 +7365,28 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
  */
   __pyx_v_nsegs = (__pyx_v_parent_ids.shape[0]);
 
-  /* "westpa/kinetics/_kinetics.pyx":454
+  /* "westpa/kinetics/_kinetics.pyx":457
  *     nsegs = parent_ids.shape[0]
  * 
  *     last_time = numpy.empty((nsegs,), numpy.double)             # <<<<<<<<<<<<<<
  *     # Use nstates + 1 to account for possible unknown states
  *     last_entries = numpy.empty((nsegs,nstates+1), numpy.double)
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 454; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_empty); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 454; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_empty); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 454; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 454; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = PyTuple_New(1); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_2);
   __pyx_t_2 = 0;
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 454; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_double); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 454; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_double); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_t_2 = NULL;
@@ -7369,7 +7401,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
       __pyx_t_6 = 1;
     }
   }
-  __pyx_t_7 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 454; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_7 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_7);
   if (__pyx_t_2) {
     __Pyx_GIVEREF(__pyx_t_2); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_2); __pyx_t_2 = NULL;
@@ -7380,30 +7412,30 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   PyTuple_SET_ITEM(__pyx_t_7, 1+__pyx_t_6, __pyx_t_5);
   __pyx_t_4 = 0;
   __pyx_t_5 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_7, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 454; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_7, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_last_time = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":456
+  /* "westpa/kinetics/_kinetics.pyx":459
  *     last_time = numpy.empty((nsegs,), numpy.double)
  *     # Use nstates + 1 to account for possible unknown states
  *     last_entries = numpy.empty((nsegs,nstates+1), numpy.double)             # <<<<<<<<<<<<<<
  *     last_exits = numpy.empty((nsegs,nstates+1), numpy.double)
  *     last_exits_td = numpy.empty((nsegs,nstates+1), numpy.double)
  */
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 456; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_empty); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 456; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_empty); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 456; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_5 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 456; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_4 = PyTuple_New(2); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 456; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = PyTuple_New(2); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_3);
@@ -7411,9 +7443,9 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   PyTuple_SET_ITEM(__pyx_t_4, 1, __pyx_t_5);
   __pyx_t_3 = 0;
   __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 456; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_double); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 456; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_double); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __pyx_t_5 = NULL;
@@ -7428,7 +7460,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
       __pyx_t_6 = 1;
     }
   }
-  __pyx_t_2 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 456; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   if (__pyx_t_5) {
     __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_5); __pyx_t_5 = NULL;
@@ -7439,30 +7471,30 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   PyTuple_SET_ITEM(__pyx_t_2, 1+__pyx_t_6, __pyx_t_3);
   __pyx_t_4 = 0;
   __pyx_t_3 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_7, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 456; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_7, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __pyx_v_last_entries = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":457
+  /* "westpa/kinetics/_kinetics.pyx":460
  *     # Use nstates + 1 to account for possible unknown states
  *     last_entries = numpy.empty((nsegs,nstates+1), numpy.double)
  *     last_exits = numpy.empty((nsegs,nstates+1), numpy.double)             # <<<<<<<<<<<<<<
  *     last_exits_td = numpy.empty((nsegs,nstates+1), numpy.double)
  *     last_completions = numpy.empty((nsegs,nstates+1,nstates+1), numpy.double)
  */
-  __pyx_t_7 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_7 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 460; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_7);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_7, __pyx_n_s_empty); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_7, __pyx_n_s_empty); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 460; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  __pyx_t_7 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_7 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 460; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_7);
-  __pyx_t_3 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 460; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = PyTuple_New(2); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = PyTuple_New(2); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 460; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_GIVEREF(__pyx_t_7);
   PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7);
@@ -7470,9 +7502,9 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   PyTuple_SET_ITEM(__pyx_t_4, 1, __pyx_t_3);
   __pyx_t_7 = 0;
   __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 460; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_double); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_double); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 460; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_3 = NULL;
@@ -7487,7 +7519,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
       __pyx_t_6 = 1;
     }
   }
-  __pyx_t_5 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 460; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   if (__pyx_t_3) {
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_3); __pyx_t_3 = NULL;
@@ -7498,30 +7530,30 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   PyTuple_SET_ITEM(__pyx_t_5, 1+__pyx_t_6, __pyx_t_7);
   __pyx_t_4 = 0;
   __pyx_t_7 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 457; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 460; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_v_last_exits = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":458
+  /* "westpa/kinetics/_kinetics.pyx":461
  *     last_entries = numpy.empty((nsegs,nstates+1), numpy.double)
  *     last_exits = numpy.empty((nsegs,nstates+1), numpy.double)
  *     last_exits_td = numpy.empty((nsegs,nstates+1), numpy.double)             # <<<<<<<<<<<<<<
  *     last_completions = numpy.empty((nsegs,nstates+1,nstates+1), numpy.double)
  * 
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 458; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_empty); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 458; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_empty); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 458; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_7 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 458; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_7 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_7);
-  __pyx_t_4 = PyTuple_New(2); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 458; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = PyTuple_New(2); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_2);
@@ -7529,9 +7561,9 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   PyTuple_SET_ITEM(__pyx_t_4, 1, __pyx_t_7);
   __pyx_t_2 = 0;
   __pyx_t_7 = 0;
-  __pyx_t_7 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 458; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_7 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_7);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_7, __pyx_n_s_double); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 458; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_7, __pyx_n_s_double); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __pyx_t_7 = NULL;
@@ -7546,7 +7578,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
       __pyx_t_6 = 1;
     }
   }
-  __pyx_t_3 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 458; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   if (__pyx_t_7) {
     __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -7557,32 +7589,32 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   PyTuple_SET_ITEM(__pyx_t_3, 1+__pyx_t_6, __pyx_t_2);
   __pyx_t_4 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 458; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __pyx_v_last_exits_td = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":459
+  /* "westpa/kinetics/_kinetics.pyx":462
  *     last_exits = numpy.empty((nsegs,nstates+1), numpy.double)
  *     last_exits_td = numpy.empty((nsegs,nstates+1), numpy.double)
  *     last_completions = numpy.empty((nsegs,nstates+1,nstates+1), numpy.double)             # <<<<<<<<<<<<<<
  * 
  *     _last_time = last_time
  */
-  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_empty); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_empty); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = PyInt_FromSsize_t(__pyx_v_nsegs); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_2 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_4 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = PyInt_FromSsize_t((__pyx_v_nstates + 1)); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_7 = PyTuple_New(3); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_7 = PyTuple_New(3); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_GIVEREF(__pyx_t_5);
   PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_5);
@@ -7593,9 +7625,9 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   __pyx_t_5 = 0;
   __pyx_t_2 = 0;
   __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_double); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_double); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_4 = NULL;
@@ -7610,7 +7642,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
       __pyx_t_6 = 1;
     }
   }
-  __pyx_t_5 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = PyTuple_New(2+__pyx_t_6); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   if (__pyx_t_4) {
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
@@ -7621,14 +7653,14 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   PyTuple_SET_ITEM(__pyx_t_5, 1+__pyx_t_6, __pyx_t_2);
   __pyx_t_7 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 459; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_last_completions = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":461
+  /* "westpa/kinetics/_kinetics.pyx":464
  *     last_completions = numpy.empty((nsegs,nstates+1,nstates+1), numpy.double)
  * 
  *     _last_time = last_time             # <<<<<<<<<<<<<<
@@ -7636,12 +7668,12 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
  *     _last_exits = last_exits
  */
   __pyx_t_8 = __Pyx_PyObject_to_MemoryviewSlice_ds_double(__pyx_v_last_time);
-  if (unlikely(!__pyx_t_8.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 461; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_8.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 464; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_v__last_time = __pyx_t_8;
   __pyx_t_8.memview = NULL;
   __pyx_t_8.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":462
+  /* "westpa/kinetics/_kinetics.pyx":465
  * 
  *     _last_time = last_time
  *     _last_entries = last_entries             # <<<<<<<<<<<<<<
@@ -7649,12 +7681,12 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
  *     _last_exits_td = last_exits_td
  */
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_v_last_entries);
-  if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 462; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 465; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_v__last_entries = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":463
+  /* "westpa/kinetics/_kinetics.pyx":466
  *     _last_time = last_time
  *     _last_entries = last_entries
  *     _last_exits = last_exits             # <<<<<<<<<<<<<<
@@ -7662,12 +7694,12 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
  *     _last_completions = last_completions
  */
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_v_last_exits);
-  if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 463; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 466; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_v__last_exits = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":464
+  /* "westpa/kinetics/_kinetics.pyx":467
  *     _last_entries = last_entries
  *     _last_exits = last_exits
  *     _last_exits_td = last_exits_td             # <<<<<<<<<<<<<<
@@ -7675,12 +7707,12 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
  * 
  */
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_v_last_exits_td);
-  if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 464; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 467; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_v__last_exits_td = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":465
+  /* "westpa/kinetics/_kinetics.pyx":468
  *     _last_exits = last_exits
  *     _last_exits_td = last_exits_td
  *     _last_completions = last_completions             # <<<<<<<<<<<<<<
@@ -7688,12 +7720,12 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
  *     has_last_state = (last_state is not None)
  */
   __pyx_t_10 = __Pyx_PyObject_to_MemoryviewSlice_dsdsds_double(__pyx_v_last_completions);
-  if (unlikely(!__pyx_t_10.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 465; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_10.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 468; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_v__last_completions = __pyx_t_10;
   __pyx_t_10.memview = NULL;
   __pyx_t_10.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":467
+  /* "westpa/kinetics/_kinetics.pyx":470
  *     _last_completions = last_completions
  * 
  *     has_last_state = (last_state is not None)             # <<<<<<<<<<<<<<
@@ -7703,7 +7735,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   __pyx_t_11 = (__pyx_v_last_state != Py_None);
   __pyx_v_has_last_state = __pyx_t_11;
 
-  /* "westpa/kinetics/_kinetics.pyx":469
+  /* "westpa/kinetics/_kinetics.pyx":472
  *     has_last_state = (last_state is not None)
  * 
  *     if has_last_state:             # <<<<<<<<<<<<<<
@@ -7713,87 +7745,87 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   __pyx_t_11 = (__pyx_v_has_last_state != 0);
   if (__pyx_t_11) {
 
-    /* "westpa/kinetics/_kinetics.pyx":470
+    /* "westpa/kinetics/_kinetics.pyx":473
  * 
  *     if has_last_state:
  *         _prev_last_time = last_state[0]             # <<<<<<<<<<<<<<
  *         _prev_last_entries = last_state[1]
  *         _prev_last_exits = last_state[2]
  */
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 470; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 473; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_t_8 = __Pyx_PyObject_to_MemoryviewSlice_ds_double(__pyx_t_1);
-    if (unlikely(!__pyx_t_8.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 470; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    if (unlikely(!__pyx_t_8.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 473; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v__prev_last_time = __pyx_t_8;
     __pyx_t_8.memview = NULL;
     __pyx_t_8.data = NULL;
 
-    /* "westpa/kinetics/_kinetics.pyx":471
+    /* "westpa/kinetics/_kinetics.pyx":474
  *     if has_last_state:
  *         _prev_last_time = last_state[0]
  *         _prev_last_entries = last_state[1]             # <<<<<<<<<<<<<<
  *         _prev_last_exits = last_state[2]
  *         _prev_last_exits_td = last_state[3]
  */
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 471; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 474; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_1);
-    if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 471; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 474; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v__prev_last_entries = __pyx_t_9;
     __pyx_t_9.memview = NULL;
     __pyx_t_9.data = NULL;
 
-    /* "westpa/kinetics/_kinetics.pyx":472
+    /* "westpa/kinetics/_kinetics.pyx":475
  *         _prev_last_time = last_state[0]
  *         _prev_last_entries = last_state[1]
  *         _prev_last_exits = last_state[2]             # <<<<<<<<<<<<<<
  *         _prev_last_exits_td = last_state[3]
  *         _prev_last_completions = last_state[4]
  */
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 472; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 475; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_1);
-    if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 472; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 475; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v__prev_last_exits = __pyx_t_9;
     __pyx_t_9.memview = NULL;
     __pyx_t_9.data = NULL;
 
-    /* "westpa/kinetics/_kinetics.pyx":473
+    /* "westpa/kinetics/_kinetics.pyx":476
  *         _prev_last_entries = last_state[1]
  *         _prev_last_exits = last_state[2]
  *         _prev_last_exits_td = last_state[3]             # <<<<<<<<<<<<<<
  *         _prev_last_completions = last_state[4]
  * 
  */
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 473; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 476; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_1);
-    if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 473; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    if (unlikely(!__pyx_t_9.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 476; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v__prev_last_exits_td = __pyx_t_9;
     __pyx_t_9.memview = NULL;
     __pyx_t_9.data = NULL;
 
-    /* "westpa/kinetics/_kinetics.pyx":474
+    /* "westpa/kinetics/_kinetics.pyx":477
  *         _prev_last_exits = last_state[2]
  *         _prev_last_exits_td = last_state[3]
  *         _prev_last_completions = last_state[4]             # <<<<<<<<<<<<<<
  * 
  *     for seg_id in xrange(nsegs):
  */
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 4, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 474; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_last_state, 4, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 477; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_t_10 = __Pyx_PyObject_to_MemoryviewSlice_dsdsds_double(__pyx_t_1);
-    if (unlikely(!__pyx_t_10.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 474; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    if (unlikely(!__pyx_t_10.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 477; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v__prev_last_completions = __pyx_t_10;
     __pyx_t_10.memview = NULL;
     __pyx_t_10.data = NULL;
 
-    /* "westpa/kinetics/_kinetics.pyx":469
+    /* "westpa/kinetics/_kinetics.pyx":472
  *     has_last_state = (last_state is not None)
  * 
  *     if has_last_state:             # <<<<<<<<<<<<<<
@@ -7802,7 +7834,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
  */
   }
 
-  /* "westpa/kinetics/_kinetics.pyx":476
+  /* "westpa/kinetics/_kinetics.pyx":479
  *         _prev_last_completions = last_state[4]
  * 
  *     for seg_id in xrange(nsegs):             # <<<<<<<<<<<<<<
@@ -7813,7 +7845,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
   for (__pyx_t_12 = 0; __pyx_t_12 < __pyx_t_6; __pyx_t_12+=1) {
     __pyx_v_seg_id = __pyx_t_12;
 
-    /* "westpa/kinetics/_kinetics.pyx":477
+    /* "westpa/kinetics/_kinetics.pyx":480
  * 
  *     for seg_id in xrange(nsegs):
  *         parent_id = parent_ids[seg_id]             # <<<<<<<<<<<<<<
@@ -7823,7 +7855,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
     __pyx_t_13 = __pyx_v_seg_id;
     __pyx_v_parent_id = (*((__pyx_t_6westpa_8kinetics_9_kinetics_seg_id_t *) ( /* dim=0 */ (__pyx_v_parent_ids.data + __pyx_t_13 * __pyx_v_parent_ids.strides[0]) )));
 
-    /* "westpa/kinetics/_kinetics.pyx":479
+    /* "westpa/kinetics/_kinetics.pyx":482
  *         parent_id = parent_ids[seg_id]
  * 
  *         if not has_last_state or parent_id < 0:             # <<<<<<<<<<<<<<
@@ -7841,7 +7873,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
     __pyx_L7_bool_binop_done:;
     if (__pyx_t_11) {
 
-      /* "westpa/kinetics/_kinetics.pyx":480
+      /* "westpa/kinetics/_kinetics.pyx":483
  * 
  *         if not has_last_state or parent_id < 0:
  *             _last_time[seg_id] = 0.0             # <<<<<<<<<<<<<<
@@ -7851,7 +7883,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
       __pyx_t_15 = __pyx_v_seg_id;
       *((double *) ( /* dim=0 */ (__pyx_v__last_time.data + __pyx_t_15 * __pyx_v__last_time.strides[0]) )) = 0.0;
 
-      /* "westpa/kinetics/_kinetics.pyx":481
+      /* "westpa/kinetics/_kinetics.pyx":484
  *         if not has_last_state or parent_id < 0:
  *             _last_time[seg_id] = 0.0
  *             _last_entries[seg_id,:] = 0.0             # <<<<<<<<<<<<<<
@@ -7869,7 +7901,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_cop
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 481; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 484; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_8.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -7894,7 +7926,7 @@ __pyx_t_8.strides[0] = __pyx_v__last_entries.strides[1];
       }
       __PYX_XDEC_MEMVIEW(&__pyx_t_8, 1);
 
-      /* "westpa/kinetics/_kinetics.pyx":482
+      /* "westpa/kinetics/_kinetics.pyx":485
  *             _last_time[seg_id] = 0.0
  *             _last_entries[seg_id,:] = 0.0
  *             _last_exits[seg_id,:] = 0.0             # <<<<<<<<<<<<<<
@@ -7912,7 +7944,7 @@ __pyx_t_8.strides[0] = __pyx_v__last_entries.strides[1];
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 482; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 485; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_16.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -7937,7 +7969,7 @@ __pyx_t_16.strides[0] = __pyx_v__last_exits.strides[1];
       }
       __PYX_XDEC_MEMVIEW(&__pyx_t_16, 1);
 
-      /* "westpa/kinetics/_kinetics.pyx":483
+      /* "westpa/kinetics/_kinetics.pyx":486
  *             _last_entries[seg_id,:] = 0.0
  *             _last_exits[seg_id,:] = 0.0
  *             _last_exits_td[seg_id,:] = 0.0             # <<<<<<<<<<<<<<
@@ -7955,7 +7987,7 @@ __pyx_t_16.strides[0] = __pyx_v__last_exits.strides[1];
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 483; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 486; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_17.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -7980,7 +8012,7 @@ __pyx_t_17.strides[0] = __pyx_v__last_exits_td.strides[1];
       }
       __PYX_XDEC_MEMVIEW(&__pyx_t_17, 1);
 
-      /* "westpa/kinetics/_kinetics.pyx":484
+      /* "westpa/kinetics/_kinetics.pyx":487
  *             _last_exits[seg_id,:] = 0.0
  *             _last_exits_td[seg_id,:] = 0.0
  *             _last_completions[seg_id,:,:] = 0.0             # <<<<<<<<<<<<<<
@@ -7998,7 +8030,7 @@ __pyx_t_17.strides[0] = __pyx_v__last_exits_td.strides[1];
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 484; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_9.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -8035,7 +8067,7 @@ __pyx_t_9.strides[1] = __pyx_v__last_completions.strides[2];
       }
       __PYX_XDEC_MEMVIEW(&__pyx_t_9, 1);
 
-      /* "westpa/kinetics/_kinetics.pyx":479
+      /* "westpa/kinetics/_kinetics.pyx":482
  *         parent_id = parent_ids[seg_id]
  * 
  *         if not has_last_state or parent_id < 0:             # <<<<<<<<<<<<<<
@@ -8045,7 +8077,7 @@ __pyx_t_9.strides[1] = __pyx_v__last_completions.strides[2];
       goto __pyx_L6;
     }
 
-    /* "westpa/kinetics/_kinetics.pyx":486
+    /* "westpa/kinetics/_kinetics.pyx":489
  *             _last_completions[seg_id,:,:] = 0.0
  *         else:
  *             _last_time[seg_id] = _prev_last_time[parent_id]             # <<<<<<<<<<<<<<
@@ -8053,19 +8085,19 @@ __pyx_t_9.strides[1] = __pyx_v__last_completions.strides[2];
  *             _last_exits[seg_id,:] = _prev_last_exits[parent_id,:]
  */
     /*else*/ {
-      if (unlikely(!__pyx_v__prev_last_time.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_time"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 486; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+      if (unlikely(!__pyx_v__prev_last_time.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_time"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
       __pyx_t_18 = __pyx_v_parent_id;
       __pyx_t_19 = __pyx_v_seg_id;
       *((double *) ( /* dim=0 */ (__pyx_v__last_time.data + __pyx_t_19 * __pyx_v__last_time.strides[0]) )) = (*((double *) ( /* dim=0 */ (__pyx_v__prev_last_time.data + __pyx_t_18 * __pyx_v__prev_last_time.strides[0]) )));
 
-      /* "westpa/kinetics/_kinetics.pyx":487
+      /* "westpa/kinetics/_kinetics.pyx":490
  *         else:
  *             _last_time[seg_id] = _prev_last_time[parent_id]
  *             _last_entries[seg_id,:] = _prev_last_entries[parent_id,:]             # <<<<<<<<<<<<<<
  *             _last_exits[seg_id,:] = _prev_last_exits[parent_id,:]
  *             _last_exits_td[seg_id,:] = _prev_last_exits_td[parent_id,:]
  */
-      if (unlikely(!__pyx_v__prev_last_entries.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_entries"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+      if (unlikely(!__pyx_v__prev_last_entries.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_entries"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 490; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
       __pyx_t_20.data = __pyx_v__prev_last_entries.data;
       __pyx_t_20.memview = __pyx_v__prev_last_entries.memview;
       __PYX_INC_MEMVIEW(&__pyx_t_20, 0);
@@ -8077,7 +8109,7 @@ __pyx_t_9.strides[1] = __pyx_v__last_completions.strides[2];
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 490; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_20.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -8097,7 +8129,7 @@ __pyx_t_21.data = __pyx_v__last_entries.data;
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 490; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_21.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -8106,18 +8138,18 @@ __pyx_t_21.shape[0] = __pyx_v__last_entries.shape[1];
 __pyx_t_21.strides[0] = __pyx_v__last_entries.strides[1];
     __pyx_t_21.suboffsets[0] = -1;
 
-if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_20, __pyx_t_21, 1, 1, 0) < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 487; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_20, __pyx_t_21, 1, 1, 0) < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 490; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
       __PYX_XDEC_MEMVIEW(&__pyx_t_21, 1);
       __PYX_XDEC_MEMVIEW(&__pyx_t_20, 1);
 
-      /* "westpa/kinetics/_kinetics.pyx":488
+      /* "westpa/kinetics/_kinetics.pyx":491
  *             _last_time[seg_id] = _prev_last_time[parent_id]
  *             _last_entries[seg_id,:] = _prev_last_entries[parent_id,:]
  *             _last_exits[seg_id,:] = _prev_last_exits[parent_id,:]             # <<<<<<<<<<<<<<
  *             _last_exits_td[seg_id,:] = _prev_last_exits_td[parent_id,:]
  *             _last_completions[seg_id,:,:] = _prev_last_completions[parent_id,:,:]
  */
-      if (unlikely(!__pyx_v__prev_last_exits.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_exits"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 488; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+      if (unlikely(!__pyx_v__prev_last_exits.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_exits"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 491; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
       __pyx_t_20.data = __pyx_v__prev_last_exits.data;
       __pyx_t_20.memview = __pyx_v__prev_last_exits.memview;
       __PYX_INC_MEMVIEW(&__pyx_t_20, 0);
@@ -8129,7 +8161,7 @@ if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_20, __pyx_t_21, 1, 1, 0) < 0
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 488; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 491; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_20.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -8149,7 +8181,7 @@ __pyx_t_22.data = __pyx_v__last_exits.data;
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 488; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 491; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_22.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -8158,18 +8190,18 @@ __pyx_t_22.shape[0] = __pyx_v__last_exits.shape[1];
 __pyx_t_22.strides[0] = __pyx_v__last_exits.strides[1];
     __pyx_t_22.suboffsets[0] = -1;
 
-if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_20, __pyx_t_22, 1, 1, 0) < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 488; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_20, __pyx_t_22, 1, 1, 0) < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 491; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
       __PYX_XDEC_MEMVIEW(&__pyx_t_22, 1);
       __PYX_XDEC_MEMVIEW(&__pyx_t_20, 1);
 
-      /* "westpa/kinetics/_kinetics.pyx":489
+      /* "westpa/kinetics/_kinetics.pyx":492
  *             _last_entries[seg_id,:] = _prev_last_entries[parent_id,:]
  *             _last_exits[seg_id,:] = _prev_last_exits[parent_id,:]
  *             _last_exits_td[seg_id,:] = _prev_last_exits_td[parent_id,:]             # <<<<<<<<<<<<<<
  *             _last_completions[seg_id,:,:] = _prev_last_completions[parent_id,:,:]
  * 
  */
-      if (unlikely(!__pyx_v__prev_last_exits_td.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_exits_td"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+      if (unlikely(!__pyx_v__prev_last_exits_td.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_exits_td"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 492; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
       __pyx_t_20.data = __pyx_v__prev_last_exits_td.data;
       __pyx_t_20.memview = __pyx_v__prev_last_exits_td.memview;
       __PYX_INC_MEMVIEW(&__pyx_t_20, 0);
@@ -8181,7 +8213,7 @@ if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_20, __pyx_t_22, 1, 1, 0) < 0
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 492; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_20.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -8201,7 +8233,7 @@ __pyx_t_23.data = __pyx_v__last_exits_td.data;
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 492; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_23.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -8210,18 +8242,18 @@ __pyx_t_23.shape[0] = __pyx_v__last_exits_td.shape[1];
 __pyx_t_23.strides[0] = __pyx_v__last_exits_td.strides[1];
     __pyx_t_23.suboffsets[0] = -1;
 
-if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_20, __pyx_t_23, 1, 1, 0) < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 489; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_20, __pyx_t_23, 1, 1, 0) < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 492; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
       __PYX_XDEC_MEMVIEW(&__pyx_t_23, 1);
       __PYX_XDEC_MEMVIEW(&__pyx_t_20, 1);
 
-      /* "westpa/kinetics/_kinetics.pyx":490
+      /* "westpa/kinetics/_kinetics.pyx":493
  *             _last_exits[seg_id,:] = _prev_last_exits[parent_id,:]
  *             _last_exits_td[seg_id,:] = _prev_last_exits_td[parent_id,:]
  *             _last_completions[seg_id,:,:] = _prev_last_completions[parent_id,:,:]             # <<<<<<<<<<<<<<
  * 
  *     return (last_time, last_entries, last_exits, last_exits_td, last_completions)
  */
-      if (unlikely(!__pyx_v__prev_last_completions.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_completions"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 490; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+      if (unlikely(!__pyx_v__prev_last_completions.memview)) { __Pyx_RaiseUnboundLocalError("_prev_last_completions"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 493; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
       __pyx_t_24.data = __pyx_v__prev_last_completions.data;
       __pyx_t_24.memview = __pyx_v__prev_last_completions.memview;
       __PYX_INC_MEMVIEW(&__pyx_t_24, 0);
@@ -8233,7 +8265,7 @@ if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_20, __pyx_t_23, 1, 1, 0) < 0
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 490; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 493; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_24.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -8257,7 +8289,7 @@ __pyx_t_25.data = __pyx_v__last_completions.data;
         __pyx_tmp_idx += __pyx_tmp_shape;
     if (0 && (__pyx_tmp_idx < 0 || __pyx_tmp_idx >= __pyx_tmp_shape)) {
         PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis 0)");
-        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 490; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        {__pyx_filename = __pyx_f[0]; __pyx_lineno = 493; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
         __pyx_t_25.data += __pyx_tmp_idx * __pyx_tmp_stride;
 }
@@ -8270,14 +8302,14 @@ __pyx_t_25.shape[1] = __pyx_v__last_completions.shape[2];
 __pyx_t_25.strides[1] = __pyx_v__last_completions.strides[2];
     __pyx_t_25.suboffsets[1] = -1;
 
-if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_24, __pyx_t_25, 2, 2, 0) < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 490; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_24, __pyx_t_25, 2, 2, 0) < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 493; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
       __PYX_XDEC_MEMVIEW(&__pyx_t_25, 1);
       __PYX_XDEC_MEMVIEW(&__pyx_t_24, 1);
     }
     __pyx_L6:;
   }
 
-  /* "westpa/kinetics/_kinetics.pyx":492
+  /* "westpa/kinetics/_kinetics.pyx":495
  *             _last_completions[seg_id,:,:] = _prev_last_completions[parent_id,:,:]
  * 
  *     return (last_time, last_entries, last_exits, last_exits_td, last_completions)             # <<<<<<<<<<<<<<
@@ -8285,7 +8317,7 @@ if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_24, __pyx_t_25, 2, 2, 0) < 0
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyTuple_New(5); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 492; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = PyTuple_New(5); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 495; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_last_time);
   __Pyx_GIVEREF(__pyx_v_last_time);
@@ -8306,7 +8338,7 @@ if (unlikely(__pyx_memoryview_copy_contents(__pyx_t_24, __pyx_t_25, 2, 2, 0) < 0
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":440
+  /* "westpa/kinetics/_kinetics.pyx":443
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * cpdef _fast_transition_state_copy(Py_ssize_t iiter,             # <<<<<<<<<<<<<<
@@ -8391,21 +8423,21 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_25_fast_transition_state_
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_nstates)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_fast_transition_state_copy", 1, 4, 4, 1); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 440; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("_fast_transition_state_copy", 1, 4, 4, 1); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 443; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_parent_ids)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_fast_transition_state_copy", 1, 4, 4, 2); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 440; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("_fast_transition_state_copy", 1, 4, 4, 2); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 443; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_last_state)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_fast_transition_state_copy", 1, 4, 4, 3); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 440; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("_fast_transition_state_copy", 1, 4, 4, 3); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 443; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_fast_transition_state_copy") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 440; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_fast_transition_state_copy") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 443; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -8415,14 +8447,14 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_25_fast_transition_state_
       values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
       values[3] = PyTuple_GET_ITEM(__pyx_args, 3);
     }
-    __pyx_v_iiter = __Pyx_PyIndex_AsSsize_t(values[0]); if (unlikely((__pyx_v_iiter == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 440; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_nstates = __Pyx_PyIndex_AsSsize_t(values[1]); if (unlikely((__pyx_v_nstates == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 441; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_parent_ids = __Pyx_PyObject_to_MemoryviewSlice_ds_nn___pyx_t_6westpa_8kinetics_9_kinetics_seg_id_t(values[2]); if (unlikely(!__pyx_v_parent_ids.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 442; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_iiter = __Pyx_PyIndex_AsSsize_t(values[0]); if (unlikely((__pyx_v_iiter == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 443; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_nstates = __Pyx_PyIndex_AsSsize_t(values[1]); if (unlikely((__pyx_v_nstates == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 444; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_parent_ids = __Pyx_PyObject_to_MemoryviewSlice_ds_nn___pyx_t_6westpa_8kinetics_9_kinetics_seg_id_t(values[2]); if (unlikely(!__pyx_v_parent_ids.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 445; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
     __pyx_v_last_state = values[3];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_fast_transition_state_copy", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 440; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+  __Pyx_RaiseArgtupleInvalid("_fast_transition_state_copy", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 443; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
   __pyx_L3_error:;
   __Pyx_AddTraceback("westpa.kinetics._kinetics._fast_transition_state_copy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -8444,8 +8476,8 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_24_fast_transition_state_
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("_fast_transition_state_copy", 0);
   __Pyx_XDECREF(__pyx_r);
-  if (unlikely(!__pyx_v_parent_ids.memview)) { __Pyx_RaiseUnboundLocalError("parent_ids"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 440; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
-  __pyx_t_1 = __pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_copy(__pyx_v_iiter, __pyx_v_nstates, __pyx_v_parent_ids, __pyx_v_last_state, 0); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 440; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_parent_ids.memview)) { __Pyx_RaiseUnboundLocalError("parent_ids"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 443; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+  __pyx_t_1 = __pyx_f_6westpa_8kinetics_9_kinetics__fast_transition_state_copy(__pyx_v_iiter, __pyx_v_nstates, __pyx_v_parent_ids, __pyx_v_last_state, 0); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 443; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -8463,7 +8495,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_24_fast_transition_state_
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":497
+/* "westpa/kinetics/_kinetics.pyx":500
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * cpdef find_macrostate_transitions(Py_ssize_t nstates,             # <<<<<<<<<<<<<<
@@ -8548,7 +8580,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("find_macrostate_transitions", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":553
+  /* "westpa/kinetics/_kinetics.pyx":556
  * 
  * 
  *     nsegs = label_assignments.shape[0]             # <<<<<<<<<<<<<<
@@ -8557,7 +8589,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
  */
   __pyx_v_nsegs = (__pyx_v_label_assignments.shape[0]);
 
-  /* "westpa/kinetics/_kinetics.pyx":554
+  /* "westpa/kinetics/_kinetics.pyx":557
  * 
  *     nsegs = label_assignments.shape[0]
  *     npts = label_assignments.shape[1]             # <<<<<<<<<<<<<<
@@ -8566,87 +8598,87 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
  */
   __pyx_v_npts = (__pyx_v_label_assignments.shape[1]);
 
-  /* "westpa/kinetics/_kinetics.pyx":556
+  /* "westpa/kinetics/_kinetics.pyx":559
  *     npts = label_assignments.shape[1]
  * 
  *     _last_time = state[0]             # <<<<<<<<<<<<<<
  *     _last_entries = state[1]
  *     _last_exits = state[2]
  */
-  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 556; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 559; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = __Pyx_PyObject_to_MemoryviewSlice_ds_double(__pyx_t_1);
-  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 556; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 559; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v__last_time = __pyx_t_2;
   __pyx_t_2.memview = NULL;
   __pyx_t_2.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":557
+  /* "westpa/kinetics/_kinetics.pyx":560
  * 
  *     _last_time = state[0]
  *     _last_entries = state[1]             # <<<<<<<<<<<<<<
  *     _last_exits = state[2]
  *     _last_exits_td = state[3]
  */
-  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 557; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 560; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_3 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_1);
-  if (unlikely(!__pyx_t_3.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 557; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_3.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 560; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v__last_entries = __pyx_t_3;
   __pyx_t_3.memview = NULL;
   __pyx_t_3.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":558
+  /* "westpa/kinetics/_kinetics.pyx":561
  *     _last_time = state[0]
  *     _last_entries = state[1]
  *     _last_exits = state[2]             # <<<<<<<<<<<<<<
  *     _last_exits_td = state[3]
  *     _last_completions = state[4]
  */
-  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 558; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 561; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_3 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_1);
-  if (unlikely(!__pyx_t_3.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 558; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_3.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 561; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v__last_exits = __pyx_t_3;
   __pyx_t_3.memview = NULL;
   __pyx_t_3.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":559
+  /* "westpa/kinetics/_kinetics.pyx":562
  *     _last_entries = state[1]
  *     _last_exits = state[2]
  *     _last_exits_td = state[3]             # <<<<<<<<<<<<<<
  *     _last_completions = state[4]
  * 
  */
-  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 559; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 562; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_3 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_1);
-  if (unlikely(!__pyx_t_3.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 559; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_3.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 562; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v__last_exits_td = __pyx_t_3;
   __pyx_t_3.memview = NULL;
   __pyx_t_3.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":560
+  /* "westpa/kinetics/_kinetics.pyx":563
  *     _last_exits = state[2]
  *     _last_exits_td = state[3]
  *     _last_completions = state[4]             # <<<<<<<<<<<<<<
  * 
  *     for seg_id in xrange(nsegs):
  */
-  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 4, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 560; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
+  __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_state, 4, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(__pyx_t_1 == NULL)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 563; __pyx_clineno = __LINE__; goto __pyx_L1_error;};
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_4 = __Pyx_PyObject_to_MemoryviewSlice_dsdsds_double(__pyx_t_1);
-  if (unlikely(!__pyx_t_4.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 560; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_4.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 563; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v__last_completions = __pyx_t_4;
   __pyx_t_4.memview = NULL;
   __pyx_t_4.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":562
+  /* "westpa/kinetics/_kinetics.pyx":565
  *     _last_completions = state[4]
  * 
  *     for seg_id in xrange(nsegs):             # <<<<<<<<<<<<<<
@@ -8657,7 +8689,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
   for (__pyx_t_6 = 0; __pyx_t_6 < __pyx_t_5; __pyx_t_6+=1) {
     __pyx_v_seg_id = __pyx_t_6;
 
-    /* "westpa/kinetics/_kinetics.pyx":563
+    /* "westpa/kinetics/_kinetics.pyx":566
  * 
  *     for seg_id in xrange(nsegs):
  *         itime = _last_time[seg_id]             # <<<<<<<<<<<<<<
@@ -8667,7 +8699,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
     __pyx_t_7 = __pyx_v_seg_id;
     __pyx_v_itime = (*((double *) ( /* dim=0 */ (__pyx_v__last_time.data + __pyx_t_7 * __pyx_v__last_time.strides[0]) )));
 
-    /* "westpa/kinetics/_kinetics.pyx":564
+    /* "westpa/kinetics/_kinetics.pyx":567
  *     for seg_id in xrange(nsegs):
  *         itime = _last_time[seg_id]
  *         _weight = weights[seg_id]             # <<<<<<<<<<<<<<
@@ -8677,7 +8709,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
     __pyx_t_8 = __pyx_v_seg_id;
     __pyx_v__weight = (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_weights.data + __pyx_t_8 * __pyx_v_weights.strides[0]) )));
 
-    /* "westpa/kinetics/_kinetics.pyx":568
+    /* "westpa/kinetics/_kinetics.pyx":571
  *         # transitions never occur between the (overlapping) end point of previous iteration and beginning of
  *         # current iteration, so it suffices to start looking at timepoint 1 (and backwards to timepoint 0)
  *         for ipt in range(1,npts):             # <<<<<<<<<<<<<<
@@ -8688,7 +8720,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
     for (__pyx_t_10 = 1; __pyx_t_10 < __pyx_t_9; __pyx_t_10+=1) {
       __pyx_v_ipt = __pyx_t_10;
 
-      /* "westpa/kinetics/_kinetics.pyx":569
+      /* "westpa/kinetics/_kinetics.pyx":572
  *         # current iteration, so it suffices to start looking at timepoint 1 (and backwards to timepoint 0)
  *         for ipt in range(1,npts):
  *             tm = itime + ipt*dt             # <<<<<<<<<<<<<<
@@ -8697,7 +8729,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
  */
       __pyx_v_tm = (__pyx_v_itime + (__pyx_v_ipt * __pyx_v_dt));
 
-      /* "westpa/kinetics/_kinetics.pyx":570
+      /* "westpa/kinetics/_kinetics.pyx":573
  *         for ipt in range(1,npts):
  *             tm = itime + ipt*dt
  *             flabel = label_assignments[seg_id,ipt]             # <<<<<<<<<<<<<<
@@ -8708,7 +8740,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
       __pyx_t_12 = __pyx_v_ipt;
       __pyx_v_flabel = (*((__pyx_t_6westpa_8kinetics_9_kinetics_index_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_label_assignments.data + __pyx_t_11 * __pyx_v_label_assignments.strides[0]) ) + __pyx_t_12 * __pyx_v_label_assignments.strides[1]) )));
 
-      /* "westpa/kinetics/_kinetics.pyx":571
+      /* "westpa/kinetics/_kinetics.pyx":574
  *             tm = itime + ipt*dt
  *             flabel = label_assignments[seg_id,ipt]
  *             ilabel = label_assignments[seg_id,ipt-1]             # <<<<<<<<<<<<<<
@@ -8719,7 +8751,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
       __pyx_t_14 = (__pyx_v_ipt - 1);
       __pyx_v_ilabel = (*((__pyx_t_6westpa_8kinetics_9_kinetics_index_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_label_assignments.data + __pyx_t_13 * __pyx_v_label_assignments.strides[0]) ) + __pyx_t_14 * __pyx_v_label_assignments.strides[1]) )));
 
-      /* "westpa/kinetics/_kinetics.pyx":572
+      /* "westpa/kinetics/_kinetics.pyx":575
  *             flabel = label_assignments[seg_id,ipt]
  *             ilabel = label_assignments[seg_id,ipt-1]
  *             slabel = state_assignments[seg_id,ipt]             # <<<<<<<<<<<<<<
@@ -8730,7 +8762,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
       __pyx_t_16 = __pyx_v_ipt;
       __pyx_v_slabel = (*((__pyx_t_6westpa_8kinetics_9_kinetics_index_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_state_assignments.data + __pyx_t_15 * __pyx_v_state_assignments.strides[0]) ) + __pyx_t_16 * __pyx_v_state_assignments.strides[1]) )));
 
-      /* "westpa/kinetics/_kinetics.pyx":575
+      /* "westpa/kinetics/_kinetics.pyx":578
  * 
  *             # if we have left our state transition barrier...
  *             if flabel == slabel:             # <<<<<<<<<<<<<<
@@ -8740,7 +8772,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
       __pyx_t_17 = ((__pyx_v_flabel == __pyx_v_slabel) != 0);
       if (__pyx_t_17) {
 
-        /* "westpa/kinetics/_kinetics.pyx":576
+        /* "westpa/kinetics/_kinetics.pyx":579
  *             # if we have left our state transition barrier...
  *             if flabel == slabel:
  *                 _last_exits_td[seg_id,flabel] = tm             # <<<<<<<<<<<<<<
@@ -8751,7 +8783,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
         __pyx_t_19 = __pyx_v_flabel;
         *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v__last_exits_td.data + __pyx_t_18 * __pyx_v__last_exits_td.strides[0]) ) + __pyx_t_19 * __pyx_v__last_exits_td.strides[1]) )) = __pyx_v_tm;
 
-        /* "westpa/kinetics/_kinetics.pyx":575
+        /* "westpa/kinetics/_kinetics.pyx":578
  * 
  *             # if we have left our state transition barrier...
  *             if flabel == slabel:             # <<<<<<<<<<<<<<
@@ -8760,7 +8792,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
  */
       }
 
-      /* "westpa/kinetics/_kinetics.pyx":578
+      /* "westpa/kinetics/_kinetics.pyx":581
  *                 _last_exits_td[seg_id,flabel] = tm
  * 
  *             if flabel != ilabel:             # <<<<<<<<<<<<<<
@@ -8770,7 +8802,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
       __pyx_t_17 = ((__pyx_v_flabel != __pyx_v_ilabel) != 0);
       if (__pyx_t_17) {
 
-        /* "westpa/kinetics/_kinetics.pyx":579
+        /* "westpa/kinetics/_kinetics.pyx":582
  * 
  *             if flabel != ilabel:
  *                 target_fluxes[flabel] += _weight             # <<<<<<<<<<<<<<
@@ -8780,7 +8812,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
         __pyx_t_20 = __pyx_v_flabel;
         *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_target_fluxes.data + __pyx_t_20 * __pyx_v_target_fluxes.strides[0]) )) += __pyx_v__weight;
 
-        /* "westpa/kinetics/_kinetics.pyx":580
+        /* "westpa/kinetics/_kinetics.pyx":583
  *             if flabel != ilabel:
  *                 target_fluxes[flabel] += _weight
  *                 target_counts[flabel] += 1             # <<<<<<<<<<<<<<
@@ -8790,7 +8822,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
         __pyx_t_21 = __pyx_v_flabel;
         *((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_target_counts.data + __pyx_t_21 * __pyx_v_target_counts.strides[0]) )) += 1;
 
-        /* "westpa/kinetics/_kinetics.pyx":581
+        /* "westpa/kinetics/_kinetics.pyx":584
  *                 target_fluxes[flabel] += _weight
  *                 target_counts[flabel] += 1
  *                 _last_exits[seg_id,ilabel] = tm             # <<<<<<<<<<<<<<
@@ -8801,7 +8833,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
         __pyx_t_23 = __pyx_v_ilabel;
         *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v__last_exits.data + __pyx_t_22 * __pyx_v__last_exits.strides[0]) ) + __pyx_t_23 * __pyx_v__last_exits.strides[1]) )) = __pyx_v_tm;
 
-        /* "westpa/kinetics/_kinetics.pyx":582
+        /* "westpa/kinetics/_kinetics.pyx":585
  *                 target_counts[flabel] += 1
  *                 _last_exits[seg_id,ilabel] = tm
  *                 _last_entries[seg_id,flabel] = tm             # <<<<<<<<<<<<<<
@@ -8812,7 +8844,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
         __pyx_t_25 = __pyx_v_flabel;
         *((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v__last_entries.data + __pyx_t_24 * __pyx_v__last_entries.strides[0]) ) + __pyx_t_25 * __pyx_v__last_entries.strides[1]) )) = __pyx_v_tm;
 
-        /* "westpa/kinetics/_kinetics.pyx":584
+        /* "westpa/kinetics/_kinetics.pyx":587
  *                 _last_entries[seg_id,flabel] = tm
  * 
  *                 for iistate in xrange(nstates):             # <<<<<<<<<<<<<<
@@ -8823,7 +8855,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
         for (__pyx_t_27 = 0; __pyx_t_27 < __pyx_t_26; __pyx_t_27+=1) {
           __pyx_v_iistate = __pyx_t_27;
 
-          /* "westpa/kinetics/_kinetics.pyx":589
+          /* "westpa/kinetics/_kinetics.pyx":592
  *                     # equality applies only for 0, which means we're counting an arrival from the
  *                     # state where the trajectory started
  *                     if _last_exits[seg_id, iistate] > 0 and _last_entries[seg_id,iistate] >= _last_completions[seg_id,iistate,flabel]:             # <<<<<<<<<<<<<<
@@ -8848,7 +8880,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
           __pyx_L12_bool_binop_done:;
           if (__pyx_t_17) {
 
-            /* "westpa/kinetics/_kinetics.pyx":590
+            /* "westpa/kinetics/_kinetics.pyx":593
  *                     # state where the trajectory started
  *                     if _last_exits[seg_id, iistate] > 0 and _last_entries[seg_id,iistate] >= _last_completions[seg_id,iistate,flabel]:
  *                         macro_fluxes[iistate,flabel] += _weight             # <<<<<<<<<<<<<<
@@ -8859,7 +8891,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
             __pyx_t_37 = __pyx_v_flabel;
             *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_macro_fluxes.data + __pyx_t_36 * __pyx_v_macro_fluxes.strides[0]) ) + __pyx_t_37 * __pyx_v_macro_fluxes.strides[1]) )) += __pyx_v__weight;
 
-            /* "westpa/kinetics/_kinetics.pyx":591
+            /* "westpa/kinetics/_kinetics.pyx":594
  *                     if _last_exits[seg_id, iistate] > 0 and _last_entries[seg_id,iistate] >= _last_completions[seg_id,iistate,flabel]:
  *                         macro_fluxes[iistate,flabel] += _weight
  *                         macro_counts[iistate,flabel] += 1             # <<<<<<<<<<<<<<
@@ -8870,7 +8902,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
             __pyx_t_39 = __pyx_v_flabel;
             *((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_macro_counts.data + __pyx_t_38 * __pyx_v_macro_counts.strides[0]) ) + __pyx_t_39 * __pyx_v_macro_counts.strides[1]) )) += 1;
 
-            /* "westpa/kinetics/_kinetics.pyx":592
+            /* "westpa/kinetics/_kinetics.pyx":595
  *                         macro_fluxes[iistate,flabel] += _weight
  *                         macro_counts[iistate,flabel] += 1
  *                         _last_completions[seg_id,iistate,flabel] = tm             # <<<<<<<<<<<<<<
@@ -8882,7 +8914,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
             __pyx_t_42 = __pyx_v_flabel;
             *((double *) ( /* dim=2 */ (( /* dim=1 */ (( /* dim=0 */ (__pyx_v__last_completions.data + __pyx_t_40 * __pyx_v__last_completions.strides[0]) ) + __pyx_t_41 * __pyx_v__last_completions.strides[1]) ) + __pyx_t_42 * __pyx_v__last_completions.strides[2]) )) = __pyx_v_tm;
 
-            /* "westpa/kinetics/_kinetics.pyx":596
+            /* "westpa/kinetics/_kinetics.pyx":599
  *                         # omit circular transitions (for now) because it causes the transition
  *                         # list to explode
  *                         if iistate != flabel:             # <<<<<<<<<<<<<<
@@ -8892,7 +8924,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
             __pyx_t_17 = ((__pyx_v_iistate != __pyx_v_flabel) != 0);
             if (__pyx_t_17) {
 
-              /* "westpa/kinetics/_kinetics.pyx":597
+              /* "westpa/kinetics/_kinetics.pyx":600
  *                         # list to explode
  *                         if iistate != flabel:
  *                             t_ed = tm - _last_exits_td[seg_id,iistate]             # <<<<<<<<<<<<<<
@@ -8903,24 +8935,24 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
               __pyx_t_44 = __pyx_v_iistate;
               __pyx_v_t_ed = (__pyx_v_tm - (*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v__last_exits_td.data + __pyx_t_43 * __pyx_v__last_exits_td.strides[0]) ) + __pyx_t_44 * __pyx_v__last_exits_td.strides[1]) ))));
 
-              /* "westpa/kinetics/_kinetics.pyx":598
+              /* "westpa/kinetics/_kinetics.pyx":601
  *                         if iistate != flabel:
  *                             t_ed = tm - _last_exits_td[seg_id,iistate]
  *                             durations.append((iistate,flabel,t_ed,_weight, seg_id))             # <<<<<<<<<<<<<<
  *         _last_time[seg_id] = tm
  * 
  */
-              __pyx_t_1 = __Pyx_PyInt_From_npy_uint16(__pyx_v_iistate); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 598; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+              __pyx_t_1 = __Pyx_PyInt_From_npy_uint16(__pyx_v_iistate); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 601; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
               __Pyx_GOTREF(__pyx_t_1);
-              __pyx_t_45 = __Pyx_PyInt_From_npy_uint16(__pyx_v_flabel); if (unlikely(!__pyx_t_45)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 598; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+              __pyx_t_45 = __Pyx_PyInt_From_npy_uint16(__pyx_v_flabel); if (unlikely(!__pyx_t_45)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 601; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
               __Pyx_GOTREF(__pyx_t_45);
-              __pyx_t_46 = PyFloat_FromDouble(__pyx_v_t_ed); if (unlikely(!__pyx_t_46)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 598; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+              __pyx_t_46 = PyFloat_FromDouble(__pyx_v_t_ed); if (unlikely(!__pyx_t_46)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 601; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
               __Pyx_GOTREF(__pyx_t_46);
-              __pyx_t_47 = PyFloat_FromDouble(__pyx_v__weight); if (unlikely(!__pyx_t_47)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 598; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+              __pyx_t_47 = PyFloat_FromDouble(__pyx_v__weight); if (unlikely(!__pyx_t_47)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 601; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
               __Pyx_GOTREF(__pyx_t_47);
-              __pyx_t_48 = PyInt_FromSsize_t(__pyx_v_seg_id); if (unlikely(!__pyx_t_48)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 598; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+              __pyx_t_48 = PyInt_FromSsize_t(__pyx_v_seg_id); if (unlikely(!__pyx_t_48)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 601; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
               __Pyx_GOTREF(__pyx_t_48);
-              __pyx_t_49 = PyTuple_New(5); if (unlikely(!__pyx_t_49)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 598; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+              __pyx_t_49 = PyTuple_New(5); if (unlikely(!__pyx_t_49)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 601; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
               __Pyx_GOTREF(__pyx_t_49);
               __Pyx_GIVEREF(__pyx_t_1);
               PyTuple_SET_ITEM(__pyx_t_49, 0, __pyx_t_1);
@@ -8937,10 +8969,10 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
               __pyx_t_46 = 0;
               __pyx_t_47 = 0;
               __pyx_t_48 = 0;
-              __pyx_t_50 = __Pyx_PyObject_Append(__pyx_v_durations, __pyx_t_49); if (unlikely(__pyx_t_50 == -1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 598; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+              __pyx_t_50 = __Pyx_PyObject_Append(__pyx_v_durations, __pyx_t_49); if (unlikely(__pyx_t_50 == -1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 601; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
               __Pyx_DECREF(__pyx_t_49); __pyx_t_49 = 0;
 
-              /* "westpa/kinetics/_kinetics.pyx":596
+              /* "westpa/kinetics/_kinetics.pyx":599
  *                         # omit circular transitions (for now) because it causes the transition
  *                         # list to explode
  *                         if iistate != flabel:             # <<<<<<<<<<<<<<
@@ -8949,7 +8981,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
  */
             }
 
-            /* "westpa/kinetics/_kinetics.pyx":589
+            /* "westpa/kinetics/_kinetics.pyx":592
  *                     # equality applies only for 0, which means we're counting an arrival from the
  *                     # state where the trajectory started
  *                     if _last_exits[seg_id, iistate] > 0 and _last_entries[seg_id,iistate] >= _last_completions[seg_id,iistate,flabel]:             # <<<<<<<<<<<<<<
@@ -8959,7 +8991,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
           }
         }
 
-        /* "westpa/kinetics/_kinetics.pyx":578
+        /* "westpa/kinetics/_kinetics.pyx":581
  *                 _last_exits_td[seg_id,flabel] = tm
  * 
  *             if flabel != ilabel:             # <<<<<<<<<<<<<<
@@ -8969,7 +9001,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
       }
     }
 
-    /* "westpa/kinetics/_kinetics.pyx":599
+    /* "westpa/kinetics/_kinetics.pyx":602
  *                             t_ed = tm - _last_exits_td[seg_id,iistate]
  *                             durations.append((iistate,flabel,t_ed,_weight, seg_id))
  *         _last_time[seg_id] = tm             # <<<<<<<<<<<<<<
@@ -8980,7 +9012,7 @@ static PyObject *__pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transition
     *((double *) ( /* dim=0 */ (__pyx_v__last_time.data + __pyx_t_51 * __pyx_v__last_time.strides[0]) )) = __pyx_v_tm;
   }
 
-  /* "westpa/kinetics/_kinetics.pyx":497
+  /* "westpa/kinetics/_kinetics.pyx":500
  * @cython.boundscheck(False)
  * @cython.wraparound(False)
  * cpdef find_macrostate_transitions(Py_ssize_t nstates,             # <<<<<<<<<<<<<<
@@ -9063,56 +9095,56 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_27find_macrostate_transit
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_weights)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 1); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 1); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_label_assignments)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 2); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 2); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_state_assignments)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 3); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 3); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_dt)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 4); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 4); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_state)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 5); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 5); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  6:
         if (likely((values[6] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_macro_fluxes)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 6); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 6); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  7:
         if (likely((values[7] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_macro_counts)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 7); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 7); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  8:
         if (likely((values[8] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_target_fluxes)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 8); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 8); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case  9:
         if (likely((values[9] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_target_counts)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 9); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 9); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
         case 10:
         if (likely((values[10] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_durations)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 10); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, 10); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "find_macrostate_transitions") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "find_macrostate_transitions") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 11) {
       goto __pyx_L5_argtuple_error;
@@ -9129,21 +9161,21 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_27find_macrostate_transit
       values[9] = PyTuple_GET_ITEM(__pyx_args, 9);
       values[10] = PyTuple_GET_ITEM(__pyx_args, 10);
     }
-    __pyx_v_nstates = __Pyx_PyIndex_AsSsize_t(values[0]); if (unlikely((__pyx_v_nstates == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_weights = __Pyx_PyObject_to_MemoryviewSlice_ds_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[1]); if (unlikely(!__pyx_v_weights.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 498; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_label_assignments = __Pyx_PyObject_to_MemoryviewSlice_dsds_nn___pyx_t_6westpa_8kinetics_9_kinetics_index_t(values[2]); if (unlikely(!__pyx_v_label_assignments.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 499; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_state_assignments = __Pyx_PyObject_to_MemoryviewSlice_dsds_nn___pyx_t_6westpa_8kinetics_9_kinetics_index_t(values[3]); if (unlikely(!__pyx_v_state_assignments.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_dt = __pyx_PyFloat_AsDouble(values[4]); if (unlikely((__pyx_v_dt == (double)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 501; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_nstates = __Pyx_PyIndex_AsSsize_t(values[0]); if (unlikely((__pyx_v_nstates == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_weights = __Pyx_PyObject_to_MemoryviewSlice_ds_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[1]); if (unlikely(!__pyx_v_weights.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 501; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_label_assignments = __Pyx_PyObject_to_MemoryviewSlice_dsds_nn___pyx_t_6westpa_8kinetics_9_kinetics_index_t(values[2]); if (unlikely(!__pyx_v_label_assignments.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 502; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_state_assignments = __Pyx_PyObject_to_MemoryviewSlice_dsds_nn___pyx_t_6westpa_8kinetics_9_kinetics_index_t(values[3]); if (unlikely(!__pyx_v_state_assignments.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 503; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_dt = __pyx_PyFloat_AsDouble(values[4]); if (unlikely((__pyx_v_dt == (double)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 504; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
     __pyx_v_state = values[5];
-    __pyx_v_macro_fluxes = __Pyx_PyObject_to_MemoryviewSlice_dsds_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[6]); if (unlikely(!__pyx_v_macro_fluxes.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 503; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_macro_counts = __Pyx_PyObject_to_MemoryviewSlice_dsds_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t(values[7]); if (unlikely(!__pyx_v_macro_counts.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 504; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_target_fluxes = __Pyx_PyObject_to_MemoryviewSlice_ds_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[8]); if (unlikely(!__pyx_v_target_fluxes.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 505; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_target_counts = __Pyx_PyObject_to_MemoryviewSlice_ds_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t(values[9]); if (unlikely(!__pyx_v_target_counts.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 506; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_macro_fluxes = __Pyx_PyObject_to_MemoryviewSlice_dsds_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[6]); if (unlikely(!__pyx_v_macro_fluxes.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 506; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_macro_counts = __Pyx_PyObject_to_MemoryviewSlice_dsds_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t(values[7]); if (unlikely(!__pyx_v_macro_counts.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 507; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_target_fluxes = __Pyx_PyObject_to_MemoryviewSlice_ds_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[8]); if (unlikely(!__pyx_v_target_fluxes.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 508; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_target_counts = __Pyx_PyObject_to_MemoryviewSlice_ds_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t(values[9]); if (unlikely(!__pyx_v_target_counts.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 509; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
     __pyx_v_durations = values[10];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+  __Pyx_RaiseArgtupleInvalid("find_macrostate_transitions", 1, 11, 11, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
   __pyx_L3_error:;
   __Pyx_AddTraceback("westpa.kinetics._kinetics.find_macrostate_transitions", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -9165,14 +9197,14 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_26find_macrostate_transit
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("find_macrostate_transitions", 0);
   __Pyx_XDECREF(__pyx_r);
-  if (unlikely(!__pyx_v_weights.memview)) { __Pyx_RaiseUnboundLocalError("weights"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
-  if (unlikely(!__pyx_v_label_assignments.memview)) { __Pyx_RaiseUnboundLocalError("label_assignments"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
-  if (unlikely(!__pyx_v_state_assignments.memview)) { __Pyx_RaiseUnboundLocalError("state_assignments"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
-  if (unlikely(!__pyx_v_macro_fluxes.memview)) { __Pyx_RaiseUnboundLocalError("macro_fluxes"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
-  if (unlikely(!__pyx_v_macro_counts.memview)) { __Pyx_RaiseUnboundLocalError("macro_counts"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
-  if (unlikely(!__pyx_v_target_fluxes.memview)) { __Pyx_RaiseUnboundLocalError("target_fluxes"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
-  if (unlikely(!__pyx_v_target_counts.memview)) { __Pyx_RaiseUnboundLocalError("target_counts"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
-  __pyx_t_1 = __pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transitions(__pyx_v_nstates, __pyx_v_weights, __pyx_v_label_assignments, __pyx_v_state_assignments, __pyx_v_dt, __pyx_v_state, __pyx_v_macro_fluxes, __pyx_v_macro_counts, __pyx_v_target_fluxes, __pyx_v_target_counts, __pyx_v_durations, 0); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 497; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_weights.memview)) { __Pyx_RaiseUnboundLocalError("weights"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+  if (unlikely(!__pyx_v_label_assignments.memview)) { __Pyx_RaiseUnboundLocalError("label_assignments"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+  if (unlikely(!__pyx_v_state_assignments.memview)) { __Pyx_RaiseUnboundLocalError("state_assignments"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+  if (unlikely(!__pyx_v_macro_fluxes.memview)) { __Pyx_RaiseUnboundLocalError("macro_fluxes"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+  if (unlikely(!__pyx_v_macro_counts.memview)) { __Pyx_RaiseUnboundLocalError("macro_counts"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+  if (unlikely(!__pyx_v_target_fluxes.memview)) { __Pyx_RaiseUnboundLocalError("target_fluxes"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+  if (unlikely(!__pyx_v_target_counts.memview)) { __Pyx_RaiseUnboundLocalError("target_counts"); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L1_error;} }
+  __pyx_t_1 = __pyx_f_6westpa_8kinetics_9_kinetics_find_macrostate_transitions(__pyx_v_nstates, __pyx_v_weights, __pyx_v_label_assignments, __pyx_v_state_assignments, __pyx_v_dt, __pyx_v_state, __pyx_v_macro_fluxes, __pyx_v_macro_counts, __pyx_v_target_fluxes, __pyx_v_target_counts, __pyx_v_durations, 0); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 500; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -9196,7 +9228,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_26find_macrostate_transit
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":615
+/* "westpa/kinetics/_kinetics.pyx":618
  *     cdef Py_ssize_t _sz0, _sz1
  * 
  *     def __init__(self, tuple shape):             # <<<<<<<<<<<<<<
@@ -9232,7 +9264,7 @@ static int __pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats2D_1__init__(Py
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 615; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 618; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
@@ -9243,13 +9275,13 @@ static int __pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats2D_1__init__(Py
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__init__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 615; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+  __Pyx_RaiseArgtupleInvalid("__init__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 618; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
   __pyx_L3_error:;
   __Pyx_AddTraceback("westpa.kinetics._kinetics.StreamingStats2D.__init__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return -1;
   __pyx_L4_argument_unpacking_done:;
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_shape), (&PyTuple_Type), 1, "shape", 1))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 615; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_shape), (&PyTuple_Type), 1, "shape", 1))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 618; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_r = __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D___init__(((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats2D *)__pyx_v_self), __pyx_v_shape);
 
   /* function exit code */
@@ -9278,7 +9310,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D___init__(str
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__init__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":617
+  /* "westpa/kinetics/_kinetics.pyx":620
  *     def __init__(self, tuple shape):
  * 
  *         assert len(shape) == 2             # <<<<<<<<<<<<<<
@@ -9289,128 +9321,128 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D___init__(str
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(__pyx_v_shape == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 617; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
-    __pyx_t_1 = PyTuple_GET_SIZE(__pyx_v_shape); if (unlikely(__pyx_t_1 == -1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 617; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = PyTuple_GET_SIZE(__pyx_v_shape); if (unlikely(__pyx_t_1 == -1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     if (unlikely(!((__pyx_t_1 == 2) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 617; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
   }
   #endif
 
-  /* "westpa/kinetics/_kinetics.pyx":619
+  /* "westpa/kinetics/_kinetics.pyx":622
  *         assert len(shape) == 2
  * 
  *         self._n = numpy.zeros(shape, dtype=numpy.uint)             # <<<<<<<<<<<<<<
  *         self._M1 = numpy.zeros(shape, dtype=weight_dtype)
  *         self._M2 = numpy.zeros(shape, dtype=weight_dtype)
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 619; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_zeros); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 619; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_zeros); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 619; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_INCREF(__pyx_v_shape);
   __Pyx_GIVEREF(__pyx_v_shape);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_v_shape);
-  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 619; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 619; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_uint); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 619; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_uint); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_t_6) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 619; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_t_6) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 619; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_6 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_7 = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t(__pyx_t_6);
-  if (unlikely(!__pyx_t_7.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 619; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_7.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_n, 0);
   __pyx_v_self->_n = __pyx_t_7;
   __pyx_t_7.memview = NULL;
   __pyx_t_7.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":620
+  /* "westpa/kinetics/_kinetics.pyx":623
  * 
  *         self._n = numpy.zeros(shape, dtype=numpy.uint)
  *         self._M1 = numpy.zeros(shape, dtype=weight_dtype)             # <<<<<<<<<<<<<<
  *         self._M2 = numpy.zeros(shape, dtype=weight_dtype)
  *         self._sz0, self._sz1 = shape
  */
-  __pyx_t_6 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_6 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 623; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_zeros); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_zeros); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 623; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 623; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_INCREF(__pyx_v_shape);
   __Pyx_GIVEREF(__pyx_v_shape);
   PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_v_shape);
-  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 623; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_weight_dtype); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_weight_dtype); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 623; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_dtype, __pyx_t_3) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_dtype, __pyx_t_3) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 623; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, __pyx_t_2); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, __pyx_t_2); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 623; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_t_8 = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(__pyx_t_3);
-  if (unlikely(!__pyx_t_8.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 620; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_8.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 623; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_M1, 0);
   __pyx_v_self->_M1 = __pyx_t_8;
   __pyx_t_8.memview = NULL;
   __pyx_t_8.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":621
+  /* "westpa/kinetics/_kinetics.pyx":624
  *         self._n = numpy.zeros(shape, dtype=numpy.uint)
  *         self._M1 = numpy.zeros(shape, dtype=weight_dtype)
  *         self._M2 = numpy.zeros(shape, dtype=weight_dtype)             # <<<<<<<<<<<<<<
  *         self._sz0, self._sz1 = shape
  * 
  */
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 621; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 624; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 621; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 624; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 621; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 624; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_INCREF(__pyx_v_shape);
   __Pyx_GIVEREF(__pyx_v_shape);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_v_shape);
-  __pyx_t_6 = PyDict_New(); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 621; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_6 = PyDict_New(); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 624; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_weight_dtype); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 621; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_weight_dtype); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 624; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_dtype, __pyx_t_4) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 621; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_dtype, __pyx_t_4) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 624; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_6); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 621; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_6); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 624; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_8 = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(__pyx_t_4);
-  if (unlikely(!__pyx_t_8.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 621; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_8.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 624; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_M2, 0);
   __pyx_v_self->_M2 = __pyx_t_8;
   __pyx_t_8.memview = NULL;
   __pyx_t_8.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":622
+  /* "westpa/kinetics/_kinetics.pyx":625
  *         self._M1 = numpy.zeros(shape, dtype=weight_dtype)
  *         self._M2 = numpy.zeros(shape, dtype=weight_dtype)
  *         self._sz0, self._sz1 = shape             # <<<<<<<<<<<<<<
@@ -9427,7 +9459,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D___init__(str
     if (unlikely(size != 2)) {
       if (size > 2) __Pyx_RaiseTooManyValuesError(2);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 625; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
     #if CYTHON_COMPILING_IN_CPYTHON
     __pyx_t_4 = PyTuple_GET_ITEM(sequence, 0); 
@@ -9435,22 +9467,22 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D___init__(str
     __Pyx_INCREF(__pyx_t_4);
     __Pyx_INCREF(__pyx_t_6);
     #else
-    __pyx_t_4 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_4 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 625; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_6 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_6 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 625; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_6);
     #endif
   } else {
-    __Pyx_RaiseNoneNotIterableError(); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __Pyx_RaiseNoneNotIterableError(); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 625; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   }
-  __pyx_t_1 = __Pyx_PyIndex_AsSsize_t(__pyx_t_4); if (unlikely((__pyx_t_1 == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyIndex_AsSsize_t(__pyx_t_4); if (unlikely((__pyx_t_1 == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 625; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_9 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_9 == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 622; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_9 = __Pyx_PyIndex_AsSsize_t(__pyx_t_6); if (unlikely((__pyx_t_9 == (Py_ssize_t)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 625; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_v_self->_sz0 = __pyx_t_1;
   __pyx_v_self->_sz1 = __pyx_t_9;
 
-  /* "westpa/kinetics/_kinetics.pyx":615
+  /* "westpa/kinetics/_kinetics.pyx":618
  *     cdef Py_ssize_t _sz0, _sz1
  * 
  *     def __init__(self, tuple shape):             # <<<<<<<<<<<<<<
@@ -9476,7 +9508,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D___init__(str
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":627
+/* "westpa/kinetics/_kinetics.pyx":630
  *     @cython.wraparound(False)
  *     @cython.cdivision(True)
  *     def update(self, weight_t[:,::1] x, bool_t[:,::1] mask):             # <<<<<<<<<<<<<<
@@ -9516,11 +9548,11 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3updat
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_mask)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("update", 1, 2, 2, 1); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 627; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("update", 1, 2, 2, 1); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 630; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "update") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 627; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "update") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 630; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 2) {
       goto __pyx_L5_argtuple_error;
@@ -9528,12 +9560,12 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3updat
       values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
     }
-    __pyx_v_x = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[0]); if (unlikely(!__pyx_v_x.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 627; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_mask = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_bool_t(values[1]); if (unlikely(!__pyx_v_mask.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 627; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_x = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[0]); if (unlikely(!__pyx_v_x.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 630; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_mask = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_bool_t(values[1]); if (unlikely(!__pyx_v_mask.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 630; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("update", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 627; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+  __Pyx_RaiseArgtupleInvalid("update", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 630; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
   __pyx_L3_error:;
   __Pyx_AddTraceback("westpa.kinetics._kinetics.StreamingStats2D.update", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -9581,7 +9613,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("update", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":643
+  /* "westpa/kinetics/_kinetics.pyx":646
  *             double delta, delta_n, term1
  * 
  *         assert x.shape[0] == mask.shape[0] == self._sz0             # <<<<<<<<<<<<<<
@@ -9596,12 +9628,12 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
     }
     if (unlikely(!(__pyx_t_1 != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 643; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 646; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
   }
   #endif
 
-  /* "westpa/kinetics/_kinetics.pyx":644
+  /* "westpa/kinetics/_kinetics.pyx":647
  * 
  *         assert x.shape[0] == mask.shape[0] == self._sz0
  *         assert x.shape[1] == mask.shape[1] == self._sz1             # <<<<<<<<<<<<<<
@@ -9616,12 +9648,12 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
     }
     if (unlikely(!(__pyx_t_1 != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 644; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 647; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
   }
   #endif
 
-  /* "westpa/kinetics/_kinetics.pyx":646
+  /* "westpa/kinetics/_kinetics.pyx":649
  *         assert x.shape[1] == mask.shape[1] == self._sz1
  * 
  *         with nogil:             # <<<<<<<<<<<<<<
@@ -9635,7 +9667,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
       #endif
       /*try:*/ {
 
-        /* "westpa/kinetics/_kinetics.pyx":647
+        /* "westpa/kinetics/_kinetics.pyx":650
  * 
  *         with nogil:
  *             for i in range(self._sz0):             # <<<<<<<<<<<<<<
@@ -9646,7 +9678,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
         for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_2; __pyx_t_3+=1) {
           __pyx_v_i = __pyx_t_3;
 
-          /* "westpa/kinetics/_kinetics.pyx":648
+          /* "westpa/kinetics/_kinetics.pyx":651
  *         with nogil:
  *             for i in range(self._sz0):
  *                 for j in range(self._sz1):             # <<<<<<<<<<<<<<
@@ -9657,7 +9689,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
           for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=1) {
             __pyx_v_j = __pyx_t_5;
 
-            /* "westpa/kinetics/_kinetics.pyx":649
+            /* "westpa/kinetics/_kinetics.pyx":652
  *             for i in range(self._sz0):
  *                 for j in range(self._sz1):
  *                     if not mask[i,j]:             # <<<<<<<<<<<<<<
@@ -9669,31 +9701,31 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
             __pyx_t_1 = ((!((*((__pyx_t_6westpa_8kinetics_9_kinetics_bool_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_bool_t *) ( /* dim=0 */ (__pyx_v_mask.data + __pyx_t_6 * __pyx_v_mask.strides[0]) )) + __pyx_t_7)) ))) != 0)) != 0);
             if (__pyx_t_1) {
 
-              /* "westpa/kinetics/_kinetics.pyx":650
+              /* "westpa/kinetics/_kinetics.pyx":653
  *                 for j in range(self._sz1):
  *                     if not mask[i,j]:
  *                         n1 = self._n[i,j]             # <<<<<<<<<<<<<<
  *                         self._n[i,j] += 1
  *                         delta = x[i,j] - self._M1[i,j]
  */
-              if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 650; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+              if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 653; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
               __pyx_t_8 = __pyx_v_i;
               __pyx_t_9 = __pyx_v_j;
               __pyx_v_n1 = (*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_self->_n.data + __pyx_t_8 * __pyx_v_self->_n.strides[0]) )) + __pyx_t_9)) )));
 
-              /* "westpa/kinetics/_kinetics.pyx":651
+              /* "westpa/kinetics/_kinetics.pyx":654
  *                     if not mask[i,j]:
  *                         n1 = self._n[i,j]
  *                         self._n[i,j] += 1             # <<<<<<<<<<<<<<
  *                         delta = x[i,j] - self._M1[i,j]
  *                         delta_n = delta / self._n[i,j]
  */
-              if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 651; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+              if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 654; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
               __pyx_t_10 = __pyx_v_i;
               __pyx_t_11 = __pyx_v_j;
               *((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_self->_n.data + __pyx_t_10 * __pyx_v_self->_n.strides[0]) )) + __pyx_t_11)) )) += 1;
 
-              /* "westpa/kinetics/_kinetics.pyx":652
+              /* "westpa/kinetics/_kinetics.pyx":655
  *                         n1 = self._n[i,j]
  *                         self._n[i,j] += 1
  *                         delta = x[i,j] - self._M1[i,j]             # <<<<<<<<<<<<<<
@@ -9702,24 +9734,24 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
  */
               __pyx_t_12 = __pyx_v_i;
               __pyx_t_13 = __pyx_v_j;
-              if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 652; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+              if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 655; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
               __pyx_t_14 = __pyx_v_i;
               __pyx_t_15 = __pyx_v_j;
               __pyx_v_delta = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_x.data + __pyx_t_12 * __pyx_v_x.strides[0]) )) + __pyx_t_13)) ))) - (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_self->_M1.data + __pyx_t_14 * __pyx_v_self->_M1.strides[0]) )) + __pyx_t_15)) ))));
 
-              /* "westpa/kinetics/_kinetics.pyx":653
+              /* "westpa/kinetics/_kinetics.pyx":656
  *                         self._n[i,j] += 1
  *                         delta = x[i,j] - self._M1[i,j]
  *                         delta_n = delta / self._n[i,j]             # <<<<<<<<<<<<<<
  *                         term1 = delta * delta_n * n1
  *                         self._M1[i,j] += delta_n
  */
-              if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 653; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+              if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 656; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
               __pyx_t_16 = __pyx_v_i;
               __pyx_t_17 = __pyx_v_j;
               __pyx_v_delta_n = (__pyx_v_delta / ((double)(*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_self->_n.data + __pyx_t_16 * __pyx_v_self->_n.strides[0]) )) + __pyx_t_17)) )))));
 
-              /* "westpa/kinetics/_kinetics.pyx":654
+              /* "westpa/kinetics/_kinetics.pyx":657
  *                         delta = x[i,j] - self._M1[i,j]
  *                         delta_n = delta / self._n[i,j]
  *                         term1 = delta * delta_n * n1             # <<<<<<<<<<<<<<
@@ -9728,31 +9760,31 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
  */
               __pyx_v_term1 = ((__pyx_v_delta * __pyx_v_delta_n) * __pyx_v_n1);
 
-              /* "westpa/kinetics/_kinetics.pyx":655
+              /* "westpa/kinetics/_kinetics.pyx":658
  *                         delta_n = delta / self._n[i,j]
  *                         term1 = delta * delta_n * n1
  *                         self._M1[i,j] += delta_n             # <<<<<<<<<<<<<<
  *                         self._M2[i,j] += term1
  * 
  */
-              if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 655; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+              if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 658; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
               __pyx_t_18 = __pyx_v_i;
               __pyx_t_19 = __pyx_v_j;
               *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_self->_M1.data + __pyx_t_18 * __pyx_v_self->_M1.strides[0]) )) + __pyx_t_19)) )) += __pyx_v_delta_n;
 
-              /* "westpa/kinetics/_kinetics.pyx":656
+              /* "westpa/kinetics/_kinetics.pyx":659
  *                         term1 = delta * delta_n * n1
  *                         self._M1[i,j] += delta_n
  *                         self._M2[i,j] += term1             # <<<<<<<<<<<<<<
  * 
  *     @cython.boundscheck(False)
  */
-              if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 656; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+              if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 659; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
               __pyx_t_20 = __pyx_v_i;
               __pyx_t_21 = __pyx_v_j;
               *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_self->_M2.data + __pyx_t_20 * __pyx_v_self->_M2.strides[0]) )) + __pyx_t_21)) )) += __pyx_v_term1;
 
-              /* "westpa/kinetics/_kinetics.pyx":649
+              /* "westpa/kinetics/_kinetics.pyx":652
  *             for i in range(self._sz0):
  *                 for j in range(self._sz1):
  *                     if not mask[i,j]:             # <<<<<<<<<<<<<<
@@ -9764,7 +9796,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
         }
       }
 
-      /* "westpa/kinetics/_kinetics.pyx":646
+      /* "westpa/kinetics/_kinetics.pyx":649
  *         assert x.shape[1] == mask.shape[1] == self._sz1
  * 
  *         with nogil:             # <<<<<<<<<<<<<<
@@ -9788,7 +9820,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
       }
   }
 
-  /* "westpa/kinetics/_kinetics.pyx":627
+  /* "westpa/kinetics/_kinetics.pyx":630
  *     @cython.wraparound(False)
  *     @cython.cdivision(True)
  *     def update(self, weight_t[:,::1] x, bool_t[:,::1] mask):             # <<<<<<<<<<<<<<
@@ -9810,7 +9842,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2updat
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":661
+/* "westpa/kinetics/_kinetics.pyx":664
  *     @cython.wraparound(False)
  *     @cython.cdivision(True)
  *     def __add__(StreamingStats2D self, StreamingStats2D other):             # <<<<<<<<<<<<<<
@@ -9827,8 +9859,8 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats2D_5__add
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__add__ (wrapper)", 0);
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_self), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D, 1, "self", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 661; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_other), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D, 1, "other", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 661; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_self), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D, 1, "self", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 664; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_other), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D, 1, "other", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 664; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_r = __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4__add__(((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats2D *)__pyx_v_self), ((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats2D *)__pyx_v_other));
 
   /* function exit code */
@@ -9894,18 +9926,18 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4__add
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__add__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":668
+  /* "westpa/kinetics/_kinetics.pyx":671
  *             StreamingStats2D combined
  * 
  *         combined = StreamingStats2D((self._sz0, self._sz1))             # <<<<<<<<<<<<<<
  * 
  *         for i in range(self._sz0):
  */
-  __pyx_t_1 = PyInt_FromSsize_t(__pyx_v_self->_sz0); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 668; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = PyInt_FromSsize_t(__pyx_v_self->_sz0); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 671; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_self->_sz1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 668; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyInt_FromSsize_t(__pyx_v_self->_sz1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 671; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 668; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 671; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
@@ -9913,18 +9945,18 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4__add
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_2);
   __pyx_t_1 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 668; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 671; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
   __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D), __pyx_t_2, NULL); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 668; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D), __pyx_t_2, NULL); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 671; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_v_combined = ((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats2D *)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":670
+  /* "westpa/kinetics/_kinetics.pyx":673
  *         combined = StreamingStats2D((self._sz0, self._sz1))
  * 
  *         for i in range(self._sz0):             # <<<<<<<<<<<<<<
@@ -9935,7 +9967,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4__add
   for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=1) {
     __pyx_v_i = __pyx_t_5;
 
-    /* "westpa/kinetics/_kinetics.pyx":671
+    /* "westpa/kinetics/_kinetics.pyx":674
  * 
  *         for i in range(self._sz0):
  *             for j in range(self._sz1):             # <<<<<<<<<<<<<<
@@ -9946,40 +9978,40 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4__add
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_j = __pyx_t_7;
 
-      /* "westpa/kinetics/_kinetics.pyx":672
+      /* "westpa/kinetics/_kinetics.pyx":675
  *         for i in range(self._sz0):
  *             for j in range(self._sz1):
  *                 combined._n[i,j] = self._n[i,j] + other._n[i,j]             # <<<<<<<<<<<<<<
  *                 delta = other._M1[i,j] - self._M1[i,j]
  *                 delta2 = delta * delta
  */
-      if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 672; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 675; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_8 = __pyx_v_i;
       __pyx_t_9 = __pyx_v_j;
-      if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 672; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 675; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_10 = __pyx_v_i;
       __pyx_t_11 = __pyx_v_j;
-      if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 672; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 675; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_12 = __pyx_v_i;
       __pyx_t_13 = __pyx_v_j;
       *((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_combined->_n.data + __pyx_t_12 * __pyx_v_combined->_n.strides[0]) )) + __pyx_t_13)) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_self->_n.data + __pyx_t_8 * __pyx_v_self->_n.strides[0]) )) + __pyx_t_9)) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_other->_n.data + __pyx_t_10 * __pyx_v_other->_n.strides[0]) )) + __pyx_t_11)) ))));
 
-      /* "westpa/kinetics/_kinetics.pyx":673
+      /* "westpa/kinetics/_kinetics.pyx":676
  *             for j in range(self._sz1):
  *                 combined._n[i,j] = self._n[i,j] + other._n[i,j]
  *                 delta = other._M1[i,j] - self._M1[i,j]             # <<<<<<<<<<<<<<
  *                 delta2 = delta * delta
  *                 combined._M1[i,j] = (other._n[i,j]*other._M1[i,j] + self._n[i,j]*self._M1[i,j]) / combined._n[i,j]
  */
-      if (unlikely(!__pyx_v_other->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 673; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_other->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 676; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_14 = __pyx_v_i;
       __pyx_t_15 = __pyx_v_j;
-      if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 673; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 676; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_16 = __pyx_v_i;
       __pyx_t_17 = __pyx_v_j;
       __pyx_v_delta = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_other->_M1.data + __pyx_t_14 * __pyx_v_other->_M1.strides[0]) )) + __pyx_t_15)) ))) - (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_self->_M1.data + __pyx_t_16 * __pyx_v_self->_M1.strides[0]) )) + __pyx_t_17)) ))));
 
-      /* "westpa/kinetics/_kinetics.pyx":674
+      /* "westpa/kinetics/_kinetics.pyx":677
  *                 combined._n[i,j] = self._n[i,j] + other._n[i,j]
  *                 delta = other._M1[i,j] - self._M1[i,j]
  *                 delta2 = delta * delta             # <<<<<<<<<<<<<<
@@ -9988,63 +10020,63 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4__add
  */
       __pyx_v_delta2 = (__pyx_v_delta * __pyx_v_delta);
 
-      /* "westpa/kinetics/_kinetics.pyx":675
+      /* "westpa/kinetics/_kinetics.pyx":678
  *                 delta = other._M1[i,j] - self._M1[i,j]
  *                 delta2 = delta * delta
  *                 combined._M1[i,j] = (other._n[i,j]*other._M1[i,j] + self._n[i,j]*self._M1[i,j]) / combined._n[i,j]             # <<<<<<<<<<<<<<
  *                 combined._M2[i,j] = other._M2[i,j] + self._M2[i,j] + (delta2 * self._n[i,j] * other._n[i,j]) / combined._n[i,j]
  * 
  */
-      if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 675; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 678; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_18 = __pyx_v_i;
       __pyx_t_19 = __pyx_v_j;
-      if (unlikely(!__pyx_v_other->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 675; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_other->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 678; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_20 = __pyx_v_i;
       __pyx_t_21 = __pyx_v_j;
-      if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 675; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 678; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_22 = __pyx_v_i;
       __pyx_t_23 = __pyx_v_j;
-      if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 675; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 678; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_24 = __pyx_v_i;
       __pyx_t_25 = __pyx_v_j;
-      if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 675; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 678; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_26 = __pyx_v_i;
       __pyx_t_27 = __pyx_v_j;
-      if (unlikely(!__pyx_v_combined->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 675; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_combined->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 678; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_28 = __pyx_v_i;
       __pyx_t_29 = __pyx_v_j;
       *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_combined->_M1.data + __pyx_t_28 * __pyx_v_combined->_M1.strides[0]) )) + __pyx_t_29)) )) = ((((*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_other->_n.data + __pyx_t_18 * __pyx_v_other->_n.strides[0]) )) + __pyx_t_19)) ))) * (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_other->_M1.data + __pyx_t_20 * __pyx_v_other->_M1.strides[0]) )) + __pyx_t_21)) )))) + ((*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_self->_n.data + __pyx_t_22 * __pyx_v_self->_n.strides[0]) )) + __pyx_t_23)) ))) * (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_self->_M1.data + __pyx_t_24 * __pyx_v_self->_M1.strides[0]) )) + __pyx_t_25)) ))))) / ((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t)(*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_combined->_n.data + __pyx_t_26 * __pyx_v_combined->_n.strides[0]) )) + __pyx_t_27)) )))));
 
-      /* "westpa/kinetics/_kinetics.pyx":676
+      /* "westpa/kinetics/_kinetics.pyx":679
  *                 delta2 = delta * delta
  *                 combined._M1[i,j] = (other._n[i,j]*other._M1[i,j] + self._n[i,j]*self._M1[i,j]) / combined._n[i,j]
  *                 combined._M2[i,j] = other._M2[i,j] + self._M2[i,j] + (delta2 * self._n[i,j] * other._n[i,j]) / combined._n[i,j]             # <<<<<<<<<<<<<<
  * 
  *         return combined
  */
-      if (unlikely(!__pyx_v_other->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 676; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_other->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 679; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_30 = __pyx_v_i;
       __pyx_t_31 = __pyx_v_j;
-      if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 676; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 679; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_32 = __pyx_v_i;
       __pyx_t_33 = __pyx_v_j;
-      if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 676; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 679; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_34 = __pyx_v_i;
       __pyx_t_35 = __pyx_v_j;
-      if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 676; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 679; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_36 = __pyx_v_i;
       __pyx_t_37 = __pyx_v_j;
-      if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 676; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 679; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_38 = __pyx_v_i;
       __pyx_t_39 = __pyx_v_j;
-      if (unlikely(!__pyx_v_combined->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 676; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+      if (unlikely(!__pyx_v_combined->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 679; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
       __pyx_t_40 = __pyx_v_i;
       __pyx_t_41 = __pyx_v_j;
       *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_combined->_M2.data + __pyx_t_40 * __pyx_v_combined->_M2.strides[0]) )) + __pyx_t_41)) )) = (((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_other->_M2.data + __pyx_t_30 * __pyx_v_other->_M2.strides[0]) )) + __pyx_t_31)) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ (__pyx_v_self->_M2.data + __pyx_t_32 * __pyx_v_self->_M2.strides[0]) )) + __pyx_t_33)) )))) + (((__pyx_v_delta2 * (*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_self->_n.data + __pyx_t_34 * __pyx_v_self->_n.strides[0]) )) + __pyx_t_35)) )))) * (*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_other->_n.data + __pyx_t_36 * __pyx_v_other->_n.strides[0]) )) + __pyx_t_37)) )))) / ((double)(*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=1 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ (__pyx_v_combined->_n.data + __pyx_t_38 * __pyx_v_combined->_n.strides[0]) )) + __pyx_t_39)) ))))));
     }
   }
 
-  /* "westpa/kinetics/_kinetics.pyx":678
+  /* "westpa/kinetics/_kinetics.pyx":681
  *                 combined._M2[i,j] = other._M2[i,j] + self._M2[i,j] + (delta2 * self._n[i,j] * other._n[i,j]) / combined._n[i,j]
  * 
  *         return combined             # <<<<<<<<<<<<<<
@@ -10056,7 +10088,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4__add
   __pyx_r = ((PyObject *)__pyx_v_combined);
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":661
+  /* "westpa/kinetics/_kinetics.pyx":664
  *     @cython.wraparound(False)
  *     @cython.cdivision(True)
  *     def __add__(StreamingStats2D self, StreamingStats2D other):             # <<<<<<<<<<<<<<
@@ -10078,7 +10110,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4__add
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":681
+/* "westpa/kinetics/_kinetics.pyx":684
  * 
  * 
  *     def __iadd__(StreamingStats2D self, StreamingStats2D other):             # <<<<<<<<<<<<<<
@@ -10095,7 +10127,7 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats2D_7__iad
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__iadd__ (wrapper)", 0);
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_other), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D, 1, "other", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 681; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_other), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D, 1, "other", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 684; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_r = __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_6__iadd__(((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats2D *)__pyx_v_self), ((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats2D *)__pyx_v_other));
 
   /* function exit code */
@@ -10118,32 +10150,32 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_6__iad
   __Pyx_RefNannySetupContext("__iadd__", 0);
   __Pyx_INCREF((PyObject *)__pyx_v_self);
 
-  /* "westpa/kinetics/_kinetics.pyx":682
+  /* "westpa/kinetics/_kinetics.pyx":685
  * 
  *     def __iadd__(StreamingStats2D self, StreamingStats2D other):
  *         combined = self + other             # <<<<<<<<<<<<<<
  *         self = combined
  *         return self
  */
-  __pyx_t_1 = PyNumber_Add(((PyObject *)__pyx_v_self), ((PyObject *)__pyx_v_other)); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 682; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = PyNumber_Add(((PyObject *)__pyx_v_self), ((PyObject *)__pyx_v_other)); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 685; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_combined = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":683
+  /* "westpa/kinetics/_kinetics.pyx":686
  *     def __iadd__(StreamingStats2D self, StreamingStats2D other):
  *         combined = self + other
  *         self = combined             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  if (!(likely(((__pyx_v_combined) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_combined, __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D))))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 683; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (!(likely(((__pyx_v_combined) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_combined, __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D))))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 686; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_t_1 = __pyx_v_combined;
   __Pyx_INCREF(__pyx_t_1);
   __Pyx_DECREF_SET(__pyx_v_self, ((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats2D *)__pyx_t_1));
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":684
+  /* "westpa/kinetics/_kinetics.pyx":687
  *         combined = self + other
  *         self = combined
  *         return self             # <<<<<<<<<<<<<<
@@ -10155,7 +10187,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_6__iad
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":681
+  /* "westpa/kinetics/_kinetics.pyx":684
  * 
  * 
  *     def __iadd__(StreamingStats2D self, StreamingStats2D other):             # <<<<<<<<<<<<<<
@@ -10176,7 +10208,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_6__iad
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":688
+/* "westpa/kinetics/_kinetics.pyx":691
  * 
  *     property mean:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10211,20 +10243,20 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4mean_
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":689
+  /* "westpa/kinetics/_kinetics.pyx":692
  *     property mean:
  *         def __get__(self):
  *             tmp = numpy.asarray(self._M1)             # <<<<<<<<<<<<<<
  *             return numpy.nan_to_num(tmp)
  * 
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 689; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 692; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 689; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 692; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 689; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M1, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 689; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 692; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M1, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 692; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -10237,17 +10269,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4mean_
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 689; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 692; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 689; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 692; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 689; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 692; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -10255,7 +10287,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4mean_
   __pyx_v_tmp = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":690
+  /* "westpa/kinetics/_kinetics.pyx":693
  *         def __get__(self):
  *             tmp = numpy.asarray(self._M1)
  *             return numpy.nan_to_num(tmp)             # <<<<<<<<<<<<<<
@@ -10263,9 +10295,9 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4mean_
  *     property var:
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 690; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 693; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_nan_to_num); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 690; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_nan_to_num); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 693; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_3 = NULL;
@@ -10279,16 +10311,16 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4mean_
     }
   }
   if (!__pyx_t_3) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_tmp); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 690; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_tmp); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 693; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_2 = PyTuple_New(1+1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 690; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_2 = PyTuple_New(1+1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 693; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3); __pyx_t_3 = NULL;
     __Pyx_INCREF(__pyx_v_tmp);
     __Pyx_GIVEREF(__pyx_v_tmp);
     PyTuple_SET_ITEM(__pyx_t_2, 0+1, __pyx_v_tmp);
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 690; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 693; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   }
@@ -10297,7 +10329,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4mean_
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":688
+  /* "westpa/kinetics/_kinetics.pyx":691
  * 
  *     property mean:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10321,7 +10353,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_4mean_
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":693
+/* "westpa/kinetics/_kinetics.pyx":696
  * 
  *     property var:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10357,20 +10389,20 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3var__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":694
+  /* "westpa/kinetics/_kinetics.pyx":697
  *     property var:
  *         def __get__(self):
  *             tmp_m = numpy.asarray(self._M2)             # <<<<<<<<<<<<<<
  *             tmp_n = numpy.asarray(self._n)
  *             return numpy.nan_to_num(tmp_m / tmp_n)
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 694; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 697; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 694; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 697; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 694; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M2, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 694; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 697; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M2, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 697; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -10383,17 +10415,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3var__
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 694; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 697; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 694; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 697; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 694; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 697; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -10401,20 +10433,20 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3var__
   __pyx_v_tmp_m = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":695
+  /* "westpa/kinetics/_kinetics.pyx":698
  *         def __get__(self):
  *             tmp_m = numpy.asarray(self._M2)
  *             tmp_n = numpy.asarray(self._n)             # <<<<<<<<<<<<<<
  *             return numpy.nan_to_num(tmp_m / tmp_n)
  * 
  */
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 695; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 698; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_asarray); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 695; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_asarray); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 698; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 695; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_3 = __pyx_memoryview_fromslice(__pyx_v_self->_n, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, 0);; if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 695; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 698; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_3 = __pyx_memoryview_fromslice(__pyx_v_self->_n, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, 0);; if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 698; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_t_2 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -10427,17 +10459,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3var__
     }
   }
   if (!__pyx_t_2) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_3); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 695; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_3); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 698; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 695; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 698; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_2); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_2); __pyx_t_2 = NULL;
     __Pyx_GIVEREF(__pyx_t_3);
     PyTuple_SET_ITEM(__pyx_t_4, 0+1, __pyx_t_3);
     __pyx_t_3 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 695; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 698; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
@@ -10445,7 +10477,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3var__
   __pyx_v_tmp_n = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":696
+  /* "westpa/kinetics/_kinetics.pyx":699
  *             tmp_m = numpy.asarray(self._M2)
  *             tmp_n = numpy.asarray(self._n)
  *             return numpy.nan_to_num(tmp_m / tmp_n)             # <<<<<<<<<<<<<<
@@ -10453,12 +10485,12 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3var__
  *     property n:
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 696; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 699; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_nan_to_num); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 696; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_nan_to_num); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 699; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyNumber_Divide(__pyx_v_tmp_m, __pyx_v_tmp_n); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 696; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyNumber_Divide(__pyx_v_tmp_m, __pyx_v_tmp_n); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 699; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_3 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_4))) {
@@ -10471,17 +10503,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3var__
     }
   }
   if (!__pyx_t_3) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 696; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 699; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_2 = PyTuple_New(1+1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 696; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_2 = PyTuple_New(1+1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 699; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3); __pyx_t_3 = NULL;
     __Pyx_GIVEREF(__pyx_t_5);
     PyTuple_SET_ITEM(__pyx_t_2, 0+1, __pyx_t_5);
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 696; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 699; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   }
@@ -10490,7 +10522,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3var__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":693
+  /* "westpa/kinetics/_kinetics.pyx":696
  * 
  *     property var:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10515,7 +10547,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_3var__
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":699
+/* "westpa/kinetics/_kinetics.pyx":702
  * 
  *     property n:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10549,7 +10581,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_1n___g
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":700
+  /* "westpa/kinetics/_kinetics.pyx":703
  *     property n:
  *         def __get__(self):
  *             return numpy.asarray(self._n)             # <<<<<<<<<<<<<<
@@ -10557,13 +10589,13 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_1n___g
  *         def __set__(self, val):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 700; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 700; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 700; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_n, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 700; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_n, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -10576,17 +10608,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_1n___g
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 700; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 700; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 700; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -10595,7 +10627,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_1n___g
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":699
+  /* "westpa/kinetics/_kinetics.pyx":702
  * 
  *     property n:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10618,7 +10650,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_1n___g
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":702
+/* "westpa/kinetics/_kinetics.pyx":705
  *             return numpy.asarray(self._n)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -10649,24 +10681,24 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_1n_2__set__(
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__set__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":703
+  /* "westpa/kinetics/_kinetics.pyx":706
  * 
  *         def __set__(self, val):
  *             self._n = val[:]             # <<<<<<<<<<<<<<
  * 
  *     property M1:
  */
-  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 706; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t(__pyx_t_1);
-  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 706; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_n, 0);
   __pyx_v_self->_n = __pyx_t_2;
   __pyx_t_2.memview = NULL;
   __pyx_t_2.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":702
+  /* "westpa/kinetics/_kinetics.pyx":705
  *             return numpy.asarray(self._n)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -10687,7 +10719,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_1n_2__set__(
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":706
+/* "westpa/kinetics/_kinetics.pyx":709
  * 
  *     property M1:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10721,7 +10753,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M1___
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":707
+  /* "westpa/kinetics/_kinetics.pyx":710
  *     property M1:
  *         def __get__(self):
  *             return numpy.asarray(self._M1)             # <<<<<<<<<<<<<<
@@ -10729,13 +10761,13 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M1___
  *         def __set__(self, val):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 707; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 707; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 707; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M1, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 707; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M1, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -10748,17 +10780,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M1___
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 707; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 707; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 707; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -10767,7 +10799,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M1___
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":706
+  /* "westpa/kinetics/_kinetics.pyx":709
  * 
  *     property M1:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10790,7 +10822,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M1___
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":709
+/* "westpa/kinetics/_kinetics.pyx":712
  *             return numpy.asarray(self._M1)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -10821,24 +10853,24 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M1_2__set__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__set__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":710
+  /* "westpa/kinetics/_kinetics.pyx":713
  * 
  *         def __set__(self, val):
  *             self._M1 = val[:]             # <<<<<<<<<<<<<<
  * 
  *     property M2:
  */
-  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__3, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__3, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 713; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(__pyx_t_1);
-  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 713; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_M1, 0);
   __pyx_v_self->_M1 = __pyx_t_2;
   __pyx_t_2.memview = NULL;
   __pyx_t_2.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":709
+  /* "westpa/kinetics/_kinetics.pyx":712
  *             return numpy.asarray(self._M1)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -10859,7 +10891,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M1_2__set__
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":713
+/* "westpa/kinetics/_kinetics.pyx":716
  * 
  *     property M2:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10893,7 +10925,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M2___
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":714
+  /* "westpa/kinetics/_kinetics.pyx":717
  *     property M2:
  *         def __get__(self):
  *             return numpy.asarray(self._M2)             # <<<<<<<<<<<<<<
@@ -10901,13 +10933,13 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M2___
  *         def __set__(self, val):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 714; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 714; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 714; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M2, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 714; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M2, 2, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -10920,17 +10952,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M2___
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 714; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 714; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 714; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -10939,7 +10971,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M2___
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":713
+  /* "westpa/kinetics/_kinetics.pyx":716
  * 
  *     property M2:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -10962,7 +10994,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M2___
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":716
+/* "westpa/kinetics/_kinetics.pyx":719
  *             return numpy.asarray(self._M2)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -10993,24 +11025,24 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M2_2__set__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__set__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":717
+  /* "westpa/kinetics/_kinetics.pyx":720
  * 
  *         def __set__(self, val):
  *             self._M2 = val[:]             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__4, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__4, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 720; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = __Pyx_PyObject_to_MemoryviewSlice_d_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(__pyx_t_1);
-  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 720; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_M2, 0);
   __pyx_v_self->_M2 = __pyx_t_2;
   __pyx_t_2.memview = NULL;
   __pyx_t_2.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":716
+  /* "westpa/kinetics/_kinetics.pyx":719
  *             return numpy.asarray(self._M2)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -11031,7 +11063,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats2D_2M2_2__set__
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":733
+/* "westpa/kinetics/_kinetics.pyx":736
  *     cdef Py_ssize_t _sz0
  * 
  *     def __init__(self, int nbins):             # <<<<<<<<<<<<<<
@@ -11067,18 +11099,18 @@ static int __pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats1D_1__init__(Py
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 733; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__init__") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
     } else {
       values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
     }
-    __pyx_v_nbins = __Pyx_PyInt_As_int(values[0]); if (unlikely((__pyx_v_nbins == (int)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 733; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_nbins = __Pyx_PyInt_As_int(values[0]); if (unlikely((__pyx_v_nbins == (int)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__init__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 733; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+  __Pyx_RaiseArgtupleInvalid("__init__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
   __pyx_L3_error:;
   __Pyx_AddTraceback("westpa.kinetics._kinetics.StreamingStats1D.__init__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -11106,139 +11138,139 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D___init__(str
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__init__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":735
+  /* "westpa/kinetics/_kinetics.pyx":738
  *     def __init__(self, int nbins):
  * 
  *         self._n = numpy.zeros((nbins,), dtype=numpy.uint)             # <<<<<<<<<<<<<<
  *         self._M1 = numpy.zeros((nbins,), dtype=weight_dtype)
  *         self._M2 = numpy.zeros((nbins,), dtype=weight_dtype)
  */
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_nbins); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_nbins); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_3);
   __pyx_t_3 = 0;
-  __pyx_t_3 = PyDict_New(); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = PyDict_New(); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_uint); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_uint); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_t_5) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_t_5) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_6 = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t(__pyx_t_5);
-  if (unlikely(!__pyx_t_6.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 735; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_6.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 738; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_n, 0);
   __pyx_v_self->_n = __pyx_t_6;
   __pyx_t_6.memview = NULL;
   __pyx_t_6.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":736
+  /* "westpa/kinetics/_kinetics.pyx":739
  * 
  *         self._n = numpy.zeros((nbins,), dtype=numpy.uint)
  *         self._M1 = numpy.zeros((nbins,), dtype=weight_dtype)             # <<<<<<<<<<<<<<
  *         self._M2 = numpy.zeros((nbins,), dtype=weight_dtype)
  *         self._sz0 = nbins
  */
-  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_zeros); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_zeros); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_nbins); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_nbins); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_5);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_5);
   __pyx_t_5 = 0;
-  __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = PyDict_New(); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = PyDict_New(); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_weight_dtype); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_weight_dtype); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_t_2) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_t_2) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, __pyx_t_1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, __pyx_t_1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_7 = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(__pyx_t_2);
-  if (unlikely(!__pyx_t_7.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 736; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_7.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 739; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_M1, 0);
   __pyx_v_self->_M1 = __pyx_t_7;
   __pyx_t_7.memview = NULL;
   __pyx_t_7.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":737
+  /* "westpa/kinetics/_kinetics.pyx":740
  *         self._n = numpy.zeros((nbins,), dtype=numpy.uint)
  *         self._M1 = numpy.zeros((nbins,), dtype=weight_dtype)
  *         self._M2 = numpy.zeros((nbins,), dtype=weight_dtype)             # <<<<<<<<<<<<<<
  *         self._sz0 = nbins
  * 
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_zeros); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_zeros); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_nbins); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_nbins); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_2);
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_5);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_5);
   __pyx_t_5 = 0;
-  __pyx_t_5 = PyDict_New(); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = PyDict_New(); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_weight_dtype); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_weight_dtype); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  if (PyDict_SetItem(__pyx_t_5, __pyx_n_s_dtype, __pyx_t_3) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyDict_SetItem(__pyx_t_5, __pyx_n_s_dtype, __pyx_t_3) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_2, __pyx_t_5); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_2, __pyx_t_5); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __pyx_t_7 = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(__pyx_t_3);
-  if (unlikely(!__pyx_t_7.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 737; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_7.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 740; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_M2, 0);
   __pyx_v_self->_M2 = __pyx_t_7;
   __pyx_t_7.memview = NULL;
   __pyx_t_7.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":738
+  /* "westpa/kinetics/_kinetics.pyx":741
  *         self._M1 = numpy.zeros((nbins,), dtype=weight_dtype)
  *         self._M2 = numpy.zeros((nbins,), dtype=weight_dtype)
  *         self._sz0 = nbins             # <<<<<<<<<<<<<<
@@ -11247,7 +11279,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D___init__(str
  */
   __pyx_v_self->_sz0 = __pyx_v_nbins;
 
-  /* "westpa/kinetics/_kinetics.pyx":733
+  /* "westpa/kinetics/_kinetics.pyx":736
  *     cdef Py_ssize_t _sz0
  * 
  *     def __init__(self, int nbins):             # <<<<<<<<<<<<<<
@@ -11273,7 +11305,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D___init__(str
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":743
+/* "westpa/kinetics/_kinetics.pyx":746
  *     @cython.wraparound(False)
  *     @cython.cdivision(True)
  *     def update(self, weight_t[::1] x, bool_t[::1] mask):             # <<<<<<<<<<<<<<
@@ -11313,11 +11345,11 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3updat
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_mask)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("update", 1, 2, 2, 1); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 743; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+          __Pyx_RaiseArgtupleInvalid("update", 1, 2, 2, 1); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 746; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "update") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 743; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "update") < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 746; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 2) {
       goto __pyx_L5_argtuple_error;
@@ -11325,12 +11357,12 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3updat
       values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
       values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
     }
-    __pyx_v_x = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[0]); if (unlikely(!__pyx_v_x.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 743; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
-    __pyx_v_mask = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_bool_t(values[1]); if (unlikely(!__pyx_v_mask.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 743; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_x = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(values[0]); if (unlikely(!__pyx_v_x.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 746; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+    __pyx_v_mask = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_bool_t(values[1]); if (unlikely(!__pyx_v_mask.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 746; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("update", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 743; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
+  __Pyx_RaiseArgtupleInvalid("update", 1, 2, 2, PyTuple_GET_SIZE(__pyx_args)); {__pyx_filename = __pyx_f[0]; __pyx_lineno = 746; __pyx_clineno = __LINE__; goto __pyx_L3_error;}
   __pyx_L3_error:;
   __Pyx_AddTraceback("westpa.kinetics._kinetics.StreamingStats1D.update", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -11367,7 +11399,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("update", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":759
+  /* "westpa/kinetics/_kinetics.pyx":762
  *             double delta, delta_n, term1
  * 
  *         assert x.shape[0] == mask.shape[0] == self._sz0             # <<<<<<<<<<<<<<
@@ -11382,12 +11414,12 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
     }
     if (unlikely(!(__pyx_t_1 != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 759; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      {__pyx_filename = __pyx_f[0]; __pyx_lineno = 762; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     }
   }
   #endif
 
-  /* "westpa/kinetics/_kinetics.pyx":761
+  /* "westpa/kinetics/_kinetics.pyx":764
  *         assert x.shape[0] == mask.shape[0] == self._sz0
  * 
  *         with nogil:             # <<<<<<<<<<<<<<
@@ -11401,7 +11433,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
       #endif
       /*try:*/ {
 
-        /* "westpa/kinetics/_kinetics.pyx":762
+        /* "westpa/kinetics/_kinetics.pyx":765
  * 
  *         with nogil:
  *             for i in range(self._sz0):             # <<<<<<<<<<<<<<
@@ -11412,7 +11444,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
         for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_2; __pyx_t_3+=1) {
           __pyx_v_i = __pyx_t_3;
 
-          /* "westpa/kinetics/_kinetics.pyx":763
+          /* "westpa/kinetics/_kinetics.pyx":766
  *         with nogil:
  *             for i in range(self._sz0):
  *                 if not mask[i]:             # <<<<<<<<<<<<<<
@@ -11423,29 +11455,29 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
           __pyx_t_1 = ((!((*((__pyx_t_6westpa_8kinetics_9_kinetics_bool_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_bool_t *) __pyx_v_mask.data) + __pyx_t_4)) ))) != 0)) != 0);
           if (__pyx_t_1) {
 
-            /* "westpa/kinetics/_kinetics.pyx":764
+            /* "westpa/kinetics/_kinetics.pyx":767
  *             for i in range(self._sz0):
  *                 if not mask[i]:
  *                     n1 = self._n[i]             # <<<<<<<<<<<<<<
  *                     self._n[i] += 1
  *                     delta = x[i] - self._M1[i]
  */
-            if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 764; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+            if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 767; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
             __pyx_t_5 = __pyx_v_i;
             __pyx_v_n1 = (*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_self->_n.data) + __pyx_t_5)) )));
 
-            /* "westpa/kinetics/_kinetics.pyx":765
+            /* "westpa/kinetics/_kinetics.pyx":768
  *                 if not mask[i]:
  *                     n1 = self._n[i]
  *                     self._n[i] += 1             # <<<<<<<<<<<<<<
  *                     delta = x[i] - self._M1[i]
  *                     delta_n = delta / self._n[i]
  */
-            if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 765; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+            if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 768; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
             __pyx_t_6 = __pyx_v_i;
             *((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_self->_n.data) + __pyx_t_6)) )) += 1;
 
-            /* "westpa/kinetics/_kinetics.pyx":766
+            /* "westpa/kinetics/_kinetics.pyx":769
  *                     n1 = self._n[i]
  *                     self._n[i] += 1
  *                     delta = x[i] - self._M1[i]             # <<<<<<<<<<<<<<
@@ -11453,22 +11485,22 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
  *                     term1 = delta * delta_n * n1
  */
             __pyx_t_7 = __pyx_v_i;
-            if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 766; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+            if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 769; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
             __pyx_t_8 = __pyx_v_i;
             __pyx_v_delta = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_x.data) + __pyx_t_7)) ))) - (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_self->_M1.data) + __pyx_t_8)) ))));
 
-            /* "westpa/kinetics/_kinetics.pyx":767
+            /* "westpa/kinetics/_kinetics.pyx":770
  *                     self._n[i] += 1
  *                     delta = x[i] - self._M1[i]
  *                     delta_n = delta / self._n[i]             # <<<<<<<<<<<<<<
  *                     term1 = delta * delta_n * n1
  *                     self._M1[i] += delta_n
  */
-            if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 767; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+            if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 770; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
             __pyx_t_9 = __pyx_v_i;
             __pyx_v_delta_n = (__pyx_v_delta / ((double)(*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_self->_n.data) + __pyx_t_9)) )))));
 
-            /* "westpa/kinetics/_kinetics.pyx":768
+            /* "westpa/kinetics/_kinetics.pyx":771
  *                     delta = x[i] - self._M1[i]
  *                     delta_n = delta / self._n[i]
  *                     term1 = delta * delta_n * n1             # <<<<<<<<<<<<<<
@@ -11477,29 +11509,29 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
  */
             __pyx_v_term1 = ((__pyx_v_delta * __pyx_v_delta_n) * __pyx_v_n1);
 
-            /* "westpa/kinetics/_kinetics.pyx":769
+            /* "westpa/kinetics/_kinetics.pyx":772
  *                     delta_n = delta / self._n[i]
  *                     term1 = delta * delta_n * n1
  *                     self._M1[i] += delta_n             # <<<<<<<<<<<<<<
  *                     self._M2[i] += term1
  * 
  */
-            if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 769; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+            if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 772; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
             __pyx_t_10 = __pyx_v_i;
             *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_self->_M1.data) + __pyx_t_10)) )) += __pyx_v_delta_n;
 
-            /* "westpa/kinetics/_kinetics.pyx":770
+            /* "westpa/kinetics/_kinetics.pyx":773
  *                     term1 = delta * delta_n * n1
  *                     self._M1[i] += delta_n
  *                     self._M2[i] += term1             # <<<<<<<<<<<<<<
  * 
  *     @cython.boundscheck(False)
  */
-            if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 770; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
+            if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 773; __pyx_clineno = __LINE__; goto __pyx_L4_error;}}
             __pyx_t_11 = __pyx_v_i;
             *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_self->_M2.data) + __pyx_t_11)) )) += __pyx_v_term1;
 
-            /* "westpa/kinetics/_kinetics.pyx":763
+            /* "westpa/kinetics/_kinetics.pyx":766
  *         with nogil:
  *             for i in range(self._sz0):
  *                 if not mask[i]:             # <<<<<<<<<<<<<<
@@ -11510,7 +11542,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
         }
       }
 
-      /* "westpa/kinetics/_kinetics.pyx":761
+      /* "westpa/kinetics/_kinetics.pyx":764
  *         assert x.shape[0] == mask.shape[0] == self._sz0
  * 
  *         with nogil:             # <<<<<<<<<<<<<<
@@ -11534,7 +11566,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
       }
   }
 
-  /* "westpa/kinetics/_kinetics.pyx":743
+  /* "westpa/kinetics/_kinetics.pyx":746
  *     @cython.wraparound(False)
  *     @cython.cdivision(True)
  *     def update(self, weight_t[::1] x, bool_t[::1] mask):             # <<<<<<<<<<<<<<
@@ -11556,7 +11588,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2updat
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":775
+/* "westpa/kinetics/_kinetics.pyx":778
  *     @cython.wraparound(False)
  *     @cython.cdivision(True)
  *     def __add__(StreamingStats1D self, StreamingStats1D other):             # <<<<<<<<<<<<<<
@@ -11573,8 +11605,8 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats1D_5__add
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__add__ (wrapper)", 0);
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_self), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D, 1, "self", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 775; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_other), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D, 1, "other", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 775; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_self), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D, 1, "self", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 778; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_other), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D, 1, "other", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 778; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_r = __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4__add__(((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats1D *)__pyx_v_self), ((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats1D *)__pyx_v_other));
 
   /* function exit code */
@@ -11619,27 +11651,27 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4__add
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__add__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":782
+  /* "westpa/kinetics/_kinetics.pyx":785
  *             StreamingStats1D combined
  * 
  *         combined = StreamingStats1D(self._sz0)             # <<<<<<<<<<<<<<
  * 
  *         for i in range(self._sz0):
  */
-  __pyx_t_1 = PyInt_FromSsize_t(__pyx_v_self->_sz0); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 782; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = PyInt_FromSsize_t(__pyx_v_self->_sz0); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 785; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 782; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 785; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D), __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 782; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D), __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 785; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_v_combined = ((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats1D *)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":784
+  /* "westpa/kinetics/_kinetics.pyx":787
  *         combined = StreamingStats1D(self._sz0)
  * 
  *         for i in range(self._sz0):             # <<<<<<<<<<<<<<
@@ -11650,35 +11682,35 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4__add
   for (__pyx_t_4 = 0; __pyx_t_4 < __pyx_t_3; __pyx_t_4+=1) {
     __pyx_v_i = __pyx_t_4;
 
-    /* "westpa/kinetics/_kinetics.pyx":785
+    /* "westpa/kinetics/_kinetics.pyx":788
  * 
  *         for i in range(self._sz0):
  *             combined._n[i] = self._n[i] + other._n[i]             # <<<<<<<<<<<<<<
  *             delta = other._M1[i] - self._M1[i]
  *             delta2 = delta * delta
  */
-    if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 785; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 788; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_5 = __pyx_v_i;
-    if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 785; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 788; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_6 = __pyx_v_i;
-    if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 785; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 788; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_7 = __pyx_v_i;
     *((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_combined->_n.data) + __pyx_t_7)) )) = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_self->_n.data) + __pyx_t_5)) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_other->_n.data) + __pyx_t_6)) ))));
 
-    /* "westpa/kinetics/_kinetics.pyx":786
+    /* "westpa/kinetics/_kinetics.pyx":789
  *         for i in range(self._sz0):
  *             combined._n[i] = self._n[i] + other._n[i]
  *             delta = other._M1[i] - self._M1[i]             # <<<<<<<<<<<<<<
  *             delta2 = delta * delta
  *             combined._M1[i] = (other._n[i]*other._M1[i] + self._n[i]*self._M1[i]) / combined._n[i]
  */
-    if (unlikely(!__pyx_v_other->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 786; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_other->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 789; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_8 = __pyx_v_i;
-    if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 786; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 789; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_9 = __pyx_v_i;
     __pyx_v_delta = ((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_other->_M1.data) + __pyx_t_8)) ))) - (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_self->_M1.data) + __pyx_t_9)) ))));
 
-    /* "westpa/kinetics/_kinetics.pyx":787
+    /* "westpa/kinetics/_kinetics.pyx":790
  *             combined._n[i] = self._n[i] + other._n[i]
  *             delta = other._M1[i] - self._M1[i]
  *             delta2 = delta * delta             # <<<<<<<<<<<<<<
@@ -11687,50 +11719,50 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4__add
  */
     __pyx_v_delta2 = (__pyx_v_delta * __pyx_v_delta);
 
-    /* "westpa/kinetics/_kinetics.pyx":788
+    /* "westpa/kinetics/_kinetics.pyx":791
  *             delta = other._M1[i] - self._M1[i]
  *             delta2 = delta * delta
  *             combined._M1[i] = (other._n[i]*other._M1[i] + self._n[i]*self._M1[i]) / combined._n[i]             # <<<<<<<<<<<<<<
  *             combined._M2[i] = other._M2[i] + self._M2[i] + (delta2 * self._n[i] * other._n[i]) / combined._n[i]
  * 
  */
-    if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 788; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 791; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_10 = __pyx_v_i;
-    if (unlikely(!__pyx_v_other->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 788; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_other->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 791; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_11 = __pyx_v_i;
-    if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 788; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 791; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_12 = __pyx_v_i;
-    if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 788; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 791; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_13 = __pyx_v_i;
-    if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 788; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 791; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_14 = __pyx_v_i;
-    if (unlikely(!__pyx_v_combined->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 788; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_combined->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 791; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_15 = __pyx_v_i;
     *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_combined->_M1.data) + __pyx_t_15)) )) = ((((*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_other->_n.data) + __pyx_t_10)) ))) * (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_other->_M1.data) + __pyx_t_11)) )))) + ((*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_self->_n.data) + __pyx_t_12)) ))) * (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_self->_M1.data) + __pyx_t_13)) ))))) / ((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t)(*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_combined->_n.data) + __pyx_t_14)) )))));
 
-    /* "westpa/kinetics/_kinetics.pyx":789
+    /* "westpa/kinetics/_kinetics.pyx":792
  *             delta2 = delta * delta
  *             combined._M1[i] = (other._n[i]*other._M1[i] + self._n[i]*self._M1[i]) / combined._n[i]
  *             combined._M2[i] = other._M2[i] + self._M2[i] + (delta2 * self._n[i] * other._n[i]) / combined._n[i]             # <<<<<<<<<<<<<<
  * 
  *         return combined
  */
-    if (unlikely(!__pyx_v_other->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 789; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_other->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 792; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_16 = __pyx_v_i;
-    if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 789; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 792; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_17 = __pyx_v_i;
-    if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 789; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 792; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_18 = __pyx_v_i;
-    if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 789; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_other->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 792; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_19 = __pyx_v_i;
-    if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 789; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_combined->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 792; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_20 = __pyx_v_i;
-    if (unlikely(!__pyx_v_combined->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 789; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+    if (unlikely(!__pyx_v_combined->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 792; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
     __pyx_t_21 = __pyx_v_i;
     *((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_combined->_M2.data) + __pyx_t_21)) )) = (((*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_other->_M2.data) + __pyx_t_16)) ))) + (*((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_weight_t *) __pyx_v_self->_M2.data) + __pyx_t_17)) )))) + (((__pyx_v_delta2 * (*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_self->_n.data) + __pyx_t_18)) )))) * (*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_other->_n.data) + __pyx_t_19)) )))) / ((double)(*((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) ( /* dim=0 */ ((char *) (((__pyx_t_6westpa_8kinetics_9_kinetics_uint_t *) __pyx_v_combined->_n.data) + __pyx_t_20)) ))))));
   }
 
-  /* "westpa/kinetics/_kinetics.pyx":791
+  /* "westpa/kinetics/_kinetics.pyx":794
  *             combined._M2[i] = other._M2[i] + self._M2[i] + (delta2 * self._n[i] * other._n[i]) / combined._n[i]
  * 
  *         return combined             # <<<<<<<<<<<<<<
@@ -11742,7 +11774,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4__add
   __pyx_r = ((PyObject *)__pyx_v_combined);
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":775
+  /* "westpa/kinetics/_kinetics.pyx":778
  *     @cython.wraparound(False)
  *     @cython.cdivision(True)
  *     def __add__(StreamingStats1D self, StreamingStats1D other):             # <<<<<<<<<<<<<<
@@ -11763,7 +11795,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4__add
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":794
+/* "westpa/kinetics/_kinetics.pyx":797
  * 
  * 
  *     def __iadd__(StreamingStats1D self, StreamingStats1D other):             # <<<<<<<<<<<<<<
@@ -11780,7 +11812,7 @@ static PyObject *__pyx_pw_6westpa_8kinetics_9_kinetics_16StreamingStats1D_7__iad
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__iadd__ (wrapper)", 0);
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_other), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D, 1, "other", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 794; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_other), __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D, 1, "other", 0))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 797; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_r = __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_6__iadd__(((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats1D *)__pyx_v_self), ((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats1D *)__pyx_v_other));
 
   /* function exit code */
@@ -11803,32 +11835,32 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_6__iad
   __Pyx_RefNannySetupContext("__iadd__", 0);
   __Pyx_INCREF((PyObject *)__pyx_v_self);
 
-  /* "westpa/kinetics/_kinetics.pyx":795
+  /* "westpa/kinetics/_kinetics.pyx":798
  * 
  *     def __iadd__(StreamingStats1D self, StreamingStats1D other):
  *         combined = self + other             # <<<<<<<<<<<<<<
  *         self = combined
  *         return self
  */
-  __pyx_t_1 = PyNumber_Add(((PyObject *)__pyx_v_self), ((PyObject *)__pyx_v_other)); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 795; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = PyNumber_Add(((PyObject *)__pyx_v_self), ((PyObject *)__pyx_v_other)); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 798; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_combined = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":796
+  /* "westpa/kinetics/_kinetics.pyx":799
  *     def __iadd__(StreamingStats1D self, StreamingStats1D other):
  *         combined = self + other
  *         self = combined             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  if (!(likely(((__pyx_v_combined) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_combined, __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D))))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 796; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (!(likely(((__pyx_v_combined) == Py_None) || likely(__Pyx_TypeTest(__pyx_v_combined, __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D))))) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 799; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_t_1 = __pyx_v_combined;
   __Pyx_INCREF(__pyx_t_1);
   __Pyx_DECREF_SET(__pyx_v_self, ((struct __pyx_obj_6westpa_8kinetics_9_kinetics_StreamingStats1D *)__pyx_t_1));
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":797
+  /* "westpa/kinetics/_kinetics.pyx":800
  *         combined = self + other
  *         self = combined
  *         return self             # <<<<<<<<<<<<<<
@@ -11840,7 +11872,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_6__iad
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":794
+  /* "westpa/kinetics/_kinetics.pyx":797
  * 
  * 
  *     def __iadd__(StreamingStats1D self, StreamingStats1D other):             # <<<<<<<<<<<<<<
@@ -11861,7 +11893,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_6__iad
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":801
+/* "westpa/kinetics/_kinetics.pyx":804
  * 
  *     property mean:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -11896,20 +11928,20 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4mean_
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":802
+  /* "westpa/kinetics/_kinetics.pyx":805
  *     property mean:
  *         def __get__(self):
  *             tmp = numpy.asarray(self._M1)             # <<<<<<<<<<<<<<
  *             return numpy.nan_to_num(tmp)
  * 
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 802; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 805; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 802; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 805; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 802; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M1, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 802; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 805; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M1, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 805; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -11922,17 +11954,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4mean_
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 802; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 805; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 802; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 805; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 802; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 805; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -11940,7 +11972,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4mean_
   __pyx_v_tmp = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":803
+  /* "westpa/kinetics/_kinetics.pyx":806
  *         def __get__(self):
  *             tmp = numpy.asarray(self._M1)
  *             return numpy.nan_to_num(tmp)             # <<<<<<<<<<<<<<
@@ -11948,9 +11980,9 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4mean_
  *     property var:
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 803; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 806; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_nan_to_num); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 803; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_nan_to_num); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 806; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_3 = NULL;
@@ -11964,16 +11996,16 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4mean_
     }
   }
   if (!__pyx_t_3) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_tmp); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 803; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_tmp); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 806; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_2 = PyTuple_New(1+1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 803; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_2 = PyTuple_New(1+1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 806; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3); __pyx_t_3 = NULL;
     __Pyx_INCREF(__pyx_v_tmp);
     __Pyx_GIVEREF(__pyx_v_tmp);
     PyTuple_SET_ITEM(__pyx_t_2, 0+1, __pyx_v_tmp);
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 803; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 806; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   }
@@ -11982,7 +12014,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4mean_
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":801
+  /* "westpa/kinetics/_kinetics.pyx":804
  * 
  *     property mean:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -12006,7 +12038,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_4mean_
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":806
+/* "westpa/kinetics/_kinetics.pyx":809
  * 
  *     property var:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -12042,20 +12074,20 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3var__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":807
+  /* "westpa/kinetics/_kinetics.pyx":810
  *     property var:
  *         def __get__(self):
  *             tmp_m = numpy.asarray(self._M2)             # <<<<<<<<<<<<<<
  *             tmp_n = numpy.asarray(self._n)
  *             return numpy.nan_to_num(tmp_m / tmp_n)
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 807; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 810; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 807; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 810; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 807; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M2, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 807; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 810; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M2, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 810; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -12068,17 +12100,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3var__
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 807; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 810; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 807; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 810; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 807; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 810; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -12086,20 +12118,20 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3var__
   __pyx_v_tmp_m = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":808
+  /* "westpa/kinetics/_kinetics.pyx":811
  *         def __get__(self):
  *             tmp_m = numpy.asarray(self._M2)
  *             tmp_n = numpy.asarray(self._n)             # <<<<<<<<<<<<<<
  *             return numpy.nan_to_num(tmp_m / tmp_n)
  * 
  */
-  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 808; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 811; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_asarray); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 808; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_asarray); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 811; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 808; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_3 = __pyx_memoryview_fromslice(__pyx_v_self->_n, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, 0);; if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 808; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 811; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_3 = __pyx_memoryview_fromslice(__pyx_v_self->_n, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, 0);; if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 811; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_t_2 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -12112,17 +12144,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3var__
     }
   }
   if (!__pyx_t_2) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_3); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 808; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_3); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 811; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 808; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 811; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_2); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_2); __pyx_t_2 = NULL;
     __Pyx_GIVEREF(__pyx_t_3);
     PyTuple_SET_ITEM(__pyx_t_4, 0+1, __pyx_t_3);
     __pyx_t_3 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 808; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 811; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
@@ -12130,7 +12162,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3var__
   __pyx_v_tmp_n = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "westpa/kinetics/_kinetics.pyx":809
+  /* "westpa/kinetics/_kinetics.pyx":812
  *             tmp_m = numpy.asarray(self._M2)
  *             tmp_n = numpy.asarray(self._n)
  *             return numpy.nan_to_num(tmp_m / tmp_n)             # <<<<<<<<<<<<<<
@@ -12138,12 +12170,12 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3var__
  *     property n:
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 809; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 812; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_nan_to_num); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 809; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_nan_to_num); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 812; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyNumber_Divide(__pyx_v_tmp_m, __pyx_v_tmp_n); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 809; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_5 = __Pyx_PyNumber_Divide(__pyx_v_tmp_m, __pyx_v_tmp_n); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 812; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_3 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_4))) {
@@ -12156,17 +12188,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3var__
     }
   }
   if (!__pyx_t_3) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 809; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 812; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_2 = PyTuple_New(1+1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 809; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_2 = PyTuple_New(1+1); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 812; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3); __pyx_t_3 = NULL;
     __Pyx_GIVEREF(__pyx_t_5);
     PyTuple_SET_ITEM(__pyx_t_2, 0+1, __pyx_t_5);
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 809; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 812; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   }
@@ -12175,7 +12207,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3var__
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":806
+  /* "westpa/kinetics/_kinetics.pyx":809
  * 
  *     property var:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -12200,7 +12232,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_3var__
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":812
+/* "westpa/kinetics/_kinetics.pyx":815
  * 
  *     property n:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -12234,7 +12266,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_1n___g
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":813
+  /* "westpa/kinetics/_kinetics.pyx":816
  *     property n:
  *         def __get__(self):
  *             return numpy.asarray(self._n)             # <<<<<<<<<<<<<<
@@ -12242,13 +12274,13 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_1n___g
  *         def __set__(self, val):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_n, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_n.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_n, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -12261,17 +12293,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_1n___g
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 813; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -12280,7 +12312,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_1n___g
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":812
+  /* "westpa/kinetics/_kinetics.pyx":815
  * 
  *     property n:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -12303,7 +12335,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_1n___g
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":815
+/* "westpa/kinetics/_kinetics.pyx":818
  *             return numpy.asarray(self._n)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -12334,24 +12366,24 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_1n_2__set__(
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__set__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":816
+  /* "westpa/kinetics/_kinetics.pyx":819
  * 
  *         def __set__(self, val):
  *             self._n = val[:]             # <<<<<<<<<<<<<<
  * 
  *     property M1:
  */
-  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__5, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__5, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 819; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_uint_t(__pyx_t_1);
-  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 819; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_n, 0);
   __pyx_v_self->_n = __pyx_t_2;
   __pyx_t_2.memview = NULL;
   __pyx_t_2.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":815
+  /* "westpa/kinetics/_kinetics.pyx":818
  *             return numpy.asarray(self._n)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -12372,7 +12404,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_1n_2__set__(
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":819
+/* "westpa/kinetics/_kinetics.pyx":822
  * 
  *     property M1:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -12406,7 +12438,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M1___
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":820
+  /* "westpa/kinetics/_kinetics.pyx":823
  *     property M1:
  *         def __get__(self):
  *             return numpy.asarray(self._M1)             # <<<<<<<<<<<<<<
@@ -12414,13 +12446,13 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M1___
  *         def __set__(self, val):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 820; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 820; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 820; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M1, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 820; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_M1.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M1, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -12433,17 +12465,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M1___
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 820; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 820; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 820; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -12452,7 +12484,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M1___
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":819
+  /* "westpa/kinetics/_kinetics.pyx":822
  * 
  *     property M1:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -12475,7 +12507,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M1___
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":822
+/* "westpa/kinetics/_kinetics.pyx":825
  *             return numpy.asarray(self._M1)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -12506,24 +12538,24 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M1_2__set__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__set__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":823
+  /* "westpa/kinetics/_kinetics.pyx":826
  * 
  *         def __set__(self, val):
  *             self._M1 = val[:]             # <<<<<<<<<<<<<<
  * 
  *     property M2:
  */
-  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__6, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__6, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 826; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(__pyx_t_1);
-  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 826; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_M1, 0);
   __pyx_v_self->_M1 = __pyx_t_2;
   __pyx_t_2.memview = NULL;
   __pyx_t_2.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":822
+  /* "westpa/kinetics/_kinetics.pyx":825
  *             return numpy.asarray(self._M1)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -12544,7 +12576,7 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M1_2__set__
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":826
+/* "westpa/kinetics/_kinetics.pyx":829
  * 
  *     property M2:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -12578,7 +12610,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M2___
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__get__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":827
+  /* "westpa/kinetics/_kinetics.pyx":830
  *     property M2:
  *         def __get__(self):
  *             return numpy.asarray(self._M2)             # <<<<<<<<<<<<<<
@@ -12586,13 +12618,13 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M2___
  *         def __set__(self, val):
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_asarray); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
-  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M2, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_v_self->_M2.memview)) {PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");{__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
+  __pyx_t_2 = __pyx_memoryview_fromslice(__pyx_v_self->_M2, 1, (PyObject *(*)(char *)) __pyx_memview_get_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, (int (*)(char *, PyObject *)) __pyx_memview_set_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t, 0);; if (unlikely(!__pyx_t_2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_4 = NULL;
   if (CYTHON_COMPILING_IN_CPYTHON && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -12605,17 +12637,17 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M2___
     }
   }
   if (!__pyx_t_4) {
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_GOTREF(__pyx_t_1);
   } else {
-    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4); __pyx_t_4 = NULL;
     __Pyx_GIVEREF(__pyx_t_2);
     PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_2);
     __pyx_t_2 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 827; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_5, NULL); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   }
@@ -12624,7 +12656,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M2___
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "westpa/kinetics/_kinetics.pyx":826
+  /* "westpa/kinetics/_kinetics.pyx":829
  * 
  *     property M2:
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -12647,7 +12679,7 @@ static PyObject *__pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M2___
   return __pyx_r;
 }
 
-/* "westpa/kinetics/_kinetics.pyx":829
+/* "westpa/kinetics/_kinetics.pyx":832
  *             return numpy.asarray(self._M2)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -12677,22 +12709,22 @@ static int __pyx_pf_6westpa_8kinetics_9_kinetics_16StreamingStats1D_2M2_2__set__
   int __pyx_clineno = 0;
   __Pyx_RefNannySetupContext("__set__", 0);
 
-  /* "westpa/kinetics/_kinetics.pyx":830
+  /* "westpa/kinetics/_kinetics.pyx":833
  * 
  *         def __set__(self, val):
  *             self._M2 = val[:]             # <<<<<<<<<<<<<<
  */
-  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__7, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_val, 0, 0, NULL, NULL, &__pyx_slice__7, 0, 0, 1); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 833; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_t_2 = __Pyx_PyObject_to_MemoryviewSlice_dc_nn___pyx_t_6westpa_8kinetics_9_kinetics_weight_t(__pyx_t_1);
-  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (unlikely(!__pyx_t_2.memview)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 833; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __PYX_XDEC_MEMVIEW(&__pyx_v_self->_M2, 0);
   __pyx_v_self->_M2 = __pyx_t_2;
   __pyx_t_2.memview = NULL;
   __pyx_t_2.data = NULL;
 
-  /* "westpa/kinetics/_kinetics.pyx":829
+  /* "westpa/kinetics/_kinetics.pyx":832
  *             return numpy.asarray(self._M2)
  * 
  *         def __set__(self, val):             # <<<<<<<<<<<<<<
@@ -27672,67 +27704,67 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple_);
   __Pyx_GIVEREF(__pyx_tuple_);
 
-  /* "westpa/kinetics/_kinetics.pyx":703
+  /* "westpa/kinetics/_kinetics.pyx":706
  * 
  *         def __set__(self, val):
  *             self._n = val[:]             # <<<<<<<<<<<<<<
  * 
  *     property M1:
  */
-  __pyx_slice__2 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 703; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_slice__2 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__2)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 706; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_slice__2);
   __Pyx_GIVEREF(__pyx_slice__2);
 
-  /* "westpa/kinetics/_kinetics.pyx":710
+  /* "westpa/kinetics/_kinetics.pyx":713
  * 
  *         def __set__(self, val):
  *             self._M1 = val[:]             # <<<<<<<<<<<<<<
  * 
  *     property M2:
  */
-  __pyx_slice__3 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 710; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_slice__3 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 713; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_slice__3);
   __Pyx_GIVEREF(__pyx_slice__3);
 
-  /* "westpa/kinetics/_kinetics.pyx":717
+  /* "westpa/kinetics/_kinetics.pyx":720
  * 
  *         def __set__(self, val):
  *             self._M2 = val[:]             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __pyx_slice__4 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 717; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_slice__4 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 720; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_slice__4);
   __Pyx_GIVEREF(__pyx_slice__4);
 
-  /* "westpa/kinetics/_kinetics.pyx":816
+  /* "westpa/kinetics/_kinetics.pyx":819
  * 
  *         def __set__(self, val):
  *             self._n = val[:]             # <<<<<<<<<<<<<<
  * 
  *     property M1:
  */
-  __pyx_slice__5 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 816; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_slice__5 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 819; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_slice__5);
   __Pyx_GIVEREF(__pyx_slice__5);
 
-  /* "westpa/kinetics/_kinetics.pyx":823
+  /* "westpa/kinetics/_kinetics.pyx":826
  * 
  *         def __set__(self, val):
  *             self._M1 = val[:]             # <<<<<<<<<<<<<<
  * 
  *     property M2:
  */
-  __pyx_slice__6 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 823; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_slice__6 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 826; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_slice__6);
   __Pyx_GIVEREF(__pyx_slice__6);
 
-  /* "westpa/kinetics/_kinetics.pyx":830
+  /* "westpa/kinetics/_kinetics.pyx":833
  * 
  *         def __set__(self, val):
  *             self._M2 = val[:]             # <<<<<<<<<<<<<<
  */
-  __pyx_slice__7 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 830; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_slice__7 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 833; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_slice__7);
   __Pyx_GIVEREF(__pyx_slice__7);
 
@@ -28113,13 +28145,13 @@ PyMODINIT_FUNC PyInit__kinetics(void)
   /*--- Variable export code ---*/
   /*--- Function export code ---*/
   /*--- Type init code ---*/
-  if (PyType_Ready(&__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats2D) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 602; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyType_Ready(&__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats2D) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 605; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats2D.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "StreamingStats2D", (PyObject *)&__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats2D) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 602; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyObject_SetAttrString(__pyx_m, "StreamingStats2D", (PyObject *)&__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats2D) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 605; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats2D = &__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats2D;
-  if (PyType_Ready(&__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats1D) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 720; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyType_Ready(&__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats1D) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 723; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats1D.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "StreamingStats1D", (PyObject *)&__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats1D) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 720; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyObject_SetAttrString(__pyx_m, "StreamingStats1D", (PyObject *)&__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats1D) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 723; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_ptype_6westpa_8kinetics_9_kinetics_StreamingStats1D = &__pyx_type_6westpa_8kinetics_9_kinetics_StreamingStats1D;
   if (PyType_Ready(&__pyx_type___pyx_array) < 0) {__pyx_filename = __pyx_f[2]; __pyx_lineno = 101; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __pyx_type___pyx_array.tp_print = 0;

--- a/lib/west_tools/westpa/kinetics/_kinetics.pyx
+++ b/lib/west_tools/westpa/kinetics/_kinetics.pyx
@@ -405,13 +405,15 @@ cpdef sequence_macro_flux_to_rate(weight_t[:] dataset, weight_t[:,:] pops, Py_ss
     with nogil:
         for iiter in xrange(dataset.shape[0]):
             if iiter == 0:
-                if pairwise:
+                # We need to catch if we haven't entered the istate or jstate yet.
+                # Otherwise, we introduce a NaN into the calculation that we cannot recover from.
+                if pairwise and (pops[0,istate] + pops[0,jstate]) != 0.0:
                     _psum[0] = pops[0, istate] / (pops[0,istate] + pops[0,jstate])
                 else:
                     _psum[0] = pops[0, istate]
                 _fluxsum[0] = dataset[0]
             else:
-                if pairwise:
+                if pairwise and (pops[iiter,istate] + pops[iiter,jstate]) != 0.0:
                     _psum[iiter] = (pops[iiter, istate] / (pops[iiter,istate] + pops[iiter,jstate])) + _psum[iiter-1]
                 else:
                     _psum[iiter] = pops[iiter,istate] + _psum[iiter-1]


### PR DESCRIPTION
Occasionally, the rate constant calculation from w_direct would return 0, even when there was probability in the istate AND a flux into the jstate.

This was caused by the rate normalization step for pairwise rate calculations (which is done by default); if no walkers had entered either the i or jstate, the sum of their probability was 0, which the istate probability was divided by, thus becoming 0/0, or NaN.  Once NaN exists in the dataset, any number interacting with NaN also becomes NaN; in that event, the code would return a 0 for the rate.

Now, if no probability has or does exist in the i or jstate, we don't do the pairwise rate normalization (and instead simply add 0 to the probability running average).  This problem primarily affected simulations where the bstates were different from the state definitions used in post processing, or with N>2 states where at least two were unpopulated for a period of time.