### PR TITLE
Added a MAB option to "skip" splitting in a specified pcoord dimension

### DIFF
--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -3,6 +3,8 @@ from westpa.core.binning import FuncBinMapper
 import westpa
 import logging
 
+log = logging.getLogger('westpa.rc')
+
 
 def map_mab(coords, mask, output, *args, **kwargs):
     '''Binning which adaptively places bins based on the positions of extrema segments and
@@ -25,13 +27,13 @@ def map_mab(coords, mask, output, *args, **kwargs):
         direction = [0] * ndim
     elif len(direction) != ndim:
         direction = [0] * ndim
-        logging.warn("Direction list is not the correct dimensions, setting to defaults.")
+        log.warn("Direction list is not the correct dimensions, setting to defaults.")
 
     if skip is None:
         skip = [0] * ndim
     elif len(skip) != ndim:
         skip = [0] * ndim
-        logging.warn("Skip list is not the correct dimensions, setting to defaults.")
+        log.warn("Skip list is not the correct dimensions, setting to defaults.")
 
     if not np.any(mask):
         return output

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -3,7 +3,7 @@ from westpa.core.binning import FuncBinMapper
 import westpa
 import logging
 
-log = logging.getLogger('westpa.rc')
+log = logging.getLogger(__name__)
 
 
 def map_mab(coords, mask, output, *args, **kwargs):

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -1,6 +1,7 @@
 import numpy as np
 from westpa.core.binning import FuncBinMapper
 import westpa
+import logging
 
 
 def map_mab(coords, mask, output, *args, **kwargs):
@@ -22,9 +23,15 @@ def map_mab(coords, mask, output, *args, **kwargs):
     ndim = len(nbins_per_dim)
     if direction is None:
         direction = [0] * ndim
+    elif len(direction) != ndim:
+        direction = [0] * ndim
+        logging.warn("Direction list is not the correct dimensions, setting to defaults.")
 
     if skip is None:
         skip = [0] * ndim
+    elif len(skip) != ndim:
+        skip = [0] * ndim
+        logging.warn("Skip list is not the correct dimensions, setting to defaults.")
 
     if not np.any(mask):
         return output
@@ -139,7 +146,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
             for n in range(ndim):
                 coord = allcoords[i][n]
 
-                if skip[n] > 0:
+                if skip[n] != 0:
                     holder = skip_base + 2 * n
                     break
 
@@ -178,7 +185,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
         if not special:
             for n in range(ndim):
 
-                if skip[n] > 0:
+                if skip[n] != 0:
                     holder = skip_base + 2 * n
                     break
 


### PR DESCRIPTION
This PR adds an option to skip binning in a specified dimension of the progress coordinate when using MAB.  It simply checks on a per-dimension basis if the user has specified a skip and if so just assigns all walkers in that dimension to the same bin (so therefore no splitting occurs outside of that single bin). This is useful for cases where a user needs to track a value for recycling purposes but doesn't want to bin along it and incur the cost associated with an added pcoord dimension.

To use this new feature, add an option under the MABBinMapper section as follows:

`skip: [0]`

Where the list provided for skip has a value for each pcoord dimension and 0 is split as normal and 1 is skip splitting in this dimension.

**Major files changed.**  
- [ ] mab.py

**Status.**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

