### PR TITLE
Making sim_manager.initialize() arguments explicit in w_init

### DIFF
--- a/src/westpa/cli/core/w_init.py
+++ b/src/westpa/cli/core/w_init.py
@@ -215,7 +215,11 @@ def initialize(tstates, tstate_file, bstates, bstate_file, sstates=None, sstate_
 
             # Prepare simulation
             sim_manager.initialize_simulation(
-                basis_states, target_states, start_states, segs_per_state=segs_per_state, suppress_we=shotgun
+                basis_states=basis_states,
+                target_states=target_states,
+                start_states=start_states,
+                segs_per_state=segs_per_state,
+                suppress_we=shotgun,
             )
         else:
             work_manager.run()


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
When using old custom sim managers where `start_states` are not defined, the following error message (which is not descriptive) might appear. I have made the keyword arguments explicit in lines 216-217 for w_init.py so the Type Error will claim `start_states` is an unexpected keyword argument, a much more descriptive error message. 


Previously w/o fix: 
> System is being built only off of the system driver
> Traceback (most recent call last):
>   File "/user/conda_local/envs/westpa-dev/bin/w_init", line 33, in <module>
>     sys.exit(load_entry_point('westpa', 'console_scripts', 'w_init')())
>   File "/user/conda_local/westpa-2.0dev1/src/westpa/cli/core/w_init.py", line 118, in entry_point
>     args.shotgun,
>   File "/user/conda_local/westpa-2.0dev1/src/westpa/cli/core/w_init.py", line 216, in initialize
>     basis_states, target_states, start_states, segs_per_state=segs_per_state, suppress_we=shotgun
> TypeError: initialize_simulation() got multiple values for argument 'segs_per_state'

Now w/ fix: 
> System is being built only off of the system driver
> Traceback (most recent call last):
>   File "/user/conda_local/envs/westpa-dev/bin/w_init", line 33, in <module>
>     sys.exit(load_entry_point('westpa', 'console_scripts', 'w_init')())
>   File "/user/conda_local/westpa-2.0dev1/src/westpa/cli/core/w_init.py", line 110, in entry_point
>     initialize(
>   File "/user/conda_local/westpa-2.0dev1/src/westpa/cli/core/w_init.py", line 217, in initialize
>     sim_manager.initialize_simulation(
> TypeError: initialize_simulation() got an unexpected keyword argument 'start_states'

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Better error message when using start_states with a custom sim_manager where start_states are not defined.

**Major files changed.**  
- [x] /src/westpa/cli/core/w_init.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

