### PR TITLE
Removed revcmap in oldtools/aframe/plotting.py

### DIFF
--- a/src/westpa/oldtools/aframe/plotting.py
+++ b/src/westpa/oldtools/aframe/plotting.py
@@ -64,7 +64,7 @@ else:
     }
 
     cm_pdr = matplotlib.colors.LinearSegmentedColormap('pdr', _pdr_data, 2048)
-    cm_pdr_r = matplotlib.colors.LinearSegmentedColormap('pdr_r', matplotlib.cm.revcmap(_pdr_data), 2048)
+    cm_pdr_r = cm_pdr.reversed()
 
     matplotlib.cm.register_cmap('pdr', cm_pdr)
     matplotlib.cm.register_cmap('pdr_r', cm_pdr_r)


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
New

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
A [recent update in matplotlib (3.4.0)](https://matplotlib.org/stable/api/api_changes.html?highlight=revcmap) removed the `matplotlib.cm.revcmap` method. This leads to the [CI dying when running w_succ test](https://github.com/westpa/westpa/runs/2353249919?check_suite_focus=true#step:6:25).

The corresponding line is changed to use the [newer method](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.LinearSegmentedColormap.html#matplotlib.colors.LinearSegmentedColormap.reversed) `matplotlib.colors.LinearSegmentedColormap.reversed()` instead.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fix error so CI doesn't fail

**Major files changed.**  
- [x] src/westpa/oldtools/aframe/plotting.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

