### PR TITLE
Fixed a problem when h5 is used as the trajectory output in the HDF5 framework

### DIFF
--- a/src/westpa/core/trajectory.py
+++ b/src/westpa/core/trajectory.py
@@ -8,6 +8,8 @@ FormatRegistry.loaders['.rst'] = mdformats.amberrst.load_restrt
 FormatRegistry.fileobjects['.rst'] = mdformats.AmberRestartFile
 
 TRAJECTORY_EXTS = FormatRegistry.loaders.keys()
+for ext in [".h5", ".hdf5", ".lh5"]:
+    TOPOLOGY_EXTS.remove(ext)
 
 
 class WESTTrajectory(Trajectory):


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
There is a bug when h5 file is used as the trajectory format in MD production, and no topology file is returned (as h5 files usually contain topology information within them). The h5 file may be considered as a topology file instead of a trajectory file. Even though h5 files may be used as a topology file but I think it is a very edge use case and it is probably better when always consider them as trajectory. 

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [ ] 

**Major files changed.**  
- [x] executable.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

