### PR TITLE
Fix circular dependency in String Method plugin

### DIFF
--- a/src/westpa/westext/stringmethod/__init__.py
+++ b/src/westpa/westext/stringmethod/__init__.py
@@ -6,12 +6,6 @@ Joshua L. Adelman 2011
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 
-from . import string_method
-from .string_method import DefaultStringMethod
-
-from . import string_driver
-from .string_driver import StringDriver
-
 
 class WESTStringMethod:
 
@@ -41,4 +35,11 @@ class WESTStringMethod:
         pass
 
 
-__all__ = ['string_method', 'DefaultStringMethod', 'string_driver', 'StringDriver']
+from . import string_method
+from .string_method import DefaultStringMethod
+
+from . import string_driver
+from .string_driver import StringDriver
+
+
+__all__ = ['string_method', 'DefaultStringMethod', 'string_driver', 'StringDriver', 'WESTStringMethod']


### PR DESCRIPTION
**Issue Number.**
NA


**Describe the changes made.** 
https://github.com/westpa/westpa/pull/180 fixed issues with 1.0-style import paths in 2.0 plugins. However, an issue persisted with the stringmethod plugin.

The stringmethod plugin's `__init__.py` imported `string_method` and `string_driver` before defining `WESTStringMethod`. However, both `string_method` and `string_driver` import `WESTStringMethod`, which led to a circular dependency where they'd be unable to resolve `WESTStringMethod`. 

Moving the definition for `WESTStringMethod` to before the imports fixes that.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Make plugins runnable without errors in discovery

**Major files changed.**  
- [x] `stringmethod/__init__.py`

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.**

