### PR TITLE
A new BinlessMapper for WESTPA

### DIFF
--- a/src/westpa/core/_rc.py
+++ b/src/westpa/core/_rc.py
@@ -305,6 +305,13 @@ class WESTRC:
         elif nestmapname == 'MABBinMapper':
             sim_manager = westpa.core.binning.mab_manager.MABSimManager(rc=self)
 
+        elif binmapname == 'BinlessMapper':
+            sim_manager = westpa.core.binning.binless_manager.BinlessManager(rc=self)
+            sys.stderr.write("-- WARNING  [config] -- Do not use BinlessMapper as an outer binning scheme with a target state.\n")
+
+        elif nestmapname == 'BinlessMapper':
+            sim_manager = westpa.core.binning.binless_manager.BinlessSimManager(rc=self)
+
         elif drivername.lower() == 'default':
             from .sim_manager import WESimManager
 

--- a/src/westpa/core/_rc.py
+++ b/src/westpa/core/_rc.py
@@ -360,6 +360,12 @@ class WESTRC:
         elif nestmapname == 'MABBinMapper':
             we_driver = westpa.core.binning.mab_driver.MABDriver()
 
+        elif binmapname == 'BinlessMapper':
+            we_driver = westpa.core.binning.binless_driver.BinlessDriver()
+
+        elif nestmapname == 'BinlessMapper':
+            we_driver = westpa.core.binning.binless_driver.BinlessDriver()
+
         elif drivername.lower() == 'default':
             we_driver = westpa.core.we_driver.WEDriver()
 

--- a/src/westpa/core/_rc.py
+++ b/src/westpa/core/_rc.py
@@ -360,21 +360,21 @@ class WESTRC:
             we_driver = extloader.get_object(drivername)(rc=self)
         log.debug('loaded WE algorithm driver: {!r}'.format(we_driver))
 
-        group_function = self.config.get(['west', 'drivers', 'group_function'], 'default')
-        if group_function.lower() == 'default':
+        subgroup_function = self.config.get(['west', 'drivers', 'subgroup_function'], 'default')
+        if subgroup_function.lower() == 'default':
             try:
-                group_function = 'westpa.core.we_driver._group_walkers_identity'
-                we_driver.group_function = westpa.core.we_driver._group_walkers_identity
+                subgroup_function = 'westpa.core.we_driver._group_walkers_identity'
+                we_driver.subgroup_function = westpa.core.we_driver._group_walkers_identity
             except Exception:
                 pass
         else:
-            we_driver.group_function = extloader.get_object(group_function)
-        we_driver.group_function_kwargs = self.config.get(['west', 'drivers', 'group_arguments'])
+            we_driver.subgroup_function = extloader.get_object(subgroup_function)
+        we_driver.subgroup_function_kwargs = self.config.get(['west', 'drivers', 'subgroup_arguments'])
         # Necessary if the user hasn't specified any options.
-        if we_driver.group_function_kwargs is None:
-            we_driver.group_function_kwargs = {}
-        log.debug('loaded WE algorithm driver grouping function {!r}'.format(group_function))
-        log.debug('WE algorithm driver grouping function kwargs: {!r}'.format(we_driver.group_function_kwargs))
+        if we_driver.subgroup_function_kwargs is None:
+            we_driver.subgroup_function_kwargs = {}
+        log.debug('loaded WE algorithm driver grouping function {!r}'.format(subgroup_function))
+        log.debug('WE algorithm driver grouping function kwargs: {!r}'.format(we_driver.subgroup_function_kwargs))
 
         return we_driver
 

--- a/src/westpa/core/binning/__init__.py
+++ b/src/westpa/core/binning/__init__.py
@@ -12,9 +12,11 @@ from .assign import (
 )
 
 from .mab import map_mab, MABBinMapper
+from .binless import map_binless, BinlessMapper
 
 from .mab_driver import MABDriver
 from .mab_manager import MABSimManager
+from .binless_manager import BinlessSimManager
 
 from ._assign import accumulate_labeled_populations, assign_and_label, accumulate_state_populations_from_labeled
 from ._assign import assignments_list_to_table
@@ -35,9 +37,12 @@ __all__ = [
     'VectorizingFuncBinMapper',
     'VoronoiBinMapper',
     'map_mab',
+    'map_binless',
     'MABBinMapper',
+    'BinlessMapper',
     'MABDriver',
     'MABSimManager',
+    'BinlessSimManager',
     'accumulate_labeled_populations',
     'assign_and_label',
     'accumulate_state_populations_from_labeled',

--- a/src/westpa/core/binning/__init__.py
+++ b/src/westpa/core/binning/__init__.py
@@ -17,6 +17,7 @@ from .binless import map_binless, BinlessMapper
 from .mab_driver import MABDriver
 from .mab_manager import MABSimManager
 from .binless_manager import BinlessSimManager
+from .binless_driver import BinlessDriver
 
 from ._assign import accumulate_labeled_populations, assign_and_label, accumulate_state_populations_from_labeled
 from ._assign import assignments_list_to_table
@@ -42,6 +43,7 @@ __all__ = [
     'BinlessMapper',
     'MABDriver',
     'MABSimManager',
+    'BinlessDriver',
     'BinlessSimManager',
     'accumulate_labeled_populations',
     'assign_and_label',

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -20,9 +20,7 @@ def map_binless(coords, mask, output, *args, **kwargs):
     allcoords = np.copy(coords)
     allmask = np.copy(mask)
 
-    #    weights = None
     isfinal = None
-    #    splitting = False
 
     # the segments should be sent in by the driver as half initial segments and half final segments
     # allcoords contains all segments
@@ -33,20 +31,45 @@ def map_binless(coords, mask, output, *args, **kwargs):
         else:
             isfinal = np.ones(coords.shape[0], dtype=np.bool_)
         coords = coords[isfinal, :ndim]
-        #        weights = allcoords[isfinal, ndim + 0]
         mask = mask[isfinal]
-    #        splitting = True
 
     # in case where there is no final segments but initial ones in range
     if not np.any(mask):
         coords = allcoords[:, :ndim]
         mask = allmask
-    #        weights = None
-    #        splitting = False
 
-    output = group_function(coords, groups_per_dim)
+    # filter the list of coordinates (which contains coordinates outside of the binless region)
+    # to obtain only the ones we want to cluster
+    # we do this per pcoord dimension
+    for n in range(ndim):
+        binless_coords = coords[mask, n]
+        nsegs_binless = len(binless_coords)
 
-    return output
+        # we need to make sure that the number of segments in the binless region is greater than
+        # the number of clusters we request
+        # if only one segment in the binless region, assign it to a single cluster
+        if nsegs_binless == 1:
+            clusters = [0]
+        # if there are more than one segment in the binless region but still the total is less than
+        # our target number, adjust our target number to be the number of segments in the binless
+        # region minus one
+        elif nsegs_binless <= groups_per_dim[n]:
+            clusters = group_function(binless_coords, nsegs_binless - 1)
+        # if there are enough segments in the binless region, proceed as planned
+        elif nsegs_binless > groups_per_dim[n]:
+            clusters = group_function(binless_coords, groups_per_dim[0])
+
+        # this is a good place to say this... output is a list which matches the length of allcoords
+        # allcoords is a collection of all initial and final segment coords for that iteration
+        # we first filtered those to only contain the final data points, since those are the ones we care
+        # about clustering
+        # we then filtered to only have the coords in the binless region, since, again, those are what we care about
+        # we then assigned each to a cluster which is essentially a slitting index
+        # all that's left is to find where each binless segment is in the output and insert the cluster index there
+        for idx, val in enumerate(binless_coords):
+            output[allcoords[:, n] == val] = clusters[idx]
+
+        return output
 
 
 class BinlessMapper(FuncBinMapper):

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -1,0 +1,60 @@
+import numpy as np
+from westpa.core.binning import FuncBinMapper
+from westpa.core.extloader import get_object
+
+
+def map_binless(coords, mask, output, *args, **kwargs):
+    '''Binning which adaptively places bins based on the positions of extrema segments and
+    bottleneck segments, which are where the difference in probability is the greatest
+    along the progress coordinate. Operates per dimension and places a fixed number of
+    evenly spaced bins between the segments with the min and max pcoord values. Extrema and
+    bottleneck segments are assigned their own bins.'''
+
+    groups_per_dim = kwargs.get("groups_per_dim")
+    group_function = get_object(kwargs.get("group_function"))
+    ndim = len(groups_per_dim)
+
+    if not np.any(mask):
+        return output
+
+    allcoords = np.copy(coords)
+    allmask = np.copy(mask)
+
+    #    weights = None
+    isfinal = None
+    #    splitting = False
+
+    # the segments should be sent in by the driver as half initial segments and half final segments
+    # allcoords contains all segments
+    # coords should contain ONLY final segments
+    if coords.shape[1] > ndim:
+        if coords.shape[1] > ndim + 1:
+            isfinal = allcoords[:, ndim + 1].astype(np.bool_)
+        else:
+            isfinal = np.ones(coords.shape[0], dtype=np.bool_)
+        coords = coords[isfinal, :ndim]
+        #        weights = allcoords[isfinal, ndim + 0]
+        mask = mask[isfinal]
+    #        splitting = True
+
+    # in case where there is no final segments but initial ones in range
+    if not np.any(mask):
+        coords = allcoords[:, :ndim]
+        mask = allmask
+    #        weights = None
+    #        splitting = False
+
+    output = group_function(coords, groups_per_dim)
+
+    return output
+
+
+class BinlessMapper(FuncBinMapper):
+    '''Adaptively place bins in between minimum and maximum segments along
+    the progress coordinte. Extrema and bottleneck segments are assigned
+    to their own bins.'''
+
+    def __init__(self, ngroups, group_function):
+        kwargs = dict(groups_per_dim=ngroups, group_function=group_function)
+        n_total_groups = np.prod(ngroups)
+        super().__init__(map_binless, n_total_groups, kwargs=kwargs)

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -10,9 +10,10 @@ def map_binless(coords, mask, output, *args, **kwargs):
     evenly spaced bins between the segments with the min and max pcoord values. Extrema and
     bottleneck segments are assigned their own bins.'''
 
-    groups_per_dim = kwargs.get("groups_per_dim")
+    n_groups = kwargs.get("n_groups")
+    n_dims = kwargs.get("n_dims")
     group_function = get_object(kwargs.get("group_function"))
-    ndim = len(groups_per_dim)
+    ndim = n_dims
 
     if not np.any(mask):
         return output
@@ -43,36 +44,39 @@ def map_binless(coords, mask, output, *args, **kwargs):
 
     # filter the list of coordinates (which contains coordinates outside of the binless region)
     # to obtain only the ones we want to cluster
-    # we do this per pcoord dimension
-    for n in range(ndim):
-        binless_coords = coords[mask, n]
-        nsegs_binless = len(binless_coords)
+    # this is done with all dimensions at once
+    binless_coords = coords[mask]
+    nsegs_binless = len(binless_coords)
 
-        # we need to make sure that the number of segments in the binless region is greater than
-        # the number of clusters we request
-        # if only one segment in the binless region, assign it to a single cluster
-        if nsegs_binless == 1:
-            clusters = [0]
-        # if there are more than one segment in the binless region but still the total is less than
-        # our target number, adjust our target number to be the number of segments in the binless
-        # region minus one
-        elif nsegs_binless < groups_per_dim[n]:
-            clusters = group_function(binless_coords, nsegs_binless, splitting)
-        # if there are enough segments in the binless region, proceed as planned
-        elif nsegs_binless >= groups_per_dim[n]:
-            clusters = group_function(binless_coords, groups_per_dim[0], splitting)
+    # we need to make sure that the number of segments in the binless region is greater than
+    # the number of clusters we request
+    # if only one segment in the binless region, assign it to a single cluster
+    if nsegs_binless == 1:
+        clusters = [0]
+    # if there are more than one segment in the binless region but still the total is less than
+    # our target number, adjust our target number to be the number of segments in the binless
+    # region minus one
+    elif nsegs_binless < n_groups:
+        clusters = group_function(binless_coords, nsegs_binless, splitting)
+    # if there are enough segments in the binless region, proceed as planned
+    elif nsegs_binless >= n_groups:
+        clusters = group_function(binless_coords, n_groups, splitting)
 
-        # this is a good place to say this... output is a list which matches the length of allcoords
-        # allcoords is a collection of all initial and final segment coords for that iteration
-        # we first filtered those to only contain the final data points, since those are the ones we care
-        # about clustering
-        # we then filtered to only have the coords in the binless region, since, again, those are what we care about
-        # we then assigned each to a cluster which is essentially a slitting index
-        # all that's left is to find where each binless segment is in the output and insert the cluster index there
-        for idx, val in enumerate(binless_coords):
-            output[allcoords[:, n] == val] = clusters[idx]
+    # this is a good place to say this... output is a list which matches the length of allcoords
+    # allcoords is a collection of all initial and final segment coords for that iteration
+    # we first filtered those to only contain the final data points, since those are the ones we care
+    # about clustering
+    # we then filtered to only have the coords in the binless region, since, again, those are what we care about
+    # we then assigned each to a cluster which is essentially a slitting index
+    # all that's left is to find where each binless segment is in the output and insert the cluster index there
+    for idx, val in enumerate(binless_coords):
+        if ndim > 1:
+            mask2 = np.logical_and(allcoords[:, 0] == val[0], allcoords[:, 1] == val[1])
+        else:
+            mask2 = allcoords[:, 0] == val[0]
+        output[mask2] = clusters[idx]
 
-        return output
+    return output
 
 
 class BinlessMapper(FuncBinMapper):
@@ -80,7 +84,7 @@ class BinlessMapper(FuncBinMapper):
     the progress coordinte. Extrema and bottleneck segments are assigned
     to their own bins.'''
 
-    def __init__(self, ngroups, group_function):
-        kwargs = dict(groups_per_dim=ngroups, group_function=group_function)
-        n_total_groups = np.prod(ngroups)
+    def __init__(self, ngroups, ndims, group_function):
+        kwargs = dict(n_groups=ngroups, n_dims=ndims, group_function=group_function)
+        n_total_groups = ngroups
         super().__init__(map_binless, n_total_groups, kwargs=kwargs)

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -56,10 +56,10 @@ def map_binless(coords, mask, output, *args, **kwargs):
         # if there are more than one segment in the binless region but still the total is less than
         # our target number, adjust our target number to be the number of segments in the binless
         # region minus one
-        elif nsegs_binless <= groups_per_dim[n]:
-            clusters = group_function(binless_coords, nsegs_binless - 1, splitting)
+        elif nsegs_binless < groups_per_dim[n]:
+            clusters = group_function(binless_coords, nsegs_binless, splitting)
         # if there are enough segments in the binless region, proceed as planned
-        elif nsegs_binless > groups_per_dim[n]:
+        elif nsegs_binless >= groups_per_dim[n]:
             clusters = group_function(binless_coords, groups_per_dim[0], splitting)
 
         # this is a good place to say this... output is a list which matches the length of allcoords

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -21,6 +21,7 @@ def map_binless(coords, mask, output, *args, **kwargs):
     allmask = np.copy(mask)
 
     isfinal = None
+    splitting = False
 
     # the segments should be sent in by the driver as half initial segments and half final segments
     # allcoords contains all segments
@@ -32,11 +33,13 @@ def map_binless(coords, mask, output, *args, **kwargs):
             isfinal = np.ones(coords.shape[0], dtype=np.bool_)
         coords = coords[isfinal, :ndim]
         mask = mask[isfinal]
+        splitting = True
 
     # in case where there is no final segments but initial ones in range
     if not np.any(mask):
         coords = allcoords[:, :ndim]
         mask = allmask
+        splitting = False
 
     # filter the list of coordinates (which contains coordinates outside of the binless region)
     # to obtain only the ones we want to cluster
@@ -54,10 +57,10 @@ def map_binless(coords, mask, output, *args, **kwargs):
         # our target number, adjust our target number to be the number of segments in the binless
         # region minus one
         elif nsegs_binless <= groups_per_dim[n]:
-            clusters = group_function(binless_coords, nsegs_binless - 1)
+            clusters = group_function(binless_coords, nsegs_binless - 1, splitting)
         # if there are enough segments in the binless region, proceed as planned
         elif nsegs_binless > groups_per_dim[n]:
-            clusters = group_function(binless_coords, groups_per_dim[0])
+            clusters = group_function(binless_coords, groups_per_dim[0], splitting)
 
         # this is a good place to say this... output is a list which matches the length of allcoords
         # allcoords is a collection of all initial and final segment coords for that iteration

--- a/src/westpa/core/binning/binless_driver.py
+++ b/src/westpa/core/binning/binless_driver.py
@@ -1,0 +1,53 @@
+import logging
+
+import numpy as np
+from westpa.core.we_driver import WEDriver
+
+log = logging.getLogger(__name__)
+
+
+class BinlessDriver(WEDriver):
+    def assign(self, segments, initializing=False):
+        '''Assign segments to initial and final bins, and update the (internal) lists of used and available
+        initial states. This function is adapted to the MAB scheme, so that the inital and final segments are
+        sent to the bin mapper at the same time, otherwise the inital and final bin boundaries can be inconsistent.'''
+
+        # collect initial and final coordinates into one place
+        n_segments = len(segments)
+        all_pcoords = np.empty((n_segments * 2, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
+
+        for iseg, segment in enumerate(segments):
+            all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 0.0])
+            all_pcoords[n_segments + iseg] = np.append(segment.pcoord[-1, :], [segment.weight, 1.0])
+
+        # assign based on initial and final progress coordinates
+        assignments = self.bin_mapper.assign(all_pcoords)
+        initial_assignments = assignments[:n_segments]
+        if initializing:
+            final_assignments = initial_assignments
+        else:
+            final_assignments = assignments[n_segments:]
+
+        initial_binning = self.initial_binning
+        final_binning = self.final_binning
+        flux_matrix = self.flux_matrix
+        transition_matrix = self.transition_matrix
+        for (segment, iidx, fidx) in zip(segments, initial_assignments, final_assignments):
+            initial_binning[iidx].add(segment)
+            final_binning[fidx].add(segment)
+            flux_matrix[iidx, fidx] += segment.weight
+            transition_matrix[iidx, fidx] += 1
+
+        n_recycled_total = self.n_recycled_segs
+        n_new_states = n_recycled_total - len(self.avail_initial_states)
+
+        log.debug(
+            '{} walkers scheduled for recycling, {} initial states available'.format(
+                n_recycled_total, len(self.avail_initial_states)
+            )
+        )
+
+        if n_new_states > 0:
+            return n_new_states
+        else:
+            return 0

--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -1,0 +1,73 @@
+import logging
+
+from westpa.core.sim_manager import WESimManager, grouper
+from westpa.core.states import InitialState, pare_basis_initial_states
+from westpa.core import wm_ops
+
+log = logging.getLogger(__name__)
+
+
+class BinlessSimManager(WESimManager):
+    def report_bin_statistics(self, bins, save_summary=False):
+        self.rc.pstatus("Binless scheme in use.")
+        super().report_bin_statistics(bins, save_summary)
+
+    def propagate(self):
+        segments = list(self.incomplete_segments.values())
+        log.debug('iteration {:d}: propagating {:d} segments'.format(self.n_iter, len(segments)))
+
+        # all futures dispatched for this iteration
+        futures = set()
+        segment_futures = set()
+
+        # Immediately dispatch any necessary initial state generation
+        istate_gen_futures = self.get_istate_futures()
+        futures.update(istate_gen_futures)
+
+        # Dispatch propagation tasks using work manager
+        for segment_block in grouper(self.propagator_block_size, segments):
+            segment_block = [_f for _f in segment_block if _f]
+            pbstates, pistates = pare_basis_initial_states(
+                self.current_iter_bstates, list(self.current_iter_istates.values()), segment_block
+            )
+            future = self.work_manager.submit(wm_ops.propagate, args=(pbstates, pistates, segment_block))
+            futures.add(future)
+            segment_futures.add(future)
+
+        while futures:
+            # TODO: add capacity for timeout or SIGINT here
+            future = self.work_manager.wait_any(futures)
+            futures.remove(future)
+
+            if future in segment_futures:
+                segment_futures.remove(future)
+                incoming = future.get_result()
+                self.n_propagated += 1
+
+                self.segments.update({segment.seg_id: segment for segment in incoming})
+                self.completed_segments.update({segment.seg_id: segment for segment in incoming})
+
+                new_istate_futures = self.get_istate_futures()
+                istate_gen_futures.update(new_istate_futures)
+                futures.update(new_istate_futures)
+
+                with self.data_manager.expiring_flushing_lock():
+                    self.data_manager.update_segments(self.n_iter, incoming)
+
+            elif future in istate_gen_futures:
+                istate_gen_futures.remove(future)
+                _basis_state, initial_state = future.get_result()
+                log.debug('received newly-prepared initial state {!r}'.format(initial_state))
+                initial_state.istate_status = InitialState.ISTATE_STATUS_PREPARED
+                with self.data_manager.expiring_flushing_lock():
+                    self.data_manager.update_initial_states([initial_state], n_iter=self.n_iter + 1)
+                self.we_driver.avail_initial_states[initial_state.state_id] = initial_state
+            else:
+                log.error('unknown future {!r} received from work manager'.format(future))
+                raise AssertionError('untracked future {!r}'.format(future))
+
+        self.we_driver.assign(self.segments.values())
+        self.get_istate_futures()
+        log.debug('done with propagation')
+        self.save_bin_data()
+        self.data_manager.flush_backing()

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -119,8 +119,8 @@ class WEDriver:
 
         # Make property for grouping function.
         # KFW self.group_function = None
-        self.group_function = _group_walkers_identity
-        self.group_function_kwargs = {}
+        self.subgroup_function = _group_walkers_identity
+        self.subgroup_function_kwargs = {}
 
         self.process_config()
 
@@ -629,7 +629,7 @@ class WEDriver:
 
             # Splits the bin into groups as defined by the called function
             target_count = self.bin_target_counts[ibin]
-            groups = self.group_function(self, ibin, **self.group_function_kwargs)
+            groups = self.subgroup_function(self, ibin, **self.subgroup_function_kwargs)
             total_number_of_groups += len(groups)
             # Clear the bin
             segments = np.array(sorted(bin, key=operator.attrgetter('weight')), dtype=np.object_)

--- a/tests/test_we_driver.py
+++ b/tests/test_we_driver.py
@@ -196,7 +196,7 @@ class TestWEDriver(TestCase):
 
         for ibin, bin in enumerate(self.we_driver.next_iter_binning):
             target_count = self.we_driver.bin_target_counts[ibin]
-            groups = self.we_driver.group_function(self.we_driver, ibin, **self.we_driver.group_function_kwargs)
+            groups = self.we_driver.subgroup_function(self.we_driver, ibin, **self.we_driver.subgroup_function_kwargs)
             self.we_driver._adjust_count(bin, groups, target_count)
 
         assert len(self.we_driver.next_iter_binning[0]) == 5


### PR DESCRIPTION
This PR adds a new BinlessMapper to WESTPA that allows for the complete employment of binless schemes during a weighted ensemble simulation.  This is essentially just a special case of the FuncBinMapper that takes in a user-defined function that groups progress coordinate values.  The framework here for use is very similar to the MAB scheme in that it can be placed inside of a Recursive Bin for use with a target state.  Please see my ODLD binless or binless-2D branch for an example of how to get this ready in the west.cfg file.  I also re-named the current group-related functions to be subgroups since those technically operate within existing "groups". See documentation in the Wiki's Binning page for how to use.

**Goals and Outstanding Issues.**
- [ ] Make this usable with more than 2 dimensions
- [ ] Remove requirement for needing to know the total number of groups before-hand

**Major files changed.**  
- [ ] we_driver.py (just for the subgroup renaming)

**Status.**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

