### PR TITLE
Fix for HDF5MDTrajectory(trace)

### DIFF
--- a/src/westpa/analysis/trajectories.py
+++ b/src/westpa/analysis/trajectories.py
@@ -335,7 +335,7 @@ class HDF5MDTrajectory(Trajectory):
 
         super().__init__(fget)
 
-        self.segment_collector.use_threads = True
+        self.segment_collector.use_threads = False
         self.segment_collector.show_progress = True
 
 


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
There are problems when attempting to retrieve a `HDF5MDTrajectory()` object of `walker.trace()` on some Linux computers. It seems to be tied to h5py having trouble with threading, and `get_segment()` unable to access the coordinates at the same time (or something). Each futures result is some sort of `HDF5ExtError` and will almost always lead to a segmentation fault.

Tried and it works with a make-shift `ProcessPoolExecutor`, but that provides no benefit to I/O bound tasks (like getting segment coordinates) so the easiest fix is to turn it off. Just add in a `use_threads=True` argument if you want to turn it back on. :) It does work on macs.


To test, run the following. Do note there were some recent breaking changes to the HDF5 Framework:
```
from westpa.analysis import Run, HDF5MDTrajectory
run = Run('west.h5')
walker = run.iteration(3).walker(4)
trace = walker.trace()
traj = HDF5MDTrajectory()
traj(trace)
```

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Have HDF5MDTrajectory(walker.trace()) work out of the box.

**Major files changed.**  
- [x] src/westpa/analysis/trajectories.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

