### PR TITLE
Updated miniconda_install_westpa.sh to use release 2020.02.

### DIFF
--- a/miniconda_install_westpa.sh
+++ b/miniconda_install_westpa.sh
@@ -67,7 +67,7 @@ export PATH="$PREFIX/bin:$PATH"
 ### +------------------------------------------------+ ########################################
 
 # Specify conda environment name
-conda_env=westpa-2020.01
+conda_env=westpa-2020.02
 
 # Update conda first
 conda update -n base -c defaults conda


### PR DESCRIPTION
After this is merged, then all installation methods will use release 2020.02.