### PR TITLE
Bugfix for states when auxref is None

### DIFF
--- a/src/westpa/core/states.py
+++ b/src/westpa/core/states.py
@@ -41,7 +41,7 @@ class BasisState:
         max_label_len = max(8, max(len(state.label or '') for state in states))
         max_auxref_len = max(8, max(len(state.auxref or '') for state in states))
         fmt = (
-            '{state.label:<{max_label_len}s}    {state.probability:12.7g}    {state.auxref:<{max_auxref_len}s}'
+            '{state.label:<{max_label_len}s}    {state.probability:12.7g}    {auxref_str:<{max_auxref_len}s}'
             '    # state_id={state_id_str:s}    pcoord={pcoord_str}\n'
         )
         fileobj.write(
@@ -52,10 +52,12 @@ class BasisState:
         for state in states:
             state_id_str = str(state.state_id) if state.state_id is not None else 'None'
             pcoord_str = str(list(state.pcoord))
+            auxref_str = str(state.auxref)
             fileobj.write(
                 fmt.format(
                     state=state,
                     pcoord_str=pcoord_str,
+                    auxref_str=auxref_str,
                     state_id_str=state_id_str,
                     max_label_len=max_label_len,
                     max_auxref_len=max_auxref_len,


### PR DESCRIPTION
If no auxref is provided for a state (it's an optional parameter) then `state.auxref` will be set to `None`. To play nicely with the string formatting, this `None` object must be cast to a string `"None"`