### PR TITLE
fixed div and rdiv in wipi.py

### DIFF
--- a/src/westpa/tools/wipi.py
+++ b/src/westpa/tools/wipi.py
@@ -78,13 +78,13 @@ class WIPIDataset:
     def __rmul__(self, other):
         return other * self.__dict__['raw']
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         return self.__dict__['raw'] / other
 
     def __floordiv__(self, other):
         return self.__dict__['raw'] // other
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         return other / self.__dict__['raw']
 
     def __mod__(self, other):


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#157 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
As per @synapticarbors, ``__div__`` and ``__rdiv__`` are replaced by ``__truediv__`` and ``__rtruediv__`` in ``wipi.py``. Those older functions no longer exist in Python 3 and don't work anyway.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] fix truediv and div in wipi.py

**Major files changed.**  
- [x] src/westpa/tools/wipi.py


**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

