### PR TITLE
Changed y-axis label of plothist energy to be consistent with everything

### DIFF
--- a/lib/west_tools/plothist.py
+++ b/lib/west_tools/plothist.py
@@ -284,7 +284,7 @@ class PlotSupports2D(PlotHistBase):
         if self.plot_output_filename:
             if self.plotscale == 'energy':
                 plothist = enehist
-                label = r'$\Delta F(\vec{x})\,/\,kT$' +'\n' + r'$\left[-\ln\,P(x)\right]$'
+                label = r'$-\ln\,P(x)\ [kT^{-1}]$'
             elif self.plotscale == 'log10':
                 plothist = log10hist
                 label = r'$\log_{10}\ P(\vec{x})$'


### PR DESCRIPTION
…ing else

**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#202 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
The y axis label for the 'energy' mode of plothist contained a delta F(X) which might be misleading. I have instead changed the axis label to be more consistent with the other plotting modes.

This is a backport of #202 and co-Authored by: @atbogetti 
**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fix labels changed in 2.0

**Major files changed.**  
- [x] lib/west_tools/plothist.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

