### PR TITLE
Fixed a bug in w_trace that resulted from h5py 3.0 upgrade

### DIFF
--- a/src/westpa/cli/tools/w_trace.py
+++ b/src/westpa/cli/tools/w_trace.py
@@ -406,7 +406,7 @@ The following options for datasets are supported:
             self.datasets.append(self.parse_dataset_string(dsstr))
 
         # self.h5storage.open_analysis_h5file()
-        self.output_file = h5py.File(args.output)
+        self.output_file = h5py.File(args.output, 'a')
 
     def parse_dataset_string(self, dsstr):
         dsinfo = {}


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
w_trace breaks when using h5py 3. This is due to the fact that h5py 3 defaults to 'r' mode by default but h5py 2 defaults to 'a'.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] fix w_trace

**Major files changed.**  
- [x] src/westpa/cli/tools/w_trace.py 

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  
