### PR TITLE
fixes for mab split and mab_log reporting

### DIFF
--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -112,7 +112,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
                     flipdifflist[n] = fliptemp[i][0]
                     flipmaxdiff = flipdiff
 
-    if mab_log and report and splitting:
+    if mab_log and report:
         westpa.rc.pstatus("################ MAB stats ################")
         westpa.rc.pstatus("minima in each dimension:      {}".format(minlist))
         westpa.rc.pstatus("maxima in each dimension:      {}".format(maxlist))

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -112,14 +112,14 @@ def map_mab(coords, mask, output, *args, **kwargs):
                     flipdifflist[n] = fliptemp[i][0]
                     flipmaxdiff = flipdiff
 
-            if mab_log and report:
-                westpa.rc.pstatus("################ MAB stats ################")
-                westpa.rc.pstatus("minima in each dimension:      {}".format(minlist))
-                westpa.rc.pstatus("maxima in each dimension:      {}".format(maxlist))
-                westpa.rc.pstatus("direction in each dimension:   {}".format(direction))
-                westpa.rc.pstatus("skip in each dimension:        {}".format(skip))
-                westpa.rc.pstatus("###########################################")
-                westpa.rc.pflush()
+    if mab_log and report and splitting:
+        westpa.rc.pstatus("################ MAB stats ################")
+        westpa.rc.pstatus("minima in each dimension:      {}".format(minlist))
+        westpa.rc.pstatus("maxima in each dimension:      {}".format(maxlist))
+        westpa.rc.pstatus("direction in each dimension:   {}".format(direction))
+        westpa.rc.pstatus("skip in each dimension:        {}".format(skip))
+        westpa.rc.pstatus("###########################################")
+        westpa.rc.pflush()
 
     # assign segments to bins
     # the total number of linear bins is the boundary base
@@ -280,4 +280,5 @@ class MABBinMapper(FuncBinMapper):
                     n_total_bins += 2 + 2 * bottleneck
             else:
                 n_total_bins -= nbins[i] - 1
+                n_total_bins += 1 * ndim  # or else it will be one bin short
         super().__init__(map_mab, n_total_bins, kwargs=kwargs)


### PR DESCRIPTION
This PR fixes a bug in the MAB scheme's "skip" feature, wherein the number of bins reserved by MAB was one short of what was required. This was simply an oversight on my part when I was previously cleaning up the code. I have tested in one and two dimensions and it should now work.

Additionally, I fixed a minor bug where mab_log stats were printed on a per-dimension basis.  They are now only printed once per iteration and contain information for all dimensions.

**Major files changed.**  
- [x] mab.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

