### PR TITLE
Removed pkill from initialization scripts, at request of @ajoshpratt

### DIFF
--- a/lib/examples/nacl_amb/init.sh
+++ b/lib/examples/nacl_amb/init.sh
@@ -11,11 +11,6 @@
 
 source env.sh
 
-# Make sure that WESTPA is not already running.  Running two instances of 
-# WESTPA on a single node/machine can cause problems.
-# The following line will kill any WESTPA process that is currently running.
-pkill -9 -f w_run
-
 # Make sure that seg_logs (log files for each westpa segment), traj_segs (data
 # from each trajectory segment), and istates (initial states for starting new
 # trajectories) directories exist and are empty. 

--- a/lib/examples/nacl_amb_gb/init.sh
+++ b/lib/examples/nacl_amb_gb/init.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 source env.sh
 ps aux | grep w_run | grep -v grep
-pkill -9 -f w_run
 
 SFX=.d$$
 mv      traj_segs{,$SFX}

--- a/lib/examples/nacl_gmx/init.sh
+++ b/lib/examples/nacl_gmx/init.sh
@@ -11,11 +11,6 @@
 
 source env.sh
 
-# Make sure that WESTPA is not already running.  Running two instances of 
-# WESTPA on a single node/machine can cause problems.
-# The following line will kill any WESTPA process that is currently running.
-pkill -9 -f w_run
-
 # Make sure that seg_logs (log files for each westpa segment), traj_segs (data
 # from each trajectory segment), and istates (initial states for starting new
 # trajectories) directories exist and are empty. 

--- a/lib/examples/nacl_gmx_5.0.4/init.sh
+++ b/lib/examples/nacl_gmx_5.0.4/init.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 source env.sh
 ps aux | grep w_run | grep -v grep
-pkill -9 -f w_run
 
 SFX=.d$$
 mv      traj_segs{,$SFX}

--- a/lib/examples/nacl_gmx_gb/init.sh
+++ b/lib/examples/nacl_gmx_gb/init.sh
@@ -11,11 +11,6 @@
 
 source env.sh
 
-# Make sure that WESTPA is not already running.  Running two instances of 
-# WESTPA on a single node/machine can cause problems.
-# This code will kill any WESTPA process that is currently running.
-pkill -9 -f w_run
-
 # Make sure that seg_logs (log files for each westpa segment), traj_segs (data
 # from each trajectory segment), and istates (initial states for starting new
 # trajectories) directories exist and are empty. 

--- a/lib/examples/nacl_namd/init.sh
+++ b/lib/examples/nacl_namd/init.sh
@@ -11,11 +11,6 @@
 
 source env.sh
 
-# Make sure that WESTPA is not already running.  Running two instances of 
-# WESTPA on a single node/machine can cause problems.
-# The following line will kill any WESTPA process that is currently running.
-pkill -9 -f w_run
-
 # Make sure that seg_logs (log files for each westpa segment), traj_segs (data
 # from each trajectory segment), and istates (initial states for starting new
 # trajectories) directories exist and are empty. 

--- a/lib/examples/nacl_namd_gb/init.sh
+++ b/lib/examples/nacl_namd_gb/init.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 source env.sh
 ps aux | grep w_run | grep -v grep
-pkill -9 -f w_run
 
 SFX=.d$$
 mv      traj_segs{,$SFX}

--- a/lib/examples/nacl_openmm/init.sh
+++ b/lib/examples/nacl_openmm/init.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 source env.sh
 ps aux | grep w_run | grep -v grep
-pkill -9 -f w_run
 
 SFX=.d$$
 mv seg_logs{,$SFX}

--- a/lib/examples/odld_exe/init.sh
+++ b/lib/examples/odld_exe/init.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 source env.sh
 ps aux | grep w_run | grep -v grep
-pkill -9 -f w_run
 
 SFX=.d$$
 mv      traj_segs{,$SFX}

--- a/lib/examples/wca-dimer_openmm/we_custom/init.sh
+++ b/lib/examples/wca-dimer_openmm/we_custom/init.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 source env.sh
 ps aux | grep w_run | grep -v grep
-pkill -9 -f w_run
 
 SFX=.d$$
 mv seg_logs{,$SFX}

--- a/lib/examples/wca-dimer_openmm/we_exec/init.sh
+++ b/lib/examples/wca-dimer_openmm/we_exec/init.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 source env.sh
 ps aux | grep w_run | grep -v grep
-pkill -9 -f w_run
 
 SFX=.d$$
 mv seg_logs{,$SFX}


### PR DESCRIPTION
Adam requested that I remove the pkill commands from the init.sh scripts.  Testing with the odld_exe example suggests this is safe. 