### PR TITLE
MAB bottleneck detection now obeys direction option

### DIFF
--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -153,14 +153,27 @@ def map_mab(coords, mask, output, *args, **kwargs):
                     break
 
                 if bottleneck:
-                    if coord == difflist[n]:
-                        holder = bottleneck_base + 2 * n
-                        special = True
-                        break
-                    elif coord == flipdifflist[n]:
-                        holder = bottleneck_base + 2 * n + 1
-                        special = True
-                        break
+                    if direction[n] < 0:
+                        if coord == flipdifflist[n]:
+                            holder = bottleneck_base + 2 * n
+                            special = True
+                            break
+
+                    if direction[n] > 0:
+                        if coord == difflist[n]:
+                            holder = bottleneck_base + 2 * n
+                            special = True
+                            break
+
+                    if direction[n] == 0:
+                        if coord == difflist[n]:
+                            holder = bottleneck_base + 2 * n
+                            special = True
+                            break
+                        elif coord == flipdifflist[n]:
+                            holder = bottleneck_base + 2 * n + 1
+                            special = True
+                            break
 
                 if direction[n] < 0:
                     if coord == minlist[n]:


### PR DESCRIPTION
This PR is adding a few lines in mab.py so the MAB direction option stops bottleneck splitting in unwanted directions. This was previously neglected, but is included here for completeness sake.

**Major files changed.**  
- [ ] mab.py

**Status.**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

