### PR TITLE
Added function to rc to clear state

### DIFF
--- a/src/westpa/core/_rc.py
+++ b/src/westpa/core/_rc.py
@@ -512,6 +512,14 @@ class WESTRC:
     def get_work_manager(self):
         return self.work_manager
 
+    def clear_state(self):
+
+        self._sim_manager = None
+        self._system = None
+        self._data_manager = None
+        self._we_driver = None
+        self._propagator = None
+
     propagator = property(get_propagator)
     we_driver = property(get_we_driver)
     system = property(get_system_driver)


### PR DESCRIPTION
Added a function `clear_state` to westpa.rc that wipes out state. This is useful for ensuring no "leftover state" persists (such as between tests)