### PR TITLE
New BinlessMapper functionality + Misc Fixes

### DIFF
--- a/src/westpa/cli/core/w_run.py
+++ b/src/westpa/cli/core/w_run.py
@@ -65,8 +65,9 @@ def run_simulation():
                 sim_manager.finalize_run()
             except KeyboardInterrupt:
                 westpa.rc.pstatus('interrupted; shutting down')
-            except Exception:
+            except Exception as e:
                 westpa.rc.pstatus('exception caught; shutting down')
+                log.error(f'error message:{e}')
                 log.error(traceback.format_exc())
         else:
             work_manager.run()

--- a/src/westpa/cli/core/w_run.py
+++ b/src/westpa/cli/core/w_run.py
@@ -67,7 +67,7 @@ def run_simulation():
                 westpa.rc.pstatus('interrupted; shutting down')
             except Exception as e:
                 westpa.rc.pstatus('exception caught; shutting down')
-                log.error(f'error message:{e}')
+                log.error(f'error message: {e}')
                 log.error(traceback.format_exc())
         else:
             work_manager.run()

--- a/src/westpa/cli/core/w_run.py
+++ b/src/westpa/cli/core/w_run.py
@@ -67,7 +67,8 @@ def run_simulation():
                 westpa.rc.pstatus('interrupted; shutting down')
             except Exception as e:
                 westpa.rc.pstatus('exception caught; shutting down')
-                log.error(f'error message: {e}')
+                if str(e) != '':
+                    log.error(f'error message: {e}')
                 log.error(traceback.format_exc())
         else:
             work_manager.run()

--- a/src/westpa/core/_rc.py
+++ b/src/westpa/core/_rc.py
@@ -418,8 +418,8 @@ class WESTRC:
         # Necessary if the user hasn't specified any options.
         if we_driver.subgroup_function_kwargs is None:
             we_driver.subgroup_function_kwargs = {}
-        log.debug('loaded WE algorithm driver grouping function {!r}'.format(subgroup_function))
-        log.debug('WE algorithm driver grouping function kwargs: {!r}'.format(we_driver.subgroup_function_kwargs))
+        log.debug('loaded WE algorithm driver subgrouping function {!r}'.format(subgroup_function))
+        log.debug('WE algorithm driver subgrouping function kwargs: {!r}'.format(we_driver.subgroup_function_kwargs))
 
         return we_driver
 

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -1,6 +1,9 @@
 import numpy as np
 from westpa.core.binning import FuncBinMapper
 from westpa.core.extloader import get_object
+import logging
+
+log = logging.getLogger('westpa.rc')
 
 
 def map_binless(coords, mask, output, *args, **kwargs):
@@ -11,10 +14,12 @@ def map_binless(coords, mask, output, *args, **kwargs):
     n_groups = kwargs.get("n_groups")
     n_dims = kwargs.get("n_dims")
     group_function = get_object(kwargs.get("group_function"))
-    group_function_kwargs = kwargs.get('group_function_kwargs')['group_arguments']
-    ndim = n_dims
-    if group_function_kwargs is None or len(group_function_kwargs) == 0:
+    log.debug(f'binless arguments: {kwargs}')
+    try:
+        group_function_kwargs = kwargs.get('group_function_kwargs')['group_arguments']
+    except KeyError:
         group_function_kwargs = {}
+    ndim = n_dims
 
     if not np.any(mask):
         return output

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -11,7 +11,11 @@ def map_binless(coords, mask, output, *args, **kwargs):
     n_groups = kwargs.get("n_groups")
     n_dims = kwargs.get("n_dims")
     group_function = get_object(kwargs.get("group_function"))
+    group_function_kwargs = kwargs.get('group_arguments')
     ndim = n_dims
+
+    if group_function_kwargs is None:
+       group_function_kwargs = {}
 
     if not np.any(mask):
         return output
@@ -55,10 +59,10 @@ def map_binless(coords, mask, output, *args, **kwargs):
     # our target number, adjust our target number to be the number of segments in the binless
     # region minus one
     elif nsegs_binless < n_groups:
-        clusters = group_function(binless_coords, nsegs_binless, splitting)
+        clusters = group_function(binless_coords, nsegs_binless, splitting, **group_function_kwargs)
     # if there are enough segments in the binless region, proceed as planned
     elif nsegs_binless >= n_groups:
-        clusters = group_function(binless_coords, n_groups, splitting)
+        clusters = group_function(binless_coords, n_groups, splitting, **group_function_kwargs)
 
     # this is a good place to say this... output is a list which matches the length of allcoords
     # allcoords is a collection of all initial and final segment coords for that iteration
@@ -81,7 +85,7 @@ class BinlessMapper(FuncBinMapper):
     '''Adaptively group walkers according to a user-defined grouping
     function that is defined externally.'''
 
-    def __init__(self, ngroups, ndims, group_function):
-        kwargs = dict(n_groups=ngroups, n_dims=ndims, group_function=group_function)
+    def __init__(self, ngroups, ndims, group_function, **group_function_kwargs):
+        kwargs = dict(n_groups=ngroups, n_dims=ndims, group_function=group_function, group_function_kwargs=group_function_kwargs)
         n_total_groups = ngroups
         super().__init__(map_binless, n_total_groups, kwargs=kwargs)

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -11,10 +11,9 @@ def map_binless(coords, mask, output, *args, **kwargs):
     n_groups = kwargs.get("n_groups")
     n_dims = kwargs.get("n_dims")
     group_function = get_object(kwargs.get("group_function"))
-    group_function_kwargs = kwargs.get('group_arguments')
+    group_function_kwargs = kwargs.get('group_function_kwargs')['group_arguments']
     ndim = n_dims
-
-    if group_function_kwargs is None:
+    if group_function_kwargs is None or len(group_function_kwargs) == 0:
        group_function_kwargs = {}
 
     if not np.any(mask):
@@ -55,6 +54,7 @@ def map_binless(coords, mask, output, *args, **kwargs):
     # if only one segment in the binless region, assign it to a single cluster
     if nsegs_binless == 1:
         clusters = [0]
+    
     # if there are more than one segment in the binless region but still the total is less than
     # our target number, adjust our target number to be the number of segments in the binless
     # region minus one

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -14,7 +14,7 @@ def map_binless(coords, mask, output, *args, **kwargs):
     group_function_kwargs = kwargs.get('group_function_kwargs')['group_arguments']
     ndim = n_dims
     if group_function_kwargs is None or len(group_function_kwargs) == 0:
-       group_function_kwargs = {}
+        group_function_kwargs = {}
 
     if not np.any(mask):
         return output
@@ -54,7 +54,7 @@ def map_binless(coords, mask, output, *args, **kwargs):
     # if only one segment in the binless region, assign it to a single cluster
     if nsegs_binless == 1:
         clusters = [0]
-    
+
     # if there are more than one segment in the binless region but still the total is less than
     # our target number, adjust our target number to be the number of segments in the binless
     # region minus one

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -199,7 +199,7 @@ class ExecutablePropagator(WESTPropagator):
         self.addtl_child_environ.update({k: str(v) for k, v in (config['west', 'executable', 'environ'] or {}).items()})
 
         # Load configuration items relating to child processes
-        for child_type in ('propagator', 'pre_iteration', 'post_iteration', 'get_pcoord', 'gen_istate', 'group_walkers'):
+        for child_type in ('propagator', 'pre_iteration', 'post_iteration', 'get_pcoord', 'gen_istate', 'subgroup_walkers'):
             child_info = config.get(['west', 'executable', child_type])
             if not child_info:
                 continue

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -701,7 +701,7 @@ class WEDriver:
                     # A modified adjustment routine is necessary to ensure we don't unnecessarily destroy trajectory pathways.
                     self._adjust_count(bin, subgroups, target_count)
             total_number_of_particles += len(bin)
-        westpa.rc.pstatus('Total number of subgroups: {!r}'.format(total_number_of_subgroups))
+        log.debug('Total number of subgroups: {!r}'.format(total_number_of_subgroups))
 
         self._check_post()
 

--- a/tests/test_we_driver.py
+++ b/tests/test_we_driver.py
@@ -196,8 +196,8 @@ class TestWEDriver(TestCase):
 
         for ibin, bin in enumerate(self.we_driver.next_iter_binning):
             target_count = self.we_driver.bin_target_counts[ibin]
-            groups = self.we_driver.subgroup_function(self.we_driver, ibin, **self.we_driver.subgroup_function_kwargs)
-            self.we_driver._adjust_count(bin, groups, target_count)
+            subgroups = self.we_driver.subgroup_function(self.we_driver, ibin, **self.we_driver.subgroup_function_kwargs)
+            self.we_driver._adjust_count(bin, subgroups, target_count)
 
         assert len(self.we_driver.next_iter_binning[0]) == 5
         assert len(self.we_driver.next_iter_binning[1]) == 5


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Added functionality to the BinlessMapper to take `group_arguments` similar to how `subgroup` does it. This allows the `group_function` to take in extra keyword arguments than whatever's predefined.

In `west.cfg`, do the following:
```
mappers:
  - type: BinlessMapper
    group_arguments:
      link_type: average
      topology_path: /home/....
```
Also did some clean up to the `w_run.py` and `we_driver` code.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] moved the threshold argument checks to a separate method from process_args()
- [x] modify `w_run.py` so it'll actually output the error message (instead of being obscured by the exception)
- [x] Modified the `BinlessMapper` to take `group_arguments` similar to how `subgroup` does it

**Major files changed.**  
- [x] src/westpa/core/we_driver.py
- [x] src/westpa/core/binning/binless.py
- [x] src/westpa/cli/core/w_run.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

