### PR TITLE
Checking binhash as bytes to eliminate errors (Fixes for WESTPA 1.0)

### DIFF
--- a/lib/west_tools/westpa/h5io.py
+++ b/lib/west_tools/westpa/h5io.py
@@ -71,6 +71,19 @@ def calc_chunksize(shape, dtype, max_chunksize=262144):
     chunk_shape = tuple(chunk_shape)
     return chunk_shape
 
+
+def tostr(b):
+    '''Covert a nostandard string object ``b`` to str with the handling of the
+    case whhere ``b`` is bytes.'''
+
+    if b is None:
+        return None
+    elif isinstance(b, bytes):
+        return b.decode('utf-8')
+    else:
+        return str(b)
+
+
 #
 # Group and dataset manipulation functions
 #

--- a/lib/west_tools/westtools/binning.py
+++ b/lib/west_tools/westtools/binning.py
@@ -71,7 +71,7 @@ def mapper_from_hdf5(topol_group, hashval):
         for i in range(len(chunk)):
             if chunk[i]['hash'] == hashval:
                 pkldat = bytes(pickle_ds[istart+i,0:chunk[i]['pickle_len']].data)
-                mapper = pickle.loads(pkldat) 
+                mapper = pickle.loads(pkldat, encoding='latin1') 
                 log.debug('loaded {!r} from {!r}'.format(mapper, topol_group))
                 log.debug('hash value {!r}'.format(hashval))
                 return mapper, pkldat, hashval

--- a/lib/west_tools/westtools/binning.py
+++ b/lib/west_tools/westtools/binning.py
@@ -69,9 +69,9 @@ def mapper_from_hdf5(topol_group, hashval):
     for istart in range(0,n_entries,chunksize):
         chunk = index_ds[istart:min(istart+chunksize,n_entries)]
         for i in range(len(chunk)):
-            if chunk[i]['hash'] == hashval:
+            if chunk[i]['hash'] == bytes(hashval, 'utf-8'):
                 pkldat = bytes(pickle_ds[istart+i,0:chunk[i]['pickle_len']].data)
-                mapper = pickle.loads(pkldat, encoding='latin1') 
+                mapper = pickle.loads(pkldat) 
                 log.debug('loaded {!r} from {!r}'.format(mapper, topol_group))
                 log.debug('hash value {!r}'.format(hashval))
                 return mapper, pkldat, hashval

--- a/lib/west_tools/westtools/kinetics_tool.py
+++ b/lib/west_tools/westtools/kinetics_tool.py
@@ -217,7 +217,7 @@ class AverageCommands(WESTKineticsBase):
 
         # This is appropriate for bootstrapped quantities, I think.
         all_items = numpy.arange(1,len(start_pts)+1)
-        bootstrap_length = 0.5*(len(start_pts)*(len(start_pts)+1)) - numpy.delete(all_items, numpy.arange(1, len(start_pts)+1, step_iter))
+        bootstrap_length = 0.5*(len(start_pts)*(len(start_pts)+1)) - numpy.delete(all_items, numpy.arange(1, len(start_pts), step_iter))
         if True:
             pi.new_operation('Calculating {}'.format(name), bootstrap_length[0])
 

--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -1235,7 +1235,7 @@ class WESTDataManager:
                 for i in range(len(chunk)):
                     if chunk[i]['hash'] == bytes(hashval, 'utf-8'):
                         pkldat = bytes(pkl[istart+i, 0:chunk[i]['pickle_len']].data)
-                        mapper = pickle.loads(pkldat)
+                        mapper = pickle.loads(pkldat, encoding='latin1')
                         log.debug('loaded {!r} from {!r}'.format(mapper, binning_group))
                         log.debug('hash value {!r}'.format(hashval))
                         return mapper

--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -1176,7 +1176,7 @@ class WESTDataManager:
         bin data tables if found, or raises KeyError if not.'''
 
         try:
-            hashval = hashval.hexdigest()
+            bytes(hashval, 'utf-8')  = hashval.hexdigest()
         except AttributeError:
             pass
         
@@ -1202,13 +1202,13 @@ class WESTDataManager:
             
             raise KeyError('hash {} not found'.format(hashval))
 
-    def get_bin_mapper(self,  hashval):
+    def get_bin_mapper(self, hashval):
         '''Look up the given hash value in the binning table, unpickling and returning the corresponding
         bin mapper if available, or raising KeyError if not.'''
 
         # Convert to a hex digest if we need to
         try:
-            hashval = hashval.hexdigest()
+            bytes(hashval,'utf-8') = hashval.hexdigest()
         except AttributeError:
             pass
 
@@ -1231,7 +1231,7 @@ class WESTDataManager:
             for istart in range(0, n_entries, chunksize):
                 chunk = index[istart:min(istart+chunksize, n_entries)]
                 for i in range(len(chunk)):
-                    if chunk[i]['hash'] == hashval:
+                    if chunk[i]['hash'] == bytes(hashval, 'utf-8'):
                         pkldat = bytes(pkl[istart+i, 0:chunk[i]['pickle_len']].data)
                         mapper = pickle.loads(pkldat)
                         log.debug('loaded {!r} from {!r}'.format(mapper, binning_group))

--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -1176,7 +1176,8 @@ class WESTDataManager:
         bin data tables if found, or raises KeyError if not.'''
 
         try:
-            hashval = hashval.hexdigest()
+            bhashval = bytes(hashval, 'utf-8')
+            bhashval  = hashval.hexdigest()
         except AttributeError:
             pass
         
@@ -1208,7 +1209,8 @@ class WESTDataManager:
 
         # Convert to a hex digest if we need to
         try:
-            hashval = hashval.hexdigest()
+            bhashval = bytes(hashval,'utf-8') 
+            bhashval = hashval.hexdigest()
         except AttributeError:
             pass
 

--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -513,7 +513,7 @@ class WESTDataManager:
                 return []
             bstate_pcoords = ibstate_group['bstate_pcoord'][...]
             bstates = [BasisState(state_id=i, label=row['label'], probability=row['probability'],
-                                  auxref = str(row['auxref']) or None, pcoord=pcoord.copy())
+                                  auxref = h5io.tostr(row['auxref']) or None, pcoord=pcoord.copy())
                        for (i, (row, pcoord))  in enumerate(zip(bstate_index, bstate_pcoords))]
             return bstates
             

--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -1235,7 +1235,7 @@ class WESTDataManager:
                 for i in range(len(chunk)):
                     if chunk[i]['hash'] == bytes(hashval, 'utf-8'):
                         pkldat = bytes(pkl[istart+i, 0:chunk[i]['pickle_len']].data)
-                        mapper = pickle.loads(pkldat, encoding='latin1')
+                        mapper = pickle.loads(pkldat)
                         log.debug('loaded {!r} from {!r}'.format(mapper, binning_group))
                         log.debug('hash value {!r}'.format(hashval))
                         return mapper

--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -1176,7 +1176,8 @@ class WESTDataManager:
         bin data tables if found, or raises KeyError if not.'''
 
         try:
-            bytes(hashval, 'utf-8')  = hashval.hexdigest()
+            bhashval = bytes(hashval, 'utf-8')
+            bhashval  = hashval.hexdigest()
         except AttributeError:
             pass
         
@@ -1208,7 +1209,8 @@ class WESTDataManager:
 
         # Convert to a hex digest if we need to
         try:
-            bytes(hashval,'utf-8') = hashval.hexdigest()
+            bhashval = bytes(hashval,'utf-8') 
+            bhashval = hashval.hexdigest()
         except AttributeError:
             pass
 

--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -1176,8 +1176,7 @@ class WESTDataManager:
         bin data tables if found, or raises KeyError if not.'''
 
         try:
-            bhashval = bytes(hashval, 'utf-8')
-            bhashval  = hashval.hexdigest()
+            hashval  = hashval.hexdigest()
         except AttributeError:
             pass
         
@@ -1198,7 +1197,7 @@ class WESTDataManager:
             for istart in range(0,n_entries,chunksize):
                 chunk = index[istart:min(istart+chunksize,n_entries)]
                 for i in range(len(chunk)):
-                    if chunk[i]['hash'] == hashval:
+                    if chunk[i]['hash'] == bytes(hashval, 'utf-8'):
                         return istart+i
             
             raise KeyError('hash {} not found'.format(hashval))
@@ -1209,8 +1208,7 @@ class WESTDataManager:
 
         # Convert to a hex digest if we need to
         try:
-            bhashval = bytes(hashval,'utf-8') 
-            bhashval = hashval.hexdigest()
+            hashval = hexdigest()
         except AttributeError:
             pass
 

--- a/src/west/data_manager.py
+++ b/src/west/data_manager.py
@@ -1176,8 +1176,7 @@ class WESTDataManager:
         bin data tables if found, or raises KeyError if not.'''
 
         try:
-            bhashval = bytes(hashval, 'utf-8')
-            bhashval  = hashval.hexdigest()
+            hashval = hashval.hexdigest()
         except AttributeError:
             pass
         
@@ -1209,8 +1208,7 @@ class WESTDataManager:
 
         # Convert to a hex digest if we need to
         try:
-            bhashval = bytes(hashval,'utf-8') 
-            bhashval = hashval.hexdigest()
+            hashval = hashval.hexdigest()
         except AttributeError:
             pass
 


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#142 #146 #147 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Made fixes for binhash error where individual hashes in each iteration west['iterations']['iter_00000002'].attrs['binhash'] are saved as strings, while the ones in west['bin_topologies']['index'] are saved as byte strings. Whenever the hash is checked, it would check the byte string version of it, instead of the string version. The saving mechanism is unchanged, so it would continue to save string-type hashes per iteration. Should probably fix #142 and definitely fix #146. 

Also ported in #147 fixes as they're also related to byte strings.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fix w_assign error where has is not found (#146)

**Major files changed.**  
- [x] lib/west_tools/westtools/binning.py 
- [x] src/west/data_manager.py 
- [x] lib/west_tools/westpa/h5io.py 
- [x] lib/west_tools/westtools/kinetics_tool.py 

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  
NOTE: The resulting labels in the assign.h5 generated (state_labels, bin_labels) are still saved as byte strings.
