### PR TITLE
Fixes to Processes Manager on MacOS

### DIFF
--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -31,6 +31,14 @@ class ProcessWorkManager(WorkManager):
 
     def __init__(self, n_workers=None, shutdown_timeout=1):
         super().__init__()
+
+        try:
+            if sys.platform == 'darwin':  # MacOS
+                multiprocessing.set_start_method('fork')
+                log.debug('setting multiprocessing start method to fork')
+        except RuntimeError:
+            log.debug('failed to set start method to fork')
+
         self.n_workers = n_workers or multiprocessing.cpu_count()
         self.workers = None
         self.task_queue = multiprocessing.Queue()

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -21,7 +21,22 @@ result_shutdown_sentinel = ('shutdown', None, None)
 
 
 class ProcessWorkManager(WorkManager):
-    '''A work manager using the ``multiprocessing`` module.'''
+    '''A work manager using the ``multiprocessing`` module.
+    
+    Notes
+    -----
+    
+    On MacOS, as of Python 3.8 the default start method for multiprocessing launching new processes was changed from fork to spawn. 
+    In general, spawn is more robust and efficient, however it requires serializability of everything being passed to the child process.
+    In contrast, fork is much less memory efficient, as it makes a full copy of everything in the parent process. 
+    However, it does not require picklability.
+    
+    So, on MacOS, the method for launching new processes is explicitly changed to fork from the (MacOS-specific) default of spawn.
+    Unix should default to fork.
+    
+    See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods and 
+    https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods for more details.
+    '''
 
     @classmethod
     def from_environ(cls, wmenv=None):

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -22,19 +22,19 @@ result_shutdown_sentinel = ('shutdown', None, None)
 
 class ProcessWorkManager(WorkManager):
     '''A work manager using the ``multiprocessing`` module.
-    
+
     Notes
     -----
-    
-    On MacOS, as of Python 3.8 the default start method for multiprocessing launching new processes was changed from fork to spawn. 
+
+    On MacOS, as of Python 3.8 the default start method for multiprocessing launching new processes was changed from fork to spawn.
     In general, spawn is more robust and efficient, however it requires serializability of everything being passed to the child process.
-    In contrast, fork is much less memory efficient, as it makes a full copy of everything in the parent process. 
+    In contrast, fork is much less memory efficient, as it makes a full copy of everything in the parent process.
     However, it does not require picklability.
-    
+
     So, on MacOS, the method for launching new processes is explicitly changed to fork from the (MacOS-specific) default of spawn.
     Unix should default to fork.
-    
-    See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods and 
+
+    See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods and
     https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods for more details.
     '''
 


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#114

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Since Python >= 3.8, `multiprocessing` defaults to `spawn` on MacOS ([link](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods)). With `spawn`, new processes no longer share memory with their parents, leading to cases like in #114 when WESTPA is used with the `processes` work manager.

The downside to swapping back to the `fork` method (which is the default on other Unix systems) is that might [crash the whole subprocess](https://github.com/python/cpython/issues/77906). Currently, we suggest users to install python 3.7 on MacOS, which defaults to `fork` and puts us at the same risk anyways.

Added a few lines to swap to `fork` when it's on a mac since the alternative is either: 1) Rewrite `processes` so it runs well with `spawn` or 2) Not working.  1) seemed non-trivial and I think swapping back to `fork` is a nice compromise.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Make `Processes` work manager work on MacOS + Python >=3.8

**Major files changed.**  
- [x] src/westpa/work_managers/processes.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

