### PR TITLE
Fix: clear westpa.rc state on teardown

### DIFF
--- a/tests/test_sim_manager.py
+++ b/tests/test_sim_manager.py
@@ -23,6 +23,7 @@ class TestSimManager:
 
     def teardown(self):
         westpa.rc._sim_manager = None
+        westpa.rc._system = None
         del os.environ['WEST_SIM_ROOT']
 
     def test_sim_manager(self):


### PR DESCRIPTION
Previously, the _sim_manager attribute of westpa.rc was cleared, but the _system was not. This resulted in state change persisting after the test completed, which adversely affected subsequent tests.