### PR TITLE
Fix recycling when using HDF5 Framework

### DIFF
--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -3,7 +3,7 @@ from westpa.core.binning import FuncBinMapper
 from westpa.core.extloader import get_object
 import logging
 
-log = logging.getLogger('westpa.rc')
+log = logging.getLogger(__name__)
 
 
 def map_binless(coords, mask, output, *args, **kwargs):

--- a/src/westpa/core/binning/binless_driver.py
+++ b/src/westpa/core/binning/binless_driver.py
@@ -12,6 +12,7 @@ class BinlessDriver(WEDriver):
         initial states. This function is adapted to the MAB scheme, so that the inital and final segments are
         sent to the bin mapper at the same time, otherwise the inital and final bin boundaries can be inconsistent.'''
 
+        log.debug("BinlessDriver in use.")
         # collect initial and final coordinates into one place
         n_segments = len(segments)
         all_pcoords = np.empty((n_segments * 2, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)

--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -1,5 +1,6 @@
 import logging
 
+from westpa.core.binning.binless import BinlessMapper
 from westpa.core.sim_manager import WESimManager, grouper
 from westpa.core.states import InitialState, pare_basis_initial_states
 from westpa.core import wm_ops
@@ -10,11 +11,21 @@ log = logging.getLogger(__name__)
 
 
 class BinlessSimManager(WESimManager):
+    def initialize_simulation(self, basis_states, target_states, start_states, segs_per_state=1, suppress_we=False):
+        if len(target_states) > 0:
+            if isinstance(self.system.bin_mapper, BinlessMapper):
+                log.error("BinlessMapper cannot be an outer binning scheme with a target state.\n")
+
+        super().initialize_simulation(
+            basis_states, target_states, start_states, segs_per_state=segs_per_state, suppress_we=suppress_we
+        )
+
     def report_bin_statistics(self, bins, save_summary=False):
         self.rc.pstatus("Binless scheme in use.")
         super().report_bin_statistics(bins, save_summary)
 
     def propagate(self):
+        log.debug("BinlessManager in use.")
         segments = list(self.incomplete_segments.values())
         log.debug('iteration {:d}: propagating {:d} segments'.format(self.n_iter, len(segments)))
 

--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -24,6 +24,9 @@ determine how to access data even as the file format (i.e. organization of data 
 evolves.
 
 Version history:
+    Version 9
+        - Basis states are now saved as iter_segid instead of just segid as a pointer label.
+        - Initial states are also saved in the iteration 0 file, with a negative sign.
     Version 8
         - Added external links to trajectory files in iterations/iter_* groups, if the HDF5
           framework was used.
@@ -62,7 +65,7 @@ import westpa
 
 log = logging.getLogger(__name__)
 
-file_format_version = 8
+file_format_version = 9
 
 makepath = ExecutablePropagator.makepath
 
@@ -689,7 +692,6 @@ class WESTDataManager:
                         n_iter=-state.iter_created,
                         seg_id=state.state_id,
                         parent_id=state.basis_state_id,
-                        weight=state.basis_state.probability,
                         wtg_parent_ids=None,
                         pcoord=state.pcoord,
                         status=Segment.SEG_STATUS_PREPARED,


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
When HDF5 Framework is enabled, the simulation will crash right after a recycling event. WESTPA tries to create dummy istate segment objects purely for saving the istates into `iter_000000.h5` but accidentally asks for a property that does not exist. It was something irrelevant so it was removed.

Also buckled in a few changes like upping the file version number to 9 (indicating #238 breaks compatibility) and changing the logger for `binless.py` to itself.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Bug fixes and streamlines.

**Major files changed.**  
- [x] src/westpa/core/binning/binless.py
- [x] src/westpa/core/data_manager.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

