### PR TITLE
Allow w_assign to pull the latest bin mapper and allow to pull bin mapper from a particular iteration

### DIFF
--- a/lib/west_tools/w_assign.py
+++ b/lib/west_tools/w_assign.py
@@ -275,8 +275,12 @@ Command-line options
     def process_args(self, args):
         self.progress.process_args(args)
         self.data_reader.process_args(args)
+        # Necessary to open the file to get the current iteration
+        # if we want to use the mapper in the file
         self.data_reader.open(mode='r+')
-        self.n_iter = getattr(args,'bins_from_h5file',None) or self.data_reader.current_iteration
+        self.n_iter = self.data_reader.current_iteration
+        # If we decide to use this option for iteration selection: 
+        # getattr(args,'bins_from_h5file',None) or self.data_reader.current_iteration
 
         with self.data_reader:
             self.dssynth.h5filename = self.data_reader.we_h5filename

--- a/lib/west_tools/w_assign.py
+++ b/lib/west_tools/w_assign.py
@@ -242,7 +242,7 @@ Command-line options
     
     def add_args(self, parser):
         self.data_reader.add_args(parser)
-        self.binning.add_args(parser) #, suppress=['--bins-from-h5file'])
+        self.binning.add_args(parser) 
         self.dssynth.add_args(parser)
         
         sgroup = parser.add_argument_group('macrostate definitions').add_mutually_exclusive_group()

--- a/lib/west_tools/w_assign.py
+++ b/lib/west_tools/w_assign.py
@@ -242,7 +242,7 @@ Command-line options
     
     def add_args(self, parser):
         self.data_reader.add_args(parser)
-        self.binning.add_args(parser, suppress=['--bins-from-h5file'])
+        self.binning.add_args(parser) #, suppress=['--bins-from-h5file'])
         self.dssynth.add_args(parser)
         
         sgroup = parser.add_argument_group('macrostate definitions').add_mutually_exclusive_group()
@@ -275,11 +275,14 @@ Command-line options
     def process_args(self, args):
         self.progress.process_args(args)
         self.data_reader.process_args(args)
+        self.data_reader.open(mode='r+')
+        self.n_iter = getattr(args,'bins_from_h5file',None) or self.data_reader.current_iteration
 
         with self.data_reader:
             self.dssynth.h5filename = self.data_reader.we_h5filename
             self.dssynth.process_args(args)
             if args.config_from_file == False:
+                self.binning.set_we_h5file_info(self.n_iter,self.data_reader)
                 self.binning.process_args(args)
 
         self.output_filename = args.output

--- a/lib/west_tools/westtools/binning.py
+++ b/lib/west_tools/westtools/binning.py
@@ -310,7 +310,7 @@ class BinMappingComponent(WESTToolComponent):
                                 [[boundset1], [boundset2], ... ]}}; only rectilinear bin bounds are supported.''')
             
         if '--bins-from-h5file' not in suppressed_options:
-            egroup.add_argument('--bins-from-h5file', action='store_true',
+            egroup.add_argument('--bins-from-h5file', dest='bins_from_h5file', type=int, #action='store_true',
                                 help='''Load bin specification from the data file being examined
                                 (default where stored bin definitions available).''')
             

--- a/lib/west_tools/westtools/binning.py
+++ b/lib/west_tools/westtools/binning.py
@@ -310,7 +310,7 @@ class BinMappingComponent(WESTToolComponent):
                                 [[boundset1], [boundset2], ... ]}}; only rectilinear bin bounds are supported.''')
             
         if '--bins-from-h5file' not in suppressed_options:
-            egroup.add_argument('--bins-from-h5file', dest='bins_from_h5file', type=int, #action='store_true',
+            egroup.add_argument('--bins-from-h5file', action='store_true',
                                 help='''Load bin specification from the data file being examined
                                 (default where stored bin definitions available).''')
             


### PR DESCRIPTION
This small change brings w_assign on par with w_bins in pulling the latest bin mapper from the master h5 file. Currently w_assign will pull the first bin mapper created/bin mapper from the system.py from what I can tell from my tests. I additionally propose to enable --bins-from-h5file argument for w_assign and make it an integer argument instead of a store_true argument, allowing the user to select the iteration to pull the bin mapper from. **Sneaky edit:** Another option is to just add a secondary argument to select the particular iteration of course, which I'm starting to lean towards after playing with this. 

Pulling the latest mapper is necessary for supporting adaptive binning schemes and it's nice to allow the user to select a particular iteration to pull the mapper from as well. I'll test these changes to ensure it doesn't break anything but these should be decoupled from anything else from what I can tell. 

**Note:** I will clean up the comments, I just wanted to bring this up and see if anybody notices any issues first. 
**Further notes:** I will be trying to merge some form of this within the week since I think it's important to have this for the upcoming WESTPA workshop. At least pulling the latest bin mapper from the h5 file is key since otherwise it becomes difficult to show people how to use the bin mapper saved in the h5 file in w_assign (it's possible using bins-from-function but I'd rather avoid that entirely for the workshop).