### PR TITLE
Make bin occupancy reporting accurate for all bin mapper types

### DIFF
--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -14,18 +14,14 @@ class BinlessSimManager(WESimManager):
     def initialize_simulation(self, basis_states, target_states, start_states, segs_per_state=1, suppress_we=False):
         if len(target_states) > 0:
             if isinstance(self.system.bin_mapper, BinlessMapper):
-                log.error("BinlessMapper cannot be an outer binning scheme with a target state.\n")
+                log.error("BinlessMapper cannot be an outer binning scheme with a target state\n")
 
         super().initialize_simulation(
             basis_states, target_states, start_states, segs_per_state=segs_per_state, suppress_we=suppress_we
         )
 
-    def report_bin_statistics(self, bins, save_summary=False):
-        self.rc.pstatus("Binless scheme in use.")
-        super().report_bin_statistics(bins, save_summary)
-
     def propagate(self):
-        log.debug("BinlessManager in use.")
+        log.debug("BinlessManager in use")
         segments = list(self.incomplete_segments.values())
         log.debug('iteration {:d}: propagating {:d} segments'.format(self.n_iter, len(segments)))
 
@@ -130,16 +126,7 @@ class BinlessSimManager(WESimManager):
         }
         log.debug('This iteration uses {:d} initial states'.format(len(self.current_iter_istates)))
 
-        # Assign this iteration's segments' initial points to bins and report on bin population
-        initial_pcoords = self.system.new_pcoord_array(len(segments))
-        initial_binning = self.system.bin_mapper.construct_bins()
-        for iseg, segment in enumerate(segments.values()):
-            initial_pcoords[iseg] = segment.pcoord[0]
-        initial_assignments = self.system.bin_mapper.assign(initial_pcoords)
-        for (segment, assignment) in zip(iter(segments.values()), initial_assignments):
-            initial_binning[assignment].add(segment)
-        self.report_bin_statistics(initial_binning, save_summary=True)
-        del initial_pcoords, initial_binning
+        self.rc.pstatus("Binless scheme in use")
 
         # Let the WE driver assign completed segments
         if completed_segments and len(incomplete_segments) == 0:
@@ -165,3 +152,36 @@ class BinlessSimManager(WESimManager):
         # dispatch and immediately wait on result for prep_iter
         log.debug('dispatching propagator prep_iter to work manager')
         self.work_manager.submit(wm_ops.prep_iter, args=(self.n_iter, segments)).get_result()
+
+    def finalize_iteration(self):
+        '''Clean up after an iteration and prepare for the next.'''
+        log.debug('finalizing iteration {:d}'.format(self.n_iter))
+
+        self.invoke_callbacks(self.finalize_iteration)
+
+        # dispatch and immediately wait on result for post_iter
+        log.debug('dispatching propagator post_iter to work manager')
+        self.work_manager.submit(wm_ops.post_iter, args=(self.n_iter, list(self.segments.values()))).get_result()
+
+        # re-assign segments after splitting and merging to report on bin stats
+        # note that this was moved here from prepare_iteration for more accurate
+        # bin population reporting
+        segments = self.segments = {segment.seg_id: segment for segment in self.data_manager.get_segments()}
+
+        n_segments = len(segments)
+        all_pcoords = np.empty((n_segments, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
+
+        for iseg, segment in enumerate(segments.values()):
+            all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 1.0])
+
+        final_binning = self.system.bin_mapper.construct_bins()
+        final_assignments = self.system.bin_mapper.assign(all_pcoords)
+        for (segment, assignment) in zip(iter(segments.values()), final_assignments):
+            final_binning[assignment].add(segment)
+
+        self.report_bin_statistics(final_binning, [], save_summary=True)
+        del all_pcoords, final_binning
+
+        # Move existing segments into place as new segments
+        del self.segments
+        self.segments = {segment.seg_id: segment for segment in self.we_driver.next_iter_segments}

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -89,7 +89,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
         temp = temp[sorted_indices]
         for p in range(len(temp)):
             if temp[p][1] == 0:
-                temp[p][1] = 10**-39
+                temp[p][1] = 10**-323
         fliptemp = np.flipud(temp)
 
         difflist.append(None)

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -252,14 +252,13 @@ class MABBinMapper(FuncBinMapper):
     def __init__(self, nbins, direction=None, skip=None, bottleneck=True, pca=False):
         kwargs = dict(nbins_per_dim=nbins, direction=direction, skip=skip, bottleneck=bottleneck, pca=pca)
         ndim = len(nbins)
-
         # the following is neccessary because functional bin mappers need to "reserve"
         # bins and tell the sim manager how many bins they will need to use, this is
         # determined by taking all direction/skipping info into account
         n_total_bins = np.prod(nbins)
         for i in range(0, ndim):
-            if skip[i] == 0:
-                if direction[i] != 0:
+            if skip is None or skip[i] == 0:
+                if direction is not None and direction[i] != 0:
                     n_total_bins += 1 + 1 * bottleneck
                 else:
                     n_total_bins += 2 + 2 * bottleneck

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -74,7 +74,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
         temp = temp[sorted_indices]
         for p in range(len(temp)):
             if temp[p][1] == 0:
-                temp[p][1] = 10**-323
+                temp[p][1] = 10**-39
         fliptemp = np.flipud(temp)
 
         difflist.append(None)

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -258,8 +258,8 @@ class MABBinMapper(FuncBinMapper):
         # determined by taking all direction/skipping info into account
         n_total_bins = np.prod(nbins)
         for i in range(0, ndim):
-            if skip is None or skip[i] == 0:
-                if direction is not None and direction[i] != 0:
+            if skip[i] == 0:
+                if direction[i] != 0:
                     n_total_bins += 1 + 1 * bottleneck
                 else:
                     n_total_bins += 2 + 2 * bottleneck

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -240,5 +240,13 @@ class MABBinMapper(FuncBinMapper):
     def __init__(self, nbins, direction=None, skip=None, bottleneck=True, pca=False):
         kwargs = dict(nbins_per_dim=nbins, direction=direction, skip=skip, bottleneck=bottleneck, pca=pca)
         ndim = len(nbins)
-        n_total_bins = np.prod(nbins) + ndim * (2 + 2 * bottleneck)
+        n_total_bins = np.prod(nbins)
+        for i in range(0, ndim):
+            if skip[i] == 0:
+                if direction[i] != 0:
+                    n_total_bins += 1 + 1 * bottleneck
+                else:
+                    n_total_bins += 2 + 2 * bottleneck
+            else:
+                n_total_bins -= np.prod(nbins) - 1
         super().__init__(map_mab, n_total_bins, kwargs=kwargs)

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -12,27 +12,12 @@ def map_mab(coords, mask, output, *args, **kwargs):
     evenly spaced bins between the segments with the min and max pcoord values. Extrema and
     bottleneck segments are assigned their own bins.'''
 
-    pca = kwargs.get("pca", False)
-    bottleneck = kwargs.get("bottleneck", True)
-    direction = kwargs.get("direction", None)
-    skip = kwargs.get("skip", None)
-    nbins_per_dim = kwargs.get("nbins_per_dim", None)
-
-    if nbins_per_dim is None:
-        raise ValueError("nbins_per_dim is missing")
-
+    pca = kwargs.get("pca")
+    bottleneck = kwargs.get("bottleneck")
+    direction = kwargs.get("direction")
+    skip = kwargs.get("skip")
+    nbins_per_dim = kwargs.get("nbins_per_dim")
     ndim = len(nbins_per_dim)
-    if direction is None:
-        direction = [0] * ndim
-    elif len(direction) != ndim:
-        direction = [0] * ndim
-        log.warn("Direction list is not the correct dimensions, setting to defaults.")
-
-    if skip is None:
-        skip = [0] * ndim
-    elif len(skip) != ndim:
-        skip = [0] * ndim
-        log.warn("Skip list is not the correct dimensions, setting to defaults.")
 
     if not np.any(mask):
         return output
@@ -250,8 +235,24 @@ class MABBinMapper(FuncBinMapper):
     to their own bins.'''
 
     def __init__(self, nbins, direction=None, skip=None, bottleneck=True, pca=False):
-        kwargs = dict(nbins_per_dim=nbins, direction=direction, skip=skip, bottleneck=bottleneck, pca=pca)
+        # Verifying parameters
+        if nbins is None:
+            raise ValueError("nbins_per_dim is missing")
         ndim = len(nbins)
+
+        if direction is None:
+            direction = [0] * ndim
+        elif len(direction) != ndim:
+            direction = [0] * ndim
+            log.warn("Direction list is not the correct dimensions, setting to defaults.")
+
+        if skip is None:
+            skip = [0] * ndim
+        elif len(skip) != ndim:
+            skip = [0] * ndim
+            log.warn("Skip list is not the correct dimensions, setting to defaults.")
+
+        kwargs = dict(nbins_per_dim=nbins, direction=direction, skip=skip, bottleneck=bottleneck, pca=pca)
         # the following is neccessary because functional bin mappers need to "reserve"
         # bins and tell the sim manager how many bins they will need to use, this is
         # determined by taking all direction/skipping info into account

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -172,7 +172,7 @@ class MABSimManager(WESimManager):
         all_pcoords = np.empty((n_segments, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
 
         for iseg, segment in enumerate(segments.values()):
-            all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 1.0])
+            all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, InitialState.ISTATE_STATUS_PREPARED])
 
         final_binning = self.system.bin_mapper.construct_bins()
         final_assignments = self.system.bin_mapper.assign(all_pcoords)

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -14,18 +14,14 @@ class MABSimManager(WESimManager):
     def initialize_simulation(self, basis_states, target_states, start_states, segs_per_state=1, suppress_we=False):
         if len(target_states) > 0:
             if isinstance(self.system.bin_mapper, MABBinMapper):
-                log.error("MABBinMapper cannot be an outer binning scheme with a target state.\n")
+                log.error("MABBinMapper cannot be an outer binning scheme with a target state\n")
 
         super().initialize_simulation(
             basis_states, target_states, start_states, segs_per_state=segs_per_state, suppress_we=suppress_we
         )
 
-    def report_bin_statistics(self, bins, target_states, save_summary=False):
-        self.rc.pstatus("MAB binning in use.")
-        super().report_bin_statistics(bins, target_states, save_summary)
-
     def propagate(self):
-        log.debug("MABSimManager in use.")
+        log.debug("MABSimManager in use")
         segments = list(self.incomplete_segments.values())
         log.debug('iteration {:d}: propagating {:d} segments'.format(self.n_iter, len(segments)))
 
@@ -130,23 +126,7 @@ class MABSimManager(WESimManager):
         }
         log.debug('This iteration uses {:d} initial states'.format(len(self.current_iter_istates)))
 
-        # Assign this iteration's segments' initial points to bins and report on bin population
-
-        n_segments = len(segments)
-        all_pcoords = np.empty((n_segments, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
-
-        for iseg, segment in enumerate(segments.values()):
-            all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 1.0])
-
-        #        print(all_pcoords)
-
-        initial_binning = self.system.bin_mapper.construct_bins()
-        initial_assignments = self.system.bin_mapper.assign(all_pcoords)
-        for (segment, assignment) in zip(iter(segments.values()), initial_assignments):
-            initial_binning[assignment].add(segment)
-        #        self.report_bin_statistics(initial_binning, [], save_summary=True)
-        del all_pcoords, initial_binning
-        #        del initial_pcoords, initial_binning
+        self.rc.pstatus("MAB binning in use")
 
         # Let the WE driver assign completed segments
         if completed_segments and len(incomplete_segments) == 0:
@@ -183,6 +163,9 @@ class MABSimManager(WESimManager):
         log.debug('dispatching propagator post_iter to work manager')
         self.work_manager.submit(wm_ops.post_iter, args=(self.n_iter, list(self.segments.values()))).get_result()
 
+        # re-assign segments after splitting and merging to report on bin stats
+        # note that this was moved here from prepare_iteration for more accurate
+        # bin population reporting
         segments = self.segments = {segment.seg_id: segment for segment in self.data_manager.get_segments()}
 
         n_segments = len(segments)

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -126,7 +126,23 @@ class MABSimManager(WESimManager):
         }
         log.debug('This iteration uses {:d} initial states'.format(len(self.current_iter_istates)))
 
+        n_segments = len(segments)
+        pcoords_with_weights = np.empty((n_segments, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
+
+        for iseg, segment in enumerate(segments.values()):
+            pcoords_with_weights[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 1.0])
+
+        # Assign this iteration's segments' initial points to bins and report on bin population
+        initial_binning = self.system.bin_mapper.construct_bins()
+        initial_assignments = self.system.bin_mapper.assign(pcoords_with_weights)
+        for (segment, assignment) in zip(iter(segments.values()), initial_assignments):
+            initial_binning[assignment].add(segment)
+        self.report_bin_statistics(initial_binning, [], save_summary=True)
+        del pcoords_with_weights, initial_binning
+
         self.rc.pstatus("MAB binning in use")
+
+        self.rc.pstatus("Bottleneck bin occupancy may not be accurately reported")
 
         self.rc.pstatus("Waiting for segments to complete...")
 
@@ -154,37 +170,3 @@ class MABSimManager(WESimManager):
         # dispatch and immediately wait on result for prep_iter
         log.debug('dispatching propagator prep_iter to work manager')
         self.work_manager.submit(wm_ops.prep_iter, args=(self.n_iter, segments)).get_result()
-
-    def finalize_iteration(self):
-        '''Clean up after an iteration and prepare for the next.'''
-        log.debug('finalizing iteration {:d}'.format(self.n_iter))
-
-        self.invoke_callbacks(self.finalize_iteration)
-
-        # dispatch and immediately wait on result for post_iter
-        log.debug('dispatching propagator post_iter to work manager')
-        self.work_manager.submit(wm_ops.post_iter, args=(self.n_iter, list(self.segments.values()))).get_result()
-
-        # Move existing segments into place as new segments
-        del self.segments
-        segments = self.segments = {segment.seg_id: segment for segment in self.we_driver.next_iter_segments}
-
-        # re-assign segments after splitting and merging to report on bin stats
-        # note that this was moved here from prepare_iteration for more accurate
-        # bin population reporting
-
-        n_segments = len(segments)
-        all_pcoords = np.empty((n_segments, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
-
-        for iseg, segment in enumerate(segments.values()):
-            all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 1.0])
-
-        final_binning = self.system.bin_mapper.construct_bins()
-        final_assignments = self.system.bin_mapper.assign(all_pcoords)
-        for (segment, assignment) in zip(iter(segments.values()), final_assignments):
-            final_binning[assignment].add(segment)
-
-        self.rc.pstatus("Iteration completed successfully")
-
-        self.report_bin_statistics(final_binning, [], save_summary=True)
-        del all_pcoords, final_binning

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -128,6 +128,8 @@ class MABSimManager(WESimManager):
 
         self.rc.pstatus("MAB binning in use")
 
+        self.rc.pstatus("Waiting for segments to complete...")
+
         # Let the WE driver assign completed segments
         if completed_segments and len(incomplete_segments) == 0:
             self.we_driver.assign(list(completed_segments.values()))
@@ -163,10 +165,13 @@ class MABSimManager(WESimManager):
         log.debug('dispatching propagator post_iter to work manager')
         self.work_manager.submit(wm_ops.post_iter, args=(self.n_iter, list(self.segments.values()))).get_result()
 
+        # Move existing segments into place as new segments
+        del self.segments
+        segments = self.segments = {segment.seg_id: segment for segment in self.we_driver.next_iter_segments}
+
         # re-assign segments after splitting and merging to report on bin stats
         # note that this was moved here from prepare_iteration for more accurate
         # bin population reporting
-        segments = self.segments = {segment.seg_id: segment for segment in self.data_manager.get_segments()}
 
         n_segments = len(segments)
         all_pcoords = np.empty((n_segments, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
@@ -179,9 +184,7 @@ class MABSimManager(WESimManager):
         for (segment, assignment) in zip(iter(segments.values()), final_assignments):
             final_binning[assignment].add(segment)
 
+        self.rc.pstatus("Iteration completed successfully")
+
         self.report_bin_statistics(final_binning, [], save_summary=True)
         del all_pcoords, final_binning
-
-        # Move existing segments into place as new segments
-        del self.segments
-        self.segments = {segment.seg_id: segment for segment in self.we_driver.next_iter_segments}

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -138,17 +138,15 @@ class MABSimManager(WESimManager):
         for iseg, segment in enumerate(segments.values()):
             all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 1.0])
 
-        print(all_pcoords)
+        #        print(all_pcoords)
 
-        initial_pcoords = self.system.new_pcoord_array(len(segments))
         initial_binning = self.system.bin_mapper.construct_bins()
-        for iseg, segment in enumerate(segments.values()):
-            initial_pcoords[iseg] = segment.pcoord[0]
         initial_assignments = self.system.bin_mapper.assign(all_pcoords)
         for (segment, assignment) in zip(iter(segments.values()), initial_assignments):
             initial_binning[assignment].add(segment)
-        self.report_bin_statistics(initial_binning, [], save_summary=True)
-        del initial_pcoords, initial_binning
+        #        self.report_bin_statistics(initial_binning, [], save_summary=True)
+        del all_pcoords, initial_binning
+        #        del initial_pcoords, initial_binning
 
         # Let the WE driver assign completed segments
         if completed_segments and len(incomplete_segments) == 0:
@@ -174,3 +172,33 @@ class MABSimManager(WESimManager):
         # dispatch and immediately wait on result for prep_iter
         log.debug('dispatching propagator prep_iter to work manager')
         self.work_manager.submit(wm_ops.prep_iter, args=(self.n_iter, segments)).get_result()
+
+    def finalize_iteration(self):
+        '''Clean up after an iteration and prepare for the next.'''
+        log.debug('finalizing iteration {:d}'.format(self.n_iter))
+
+        self.invoke_callbacks(self.finalize_iteration)
+
+        # dispatch and immediately wait on result for post_iter
+        log.debug('dispatching propagator post_iter to work manager')
+        self.work_manager.submit(wm_ops.post_iter, args=(self.n_iter, list(self.segments.values()))).get_result()
+
+        segments = self.segments = {segment.seg_id: segment for segment in self.data_manager.get_segments()}
+
+        n_segments = len(segments)
+        all_pcoords = np.empty((n_segments, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
+
+        for iseg, segment in enumerate(segments.values()):
+            all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 1.0])
+
+        final_binning = self.system.bin_mapper.construct_bins()
+        final_assignments = self.system.bin_mapper.assign(all_pcoords)
+        for (segment, assignment) in zip(iter(segments.values()), final_assignments):
+            final_binning[assignment].add(segment)
+
+        self.report_bin_statistics(final_binning, [], save_summary=True)
+        del all_pcoords, final_binning
+
+        # Move existing segments into place as new segments
+        del self.segments
+        self.segments = {segment.seg_id: segment for segment in self.we_driver.next_iter_segments}

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -161,13 +161,17 @@ class WESimManager:
                 plugin = extloader.get_object(plugin_name)(self, plugin_config)
                 log.debug('loaded plugin {!r}'.format(plugin))
 
-    def report_bin_statistics(self, bins, save_summary=False):
+    def report_bin_statistics(self, bins, target_states, save_summary=False):
         segments = list(self.segments.values())
         bin_counts = np.fromiter(map(len, bins), dtype=np.int_, count=len(bins))
         target_counts = self.we_driver.bin_target_counts
 
         # Do not include bins with target count zero (e.g. sinks, never-filled bins) in the (non)empty bins statistics
         n_active_bins = len(target_counts[target_counts != 0])
+
+        if target_states:
+            n_active_bins -= len(target_states)
+
         seg_probs = np.fromiter(map(operator.attrgetter('weight'), segments), dtype=weight_dtype, count=len(segments))
         bin_probs = np.fromiter(map(operator.attrgetter('weight'), bins), dtype=weight_dtype, count=len(bins))
         norm = seg_probs.sum()
@@ -366,6 +370,9 @@ class WESimManager:
         bin_occupancies = np.fromiter(map(len, binning), dtype=np.uint, count=self.we_driver.bin_mapper.nbins)
         target_occupancies = np.require(self.we_driver.bin_target_counts, dtype=np.uint)
 
+        total_bins = len(bin_occupancies) - len(target_states)
+        total_replicas = int(sum(target_occupancies)) - int(self.we_driver.bin_target_counts[-1]) * len(target_states)
+
         # Make sure we have
         for segment in segments:
             segment.n_iter = 1
@@ -387,11 +394,11 @@ class WESimManager:
         Initial replicas:      {init_replicas:d} in {occ_bins:d} bins, total weight = {weight:g}
         Total target replicas: {total_replicas:d}
         '''.format(
-                total_bins=len(bin_occupancies),
+                total_bins=total_bins,
                 init_replicas=int(sum(bin_occupancies)),
                 occ_bins=len(bin_occupancies[bin_occupancies > 0]),
                 weight=float(sum(segment.weight for segment in segments)),
-                total_replicas=int(sum(target_occupancies)),
+                total_replicas=total_replicas,
             )
         )
 
@@ -415,7 +422,7 @@ class WESimManager:
         # Report statistics
         pstatus('Simulation prepared.')
         self.segments = {segment.seg_id: segment for segment in segments}
-        self.report_bin_statistics(binning, save_summary=True)
+        self.report_bin_statistics(binning, target_states, save_summary=True)
         data_manager.flush_backing()
         data_manager.close_backing()
 
@@ -472,7 +479,7 @@ class WESimManager:
         initial_assignments = self.system.bin_mapper.assign(initial_pcoords)
         for (segment, assignment) in zip(iter(segments.values()), initial_assignments):
             initial_binning[assignment].add(segment)
-        self.report_bin_statistics(initial_binning, save_summary=True)
+        self.report_bin_statistics(initial_binning, [], save_summary=True)
         del initial_pcoords, initial_binning
 
         # Let the WE driver assign completed segments


### PR DESCRIPTION
**Describe the changes made.**   
The bin reporting for MAB was inaccurate (and was reserving more bins than it needed if direction or skip was being used). This PR fixes that and makes MAB bin occupancy reporting 100% accurate.

I also made initialization bin occupancy reporting by not recognizing target states as active bins.

I also moved the bin population log file reporting to finalize_iteration instead of prepare_iteration. This fixes issues with inconsistencies between pre and post-we bin occupations, and makes more sense in the context of adaptive binning schemes.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [ ] Testing with multiple target states
- [ ] Testing with > 1D progress coordinate

**Major files changed.**  
- [ ] sim_manager.py
- [ ] mab.py
- [ ] mab_manager.py
- [ ] binless.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

