### PR TITLE
Making Start States Compatible with the HDF5 Framework

### DIFF
--- a/src/westpa/cli/core/w_init.py
+++ b/src/westpa/cli/core/w_init.py
@@ -215,7 +215,11 @@ def initialize(tstates, tstate_file, bstates, bstate_file, sstates=None, sstate_
 
             # Prepare simulation
             sim_manager.initialize_simulation(
-                basis_states, target_states, start_states, segs_per_state=segs_per_state, suppress_we=shotgun
+                basis_states=basis_states,
+                target_states=target_states,
+                start_states=start_states,
+                segs_per_state=segs_per_state,
+                suppress_we=shotgun,
             )
         else:
             work_manager.run()

--- a/src/westpa/cli/core/w_init.py
+++ b/src/westpa/cli/core/w_init.py
@@ -204,7 +204,7 @@ def initialize(tstates, tstate_file, bstates, bstate_file, sstates=None, sstate_
             if abs(1.0 - tprob) > len(basis_states) * EPS:
                 pscale = 1 / tprob
                 log.warning(
-                    'Basis state probabilities do not add to unity (basis: {:.2f}, start states: {:.2f}); rescaling by {:g}. If using start-states, some rescaling is normal.'.format(
+                    'Basis state probabilities do not add to unity (basis: {:.2f}, start states: {:.2f}); rescaling by {:g}. If using start states, some rescaling is normal.'.format(
                         bstate_prob, sstate_prob, pscale
                     )
                 )

--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -1113,7 +1113,7 @@ class WESTDataManager:
 
         if not self.store_h5:
             return
-        print('in prepare_segment_restarts')
+
         for segment in segments:
             if segment.parent_id < 0:
                 if initial_states is None or basis_states is None:

--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -1113,13 +1113,21 @@ class WESTDataManager:
 
         if not self.store_h5:
             return
-
+        print('in prepare_segment_restarts')
         for segment in segments:
             if segment.parent_id < 0:
                 if initial_states is None or basis_states is None:
                     raise ValueError('initial and basis states required for preparing the segments')
                 initial_state = initial_states[segment.initial_state_id]
-                basis_state = basis_states[initial_state.basis_state_id]
+                # Check if it's a start state
+                if initial_state.istate_type == InitialState.ISTATE_TYPE_START:
+                    log.debug(
+                        f'Skip reading start state file from per-iteration HDF5 file for initial state {segment.initial_state_id}'
+                    )
+                    continue
+                else:
+                    basis_state = basis_states[initial_state.basis_state_id]
+
                 parent = Segment(n_iter=0, seg_id=basis_state.state_id)
             else:
                 parent = Segment(n_iter=segment.n_iter - 1, seg_id=segment.parent_id)

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -287,6 +287,14 @@ class WESimManager:
         # Unlike the above, does not create an ibstate group.
         # TODO: Should it? I don't think so, if needed it can be traced back through basis_auxref
 
+        # Here, we are trying to assign a state_id to the start state to be initialized, without actually
+        # saving it to the ibstates records in any of the h5 files. It might actually be a problem
+        # when tracing trajectories with westpa.analysis (especially with HDF5 framework) since it would
+        # try to look for a basis state id > len(basis_state).
+        # Since start states are only used while initializing and iteration 1, it's ok to not save it to save space. If necessary,
+        # the structure can be traced directly to the parent file using the standard basis state logic referencing
+        # west[iterations/iter_00000001/ibstates/istate_index/basis_auxref] of that istate.
+
         try:
             if start_states[0].state_id is None:
                 last_id = basis_states[-1].state_id

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -295,14 +295,11 @@ class WESimManager:
         # the structure can be traced directly to the parent file using the standard basis state logic referencing
         # west[iterations/iter_00000001/ibstates/istate_index/basis_auxref] of that istate.
 
-        try:
-            if start_states[0].state_id is None:
-                last_id = basis_states[-1].state_id
-                for start_state in start_states:
-                    start_state.state_id = last_id + 1
-                    last_id += 1
-        except IndexError:
-            pass
+        if len(start_states) > 0 and start_states[0].state_id is None:
+            last_id = basis_states[-1].state_id
+            for start_state in start_states:
+                start_state.state_id = last_id + 1
+                last_id += 1
 
         self.get_bstate_pcoords(start_states, label='start')
         self.report_basis_states(start_states, label='start')

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -287,11 +287,14 @@ class WESimManager:
         # Unlike the above, does not create an ibstate group.
         # TODO: Should it? I don't think so, if needed it can be traced back through basis_auxref
 
-        if start_states[0].state_id is None:
-            last_id = basis_states[-1].state_id
-            for start_state in start_states:
-                start_state.state_id = last_id + 1
-                last_id += 1
+        try:
+            if start_states[0].state_id is None:
+                last_id = basis_states[-1].state_id
+                for start_state in start_states:
+                    start_state.state_id = last_id + 1
+                    last_id += 1
+        except IndexError:
+            pass
 
         self.get_bstate_pcoords(start_states, label='start')
         self.report_basis_states(start_states, label='start')

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -211,19 +211,19 @@ class WESimManager:
                 iter_summary['walltime'] = 0.0
             self.data_manager.update_iter_summary(iter_summary)
 
-    def get_bstate_pcoords(self, basis_states):
+    def get_bstate_pcoords(self, basis_states, label='basis'):
         '''For each of the given ``basis_states``, calculate progress coordinate values
         as necessary.  The HDF5 file is not updated.'''
 
-        self.rc.pstatus('Calculating progress coordinate values for basis states.')
+        self.rc.pstatus('Calculating progress coordinate values for {} states.'.format(label))
         futures = [self.work_manager.submit(wm_ops.get_pcoord, args=(basis_state,)) for basis_state in basis_states]
         fmap = {future: i for (i, future) in enumerate(futures)}
         for future in self.work_manager.as_completed(futures):
             basis_states[fmap[future]].pcoord = future.get_result().pcoord
 
-    def report_basis_states(self, basis_states):
+    def report_basis_states(self, basis_states, label='basis'):
         pstatus = self.rc.pstatus
-        pstatus('{:d} basis state(s) present'.format(len(basis_states)), end='')
+        pstatus('{:d} {} state(s) present'.format(len(basis_states), label), end='')
         if self.rc.verbose_mode:
             pstatus(':')
             pstatus(
@@ -286,8 +286,15 @@ class WESimManager:
         # Process start states
         # Unlike the above, does not create an ibstate group.
         # TODO: Should it? I don't think so, if needed it can be traced back through basis_auxref
-        self.get_bstate_pcoords(start_states)
-        self.report_basis_states(start_states)
+
+        if start_states[0].state_id is None:
+            last_id = basis_states[-1].state_id
+            for start_state in start_states:
+                start_state.state_id = last_id + 1
+                last_id += 1
+
+        self.get_bstate_pcoords(start_states, label='start')
+        self.report_basis_states(start_states, label='start')
 
         pstatus('Preparing initial states')
         initial_states = []

--- a/src/westpa/core/states.py
+++ b/src/westpa/core/states.py
@@ -139,8 +139,9 @@ class InitialState:
     :ivar istate_type:      Integer describing the type of this initial state
                             (ISTATE_TYPE_BASIS for direct use of a basis state,
                             ISTATE_TYPE_GENERATED for a state generated from a basis state,
-                            or ISTATE_TYPE_RESTART for a state corresponding to the endpoint
-                            of a segment in another simulation).
+                            ISTATE_TYPE_RESTART for a state corresponding to the endpoint
+                            of a segment in another simulation, or
+                            ISTATE_TYPE_START for a state generated from a start state).
     :ivar istate_status:    Integer describing whether this initial state has been properly
                             prepared.
     :ivar pcoord:           The representative progress coordinate of this state.


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Start states do not work with the HDF5 Framework. This PR fixes that by allowing the propagator to read the start states structure files directly (since they are not saved into any of the per-iteration HDF5 files). 

As a bonus, I expanded the docstrings in src/westpa/core/states.py and fixed some typo errors here and there.

Should be merged after #220 since it contains those changes. (Or just close #220 and merge this one directly)

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Make start states compatible with HDF5 Framework

**Major files changed.**  
- [x] src/westpa/core/data_manager.py
- [x] src/westpa/core/propagators/executable.py
- [x] src/westpa/core/sim_manager.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

