### PR TITLE
Bugfix: Removed extra argument

### DIFF
--- a/src/westpa/cli/core/w_states.py
+++ b/src/westpa/cli/core/w_states.py
@@ -144,7 +144,7 @@ def entry_point():
                             bstate.probability *= pscale
 
                     # Assign progress coordinates to basis states
-                    sim_manager.get_bstate_pcoords(basis_states, n_iter)
+                    sim_manager.get_bstate_pcoords(basis_states)
                     data_manager.create_ibstate_group(basis_states, n_iter)
                     sim_manager.report_basis_states(basis_states)
 


### PR DESCRIPTION
w_states was calling `sim_manager.get_bstate_pcoords()` with a second argument `n_iter`, which it doesn't take. Removed.

**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
No

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
w_states crashes when you try to replace bstates. Removed the incorrect extra argument it passes to get_bstate_coords

We should probably extend the w_states test too, since this never came up in CI.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x]  Be able to replace basis states with w_states

**Major files changed.**  
- [x] w_states.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

