### PR TITLE
Minor bugfix: Changed check for seg_id defined

### DIFF
--- a/lib/west_tools/westtools/wipi.py
+++ b/lib/west_tools/westtools/wipi.py
@@ -325,11 +325,8 @@ class __get_data_for_iteration__(object):
         self.parent = parent
         current = {}
         current['iteration'] = value
-        try: 
-            if seg_ids == None:
-                seg_ids = range(0, iter_group['seg_index']['weight'].shape[0])
-        except:
-            pass
+        if seg_ids is None:
+            seg_ids = range(0, iter_group['seg_index']['weight'].shape[0])
         # Just make these easier to access.
         current['weights'] = iter_group['seg_index']['weight'][seg_ids]
         current['pcoord'] = iter_group['pcoord'][...][seg_ids, :, :]


### PR DESCRIPTION
The previous behavior checked `seg_ids == None`, which raises an error if `seg_ids` is defined. This was addressed by wrapping the whole thing in a try/except block.

However, the intended behavior can be produced by just checking with `is` instead of `==`, which correctly evaluates to `False` if `seg_ids` is defined instead of erroring out. Although the contents of the try block are fairly simple, doing the evaluation this way without the unnecessary try block prevents other potential errors in the block from being incorrectly ignored.