### PR TITLE
MABBinMapper Fix for restarting a partially-completed iteration

### DIFF
--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -181,7 +181,12 @@ def map_mab(coords, mask, output, *args, **kwargs):
                     elif bin_number < 0:
                         bin_number = 0
                 elif bin_number >= nbins or bin_number < 0:
-                    raise ValueError("Walker out of boundary")
+                    if np.isclose(bins[-1], coord):
+                        bin_number = nbins - 1
+                    elif np.isclose(bins[0], coord):
+                        bin_number = 0
+                    else:
+                        raise ValueError("Walker out of boundary")
 
                 holder += bin_number * np.prod(nbins_per_dim[:n])
 

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -10,10 +10,10 @@ def map_mab(coords, mask, output, *args, **kwargs):
     evenly spaced bins between the segments with the min and max pcoord values. Extrema and
     bottleneck segments are assigned their own bins.'''
 
-    pca = kwargs.pop("pca", False)
-    bottleneck = kwargs.pop("bottleneck", True)
-    direction = kwargs.pop("direction", None)
-    nbins_per_dim = kwargs.pop("nbins_per_dim")
+    pca = kwargs.get("pca", False)
+    bottleneck = kwargs.get("bottleneck", True)
+    direction = kwargs.get("direction", None)
+    nbins_per_dim = kwargs.get("nbins_per_dim", None)
 
     if nbins_per_dim is None:
         raise ValueError("nbins_per_dim is missing")
@@ -175,10 +175,13 @@ def map_mab(coords, mask, output, *args, **kwargs):
                 bins = np.linspace(minp, maxp, nbins + 1)
                 bin_number = np.digitize(coord, bins) - 1
 
-                if bin_number >= nbins:
-                    bin_number = nbins - 1
-                elif bin_number < 0:
-                    bin_number = 0
+                if isfinal is None or not isfinal[i]:
+                    if bin_number >= nbins:
+                        bin_number = nbins - 1
+                    elif bin_number < 0:
+                        bin_number = 0
+                elif bin_number >= nbins or bin_number < 0:
+                    raise ValueError("Walker out of boundary")
 
                 holder += bin_number * np.prod(nbins_per_dim[:n])
 

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -4,6 +4,8 @@ from westpa.core.binning.mab import MABBinMapper
 from westpa.core.sim_manager import WESimManager, grouper
 from westpa.core.states import InitialState, pare_basis_initial_states
 from westpa.core import wm_ops
+from westpa.core.segment import Segment
+import numpy as np
 
 log = logging.getLogger(__name__)
 
@@ -82,3 +84,84 @@ class MABSimManager(WESimManager):
         log.debug('done with propagation')
         self.save_bin_data()
         self.data_manager.flush_backing()
+
+    def prepare_iteration(self):
+        log.debug('beginning iteration {:d}'.format(self.n_iter))
+
+        # the WE driver needs a list of all target states for this iteration
+        # along with information about any new weights introduced (e.g. by recycling)
+        target_states = self.data_manager.get_target_states(self.n_iter)
+        new_weights = self.data_manager.get_new_weight_data(self.n_iter)
+
+        self.we_driver.new_iteration(target_states=target_states, new_weights=new_weights)
+
+        # Get basis states used in this iteration
+        self.current_iter_bstates = self.data_manager.get_basis_states(self.n_iter)
+
+        # Get the segments for this iteration and separate into complete and incomplete
+        if self.segments is None:
+            segments = self.segments = {segment.seg_id: segment for segment in self.data_manager.get_segments()}
+            log.debug('loaded {:d} segments'.format(len(segments)))
+        else:
+            segments = self.segments
+            log.debug('using {:d} pre-existing segments'.format(len(segments)))
+
+        completed_segments = self.completed_segments = {}
+        incomplete_segments = self.incomplete_segments = {}
+        for segment in segments.values():
+            if segment.status == Segment.SEG_STATUS_COMPLETE:
+                completed_segments[segment.seg_id] = segment
+            else:
+                incomplete_segments[segment.seg_id] = segment
+        log.debug('{:d} segments are complete; {:d} are incomplete'.format(len(completed_segments), len(incomplete_segments)))
+
+        if len(incomplete_segments) == len(segments):
+            # Starting a new iteration
+            self.rc.pstatus('Beginning iteration {:d}'.format(self.n_iter))
+        elif incomplete_segments:
+            self.rc.pstatus('Continuing iteration {:d}'.format(self.n_iter))
+        self.rc.pstatus(
+            '{:d} segments remain in iteration {:d} ({:d} total)'.format(len(incomplete_segments), self.n_iter, len(segments))
+        )
+
+        # Get the initial states active for this iteration (so that the propagator has them if necessary)
+        self.current_iter_istates = {
+            state.state_id: state for state in self.data_manager.get_segment_initial_states(list(segments.values()))
+        }
+        log.debug('This iteration uses {:d} initial states'.format(len(self.current_iter_istates)))
+
+        # Assign this iteration's segments' initial points to bins and report on bin population
+        initial_pcoords = self.system.new_pcoord_array(len(segments))
+        initial_binning = self.system.bin_mapper.construct_bins()
+        for iseg, segment in enumerate(segments.values()):
+            initial_pcoords[iseg] = segment.pcoord[0]
+        initial_assignments = self.system.bin_mapper.assign(initial_pcoords)
+        for (segment, assignment) in zip(iter(segments.values()), initial_assignments):
+            initial_binning[assignment].add(segment)
+        self.report_bin_statistics(initial_binning, save_summary=True)
+        del initial_pcoords, initial_binning
+
+        # Let the WE driver assign completed segments
+        if completed_segments and len(incomplete_segments) == 0:
+            self.we_driver.assign(list(completed_segments.values()))
+
+        # load restart data
+        self.data_manager.prepare_segment_restarts(
+            incomplete_segments.values(), self.current_iter_bstates, self.current_iter_istates
+        )
+
+        # Get the basis states and initial states for the next iteration, necessary for doing on-the-fly recycling
+        self.next_iter_bstates = self.data_manager.get_basis_states(self.n_iter + 1)
+        self.next_iter_bstate_cprobs = np.add.accumulate([bstate.probability for bstate in self.next_iter_bstates])
+
+        self.we_driver.avail_initial_states = {
+            istate.state_id: istate for istate in self.data_manager.get_unused_initial_states(n_iter=self.n_iter + 1)
+        }
+        log.debug('{:d} unused initial states found'.format(len(self.we_driver.avail_initial_states)))
+
+        # Invoke callbacks
+        self.invoke_callbacks(self.prepare_iteration)
+
+        # dispatch and immediately wait on result for prep_iter
+        log.debug('dispatching propagator prep_iter to work manager')
+        self.work_manager.submit(wm_ops.prep_iter, args=(self.n_iter, segments)).get_result()


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#239 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
`MABBinMapper` will assign segment twice on a restarted simulation with a partially completed iteration, once only on completed segments from the partially completed iteration, once after all of them are propagated. This will lead to trajectories with a probability of more than 1.

I've subclassed the `sim_manager` to include the `prepare_iteration()` so the BinMapper will not attempt to run assign an extra time on an incompletely simulated iteration. This didn't matter to the regular schemes because it only takes into account of the pcoord of each segment so both assignments are identical. Not the case for MAB since it depends on the pcoord of all of the segs in that iteration.

The other change is to add back code that was deleted during the MAB one-direction PR (#239). Introduced extra checks that catches segs that are mapped incorrectly due to floating point error before completely ValueError - ing out.

The `pop` > `get` change should prevent some kwargs from disappearing/changing during the simulation.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fix issue where simulation consistently crashes with MAB after restart.

**Major files changed.**  
- [x] src/westpa/core/binning/mab.py
- [x] src/westpa/core/binning/mab_manager.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

