### PR TITLE
port of PR #169 to WESTPA 1.0

### DIFF
--- a/src/oldtools/aframe/plotting.py
+++ b/src/oldtools/aframe/plotting.py
@@ -59,8 +59,8 @@ else:
                              (1.0,1.0,1.0)]}
     
     cm_pdr = matplotlib.colors.LinearSegmentedColormap('pdr', _pdr_data, 2048)
-    cm_pdr_r = matplotlib.colors.LinearSegmentedColormap('pdr_r', matplotlib.cm.revcmap(_pdr_data), 2048)
-    
+    cm_pdr_r = cm_pdr.reversed()
+
     matplotlib.cm.register_cmap('pdr', cm_pdr)
     matplotlib.cm.register_cmap('pdr_r', cm_pdr_r)
     matplotlib.cm.register_cmap('hovmol', cm_hovmol)


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#169 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Current code in `src/oldtools/aframe/plotting.py` uses a deprecated/removed matplotlib feature which breaks `w_succ`. This is a back-port of a WESTPA 2.0 fix to WESTPA 1.0.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Backport the Revcmap fix to WESTPA 1.0 

**Major files changed.**  
- [x] src/oldtools/aframe/plotting.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

