### PR TITLE
Binhash error fix (WESTPA 2.0)

### DIFF
--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -1248,7 +1248,7 @@ class WESTDataManager:
             for istart in range(0, n_entries, chunksize):
                 chunk = index[istart : min(istart + chunksize, n_entries)]
                 for i in range(len(chunk)):
-                    if chunk[i]['hash'] == hashval:
+                    if chunk[i]['hash'] == bytes(hashval, 'utf-8'):
                         return istart + i
 
             raise KeyError('hash {} not found'.format(hashval))
@@ -1282,7 +1282,7 @@ class WESTDataManager:
             for istart in range(0, n_entries, chunksize):
                 chunk = index[istart : min(istart + chunksize, n_entries)]
                 for i in range(len(chunk)):
-                    if chunk[i]['hash'] == hashval:
+                    if chunk[i]['hash'] == bytes(hashval, 'utf-8'):
                         pkldat = bytes(pkl[istart + i, 0 : chunk[i]['pickle_len']].data)
                         mapper = pickle.loads(pkldat)
                         log.debug('loaded {!r} from {!r}'.format(mapper, binning_group))

--- a/src/westpa/tools/binning.py
+++ b/src/westpa/tools/binning.py
@@ -77,7 +77,7 @@ def mapper_from_hdf5(topol_group, hashval):
     for istart in range(0, n_entries, chunksize):
         chunk = index_ds[istart : min(istart + chunksize, n_entries)]
         for i in range(len(chunk)):
-            if chunk[i]['hash'] == hashval:
+            if chunk[i]['hash'] == bytes(hashval, 'utf-8'):
                 pkldat = bytes(pickle_ds[istart + i, 0 : chunk[i]['pickle_len']].data)
                 # mapper = pickle.loads(pkldat, encoding='latin1')
                 mapper = pickle.loads(pkldat)


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#142 #146  

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Fixes so WESTPA checks for the the bytes version of the hashval. It should eliminate duplicate bin_mappers and errors when running w_assign

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fixes errors where hashval is saved twice because hash is saved as byte strings and strings in 2 different places
- [x] Fixes errors with binhash when running w_assign

**Major files changed.**  
- [x] /src/westpa/core/data_manager.py
- [x] /src/westpa/tools/binning.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

