### PR TITLE
Complete rewrite of weight min/max threshold portions of resampler

### DIFF
--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -198,7 +198,7 @@ class WESimManager:
 
         if min_seg_prob < 1e-100:
             log.warning(
-                '\n Minimum segment weight is < 1e-100 and might not be physically relevant. Please reconsider your progress coordinate or binning scheme.'
+                '\nMinimum segment weight is < 1e-100 and might not be physically relevant. Please reconsider your progress coordinate or binning scheme.'
             )
 
         if save_summary:

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -687,9 +687,6 @@ class WEDriver:
 
                 if len(subgroups) > target_count:
                     self._adjust_count(bin, subgroups, target_count)
-                if self.do_thresholds:
-                    self._split_by_threshold(bin, subgroups, target_count)
-                    self._merge_by_threshold(bin, subgroups, target_count)
 
             if len(subgroups) < target_count:
                 for i in subgroups:
@@ -700,9 +697,14 @@ class WEDriver:
                 if self.do_adjust_counts:
                     # A modified adjustment routine is necessary to ensure we don't unnecessarily destroy trajectory pathways.
                     self._adjust_count(bin, subgroups, target_count)
-                if self.do_thresholds:
-                    self._split_by_threshold(bin, subgroups, target_count)
-                    self._merge_by_threshold(bin, subgroups, target_count)
+            if self.do_thresholds:
+                self._split_by_threshold(bin, subgroups, target_count)
+                self._merge_by_threshold(bin, subgroups, target_count)
+                for iseg in bin:
+                    if iseg.weight > self.largest_allowed_weight or iseg.weight < self.smallest_allowed_weight:
+                        log.warning(
+                            f'Unable to fulfill threshold conditions for {iseg}. The given threshold range is likely too small.'
+                        )
             total_number_of_particles += len(bin)
         log.debug('Total number of subgroups: {!r}'.format(total_number_of_subgroups))
 

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -598,35 +598,37 @@ class WEDriver:
                     if len(bin) == target_count:
                         break
 
-    def _merge_by_threshold(self, bin):
+    def _merge_by_threshold(self, bin, subgroup):
         # merge to satisfy weight thresholds
         # this gets rid of weights that are too small
         while True:
-            segments = np.array(sorted(bin, key=operator.attrgetter('weight')), dtype=np.object_)
+            segments = np.array(sorted(subgroup, key=operator.attrgetter('weight')), dtype=np.object_)
             weights = np.array(list(map(operator.attrgetter('weight'), segments)))
             cumul_weight = np.add.accumulate(weights)
 
             to_merge = segments[weights < self.smallest_allowed_weight]
             if len(to_merge) < 2:
-                print('break here')
                 return
             bin.difference_update(to_merge)
+            subgroup.difference_update(to_merge)
             new_segment, parent = self._merge_walkers(to_merge, cumul_weight, bin)
             bin.add(new_segment)
+            subgroup.add(new_segment)
 
-    def _split_by_threshold(self, bin):
+    def _split_by_threshold(self, bin, subgroup):
         # split to satisfy weight thresholds
         # this splits walkers that are too big
-        segments = np.array(sorted(bin, key=operator.attrgetter('weight')), dtype=np.object_)
+        segments = np.array(sorted(subgroup, key=operator.attrgetter('weight')), dtype=np.object_)
         weights = np.array(list(map(operator.attrgetter('weight'), segments)))
-        print(segments)
 
         to_split = segments[weights > self.largest_allowed_weight]
         for segment in to_split:
             m = int(math.ceil(segment.weight / self.largest_allowed_weight))
             bin.remove(segment)
+            subgroup.remove(segment)
             new_segments_list = self._split_walker(segment, m, bin)
             bin.update(new_segments_list)
+            subgroup.update(new_segments_list)
 
     def _check_pre(self):
         for ibin, _bin in enumerate(self.next_iter_binning):
@@ -696,12 +698,10 @@ class WEDriver:
                 if self.do_adjust_counts:
                     # A modified adjustment routine is necessary to ensure we don't unnecessarily destroy trajectory pathways.
                     self._adjust_count(bin, subgroups, target_count)
-            bin.clear()
             if self.do_thresholds:
                 for i in subgroups:
-                    self._split_by_threshold(i)
-                    self._merge_by_threshold(i)
-                    bin.update(i)
+                    self._split_by_threshold(bin, i)
+                    self._merge_by_threshold(bin, i)
                 for iseg in bin:
                     if iseg.weight > self.largest_allowed_weight or iseg.weight < self.smallest_allowed_weight:
                         log.warning(

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -606,7 +606,7 @@ class WEDriver:
             weights = np.array(list(map(operator.attrgetter('weight'), segments)))
             cumul_weight = np.add.accumulate(weights)
 
-            to_merge = segments[weights <= self.smallest_allowed_weight]
+            to_merge = segments[weights < self.smallest_allowed_weight]
             if len(to_merge) < 2:
                 return
             bin.difference_update(to_merge)

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -131,8 +131,13 @@ class WEDriver:
 
         config.require_type_if_present(['west', 'we', 'adjust_counts'], bool)
 
+        config.require_type_if_present(['west', 'we', 'thresholds'], bool)
+
         self.do_adjust_counts = config.get(['west', 'we', 'adjust_counts'], True)
         log.info('Adjust counts to exactly match target_counts: {}'.format(self.do_adjust_counts))
+
+        self.do_thresholds = config.get(['west', 'we', 'thresholds'], False)
+        log.info('Obey abolute weight thresholds: {}'.format(self.do_thresholds))
 
         self.weight_split_threshold = config.get(['west', 'we', 'weight_split_threshold'], self.weight_split_threshold)
         log.info('Split threshold: {}'.format(self.weight_split_threshold))
@@ -528,15 +533,7 @@ class WEDriver:
             m = int(math.ceil(segment.weight / ideal_weight))
             bin.remove(segment)
             new_segments_list = self._split_walker(segment, m, bin)
-            # for i in new_segments_list:
-            #   print(i.weight)
-            # print(self.smallest_allowed_weight)
-            if all(new_segment.weight < self.smallest_allowed_weight for new_segment in new_segments_list):
-                # print("instance of threshold break (bw)")
-                bin.add(segment)
-            else:
-                # print("no threshold break (bw)")
-                bin.update(new_segments_list)
+            bin.update(new_segments_list)
 
     def _merge_by_weight(self, bin, target_count, ideal_weight, number_of_subgroups):
         '''Merge underweight particles'''
@@ -551,12 +548,7 @@ class WEDriver:
                 return
             bin.difference_update(to_merge)
             new_segment, parent = self._merge_walkers(to_merge, cumul_weight, bin)
-            if new_segment.weight > self.largest_allowed_weight:
-                # print("instance of threshold break (bw)")
-                bin.add(to_merge)
-            else:
-                # print("no threshold break (bw)")
-                bin.add(new_segment)
+            bin.add(new_segment)
 
     def _adjust_count(self, bin, subgroups, target_count):
         weight_getter = operator.attrgetter('weight')
@@ -569,11 +561,8 @@ class WEDriver:
             sorted_subgroups = sorted(subgroups, key=lambda gp: sum(seg.weight for seg in gp))
         # Loops over the groups, splitting/merging until the proper count has been reached.  This way, no trajectories are accidentally destroyed.
 
-        threshold_target_count = target_count
-
         # split
-        while len(bin) < threshold_target_count:
-            last_bin = len(bin)
+        while len(bin) < target_count:
             for i in sorted_subgroups:
                 log.debug('adjusting counts by splitting')
                 # always split the highest probability walker into two
@@ -581,28 +570,14 @@ class WEDriver:
                 bin.remove(segments[-1])
                 i.remove(segments[-1])
                 new_segments_list = self._split_walker(segments[-1], 2, bin)
-
-                if all(new_segment.weight < self.smallest_allowed_weight for new_segment in new_segments_list):
-                    # print("instance of threshold break (ac)")
-                    bin.add(segments[-1])
-                    i.add(segments[-1])
-                else:
-                    # print("no threshold break (ac)")
-                    i.update(new_segments_list)
-                    bin.update(new_segments_list)
+                i.update(new_segments_list)
+                bin.update(new_segments_list)
 
                 if len(bin) == target_count:
                     break
-                elif i == sorted_subgroups[-1] and last_bin == len(
-                    bin
-                ):  # If the last "for" iteration didn't change anything, soft-break.
-                    threshold_target_count = len(bin)
-
-        threshold_target_count = target_count
 
         # merge
-        while len(bin) > threshold_target_count:
-            last_bin = len(bin)
+        while len(bin) > target_count:
             sorted_subgroups.reverse()
             # Adjust to go from lowest weight group to highest to merge
             for i in sorted_subgroups:
@@ -614,24 +589,49 @@ class WEDriver:
                     bin.difference_update(segments[:2])
                     i.difference_update(segments[:2])
                     merged_segment, parent = self._merge_walkers(segments[:2], cumul_weight=None, bin=bin)
-
-                    if merged_segment.weight > self.largest_allowed_weight:
-                        # print("instance of threshold break (bw)")
-                        bin.add(segments[:2])
-                    else:
-                        # print("no threshold break (bw)")
-                        i.add(merged_segment)
-                        bin.add(merged_segment)
+                    i.add(merged_segment)
+                    bin.add(merged_segment)
 
                     # As long as we're changing the merge_walkers and split_walkers, adjust them so that they don't update the bin within the function
                     # and instead update the bin here.  Assuming nothing else relies on those.  Make sure with grin.
                     # in bash, "find . -name \*.py | xargs fgrep -n '_merge_walkers'"
                     if len(bin) == target_count:
                         break
-                    elif i == sorted_subgroups[-1] and last_bin == len(
-                        bin
-                    ):  # If the last "for" iteration didn't change anything, soft-break.
-                        threshold_target_count = len(bin)
+
+    def _thresholds_check(self, bin, subgroups, target_count):
+
+        # split to satisfy weight thresholds
+        # this splits walkers that are too big
+        while True:
+            segments = np.array(sorted(bin, key=operator.attrgetter('weight')), dtype=np.object_)
+            weights = np.array(list(map(operator.attrgetter('weight'), segments)))
+
+            if len(bin) > 0:
+                assert target_count > 0
+
+            to_split = segments[weights > self.largest_allowed_weight]
+            if len(to_split) < 1:
+                return
+            for segment in to_split:
+                # m = int(math.ceil(segment.weight / self.largest_allowed_weight))
+                m = 2
+                bin.remove(segment)
+                new_segments_list = self._split_walker(segment, m, bin)
+                bin.update(new_segments_list)
+
+        # merge to satisfy weight thresholds
+        # this gets rid of weights that are too small
+        while True:
+            segments = np.array(sorted(bin, key=operator.attrgetter('weight')), dtype=np.object_)
+            weights = np.array(list(map(operator.attrgetter('weight'), segments)))
+            cumul_weight = np.add.accumulate(weights)
+
+            to_merge = segments[cumul_weight <= self.smallest_allowed_weight]
+            if len(to_merge) < 2:
+                return
+            bin.difference_update(to_merge)
+            new_segment, parent = self._merge_walkers(to_merge, cumul_weight, bin)
+            bin.add(new_segment)
 
     def _check_pre(self):
         for ibin, _bin in enumerate(self.next_iter_binning):
@@ -700,6 +700,8 @@ class WEDriver:
                 if self.do_adjust_counts:
                     # A modified adjustment routine is necessary to ensure we don't unnecessarily destroy trajectory pathways.
                     self._adjust_count(bin, subgroups, target_count)
+                if self.do_thresholds:
+                    self._thresholds_check(bin, subgroups, target_count)
             total_number_of_particles += len(bin)
         log.debug('Total number of subgroups: {!r}'.format(total_number_of_subgroups))
 

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -606,7 +606,7 @@ class WEDriver:
             weights = np.array(list(map(operator.attrgetter('weight'), segments)))
             cumul_weight = np.add.accumulate(weights)
 
-            to_merge = segments[cumul_weight <= self.smallest_allowed_weight]
+            to_merge = segments[weights <= self.smallest_allowed_weight]
             if len(to_merge) < 2:
                 return
             bin.difference_update(to_merge)
@@ -691,6 +691,10 @@ class WEDriver:
 
                 if len(subgroups) > target_count:
                     self._adjust_count(bin, subgroups, target_count)
+                if self.do_thresholds:
+                    self._split_by_threshold(bin, subgroups, target_count)
+                    self._merge_by_threshold(bin, subgroups, target_count)
+
             if len(subgroups) < target_count:
                 for i in subgroups:
                     self._split_by_weight(i, target_count, ideal_weight, len(subgroups))

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -616,22 +616,18 @@ class WEDriver:
     def _split_by_threshold(self, bin, subgroups, target_count):
         # split to satisfy weight thresholds
         # this splits walkers that are too big
-        while True:
-            segments = np.array(sorted(bin, key=operator.attrgetter('weight')), dtype=np.object_)
-            weights = np.array(list(map(operator.attrgetter('weight'), segments)))
+        segments = np.array(sorted(bin, key=operator.attrgetter('weight')), dtype=np.object_)
+        weights = np.array(list(map(operator.attrgetter('weight'), segments)))
 
-            if len(bin) > 0:
-                assert target_count > 0
+        if len(bin) > 0:
+            assert target_count > 0
 
-            to_split = segments[weights > self.largest_allowed_weight]
-            if len(to_split) < 1:
-                return
-            for segment in to_split:
-                # m = int(math.ceil(segment.weight / self.largest_allowed_weight))
-                m = 2
-                bin.remove(segment)
-                new_segments_list = self._split_walker(segment, m, bin)
-                bin.update(new_segments_list)
+        to_split = segments[weights > self.largest_allowed_weight]
+        for segment in to_split:
+            m = int(math.ceil(segment.weight / self.largest_allowed_weight))
+            bin.remove(segment)
+            new_segments_list = self._split_walker(segment, m, bin)
+            bin.update(new_segments_list)
 
     def _check_pre(self):
         for ibin, _bin in enumerate(self.next_iter_binning):


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
The weight threshold portions of the code is moved  from the Huber/Kim portions of the resampler into its own independent methods (and rewritten to respect subgroups). It is executed after the H/K algorithm and adjust_count().

Also slipped in some syntax fixes like a typo in the sim_manager and code cleanup to the split/merge_by_weight() methods.

Note that the thresholds is enabled by default so we don't hit the 64-bit floating point limit for weights. If you don't want this to run, just add to your west.cfg:

```
west:
  we:
    thresholds: false
```


**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fix weight threshold
- [x] Typo fix to the low weight warning
- [x] remove unused arguments for the split/merge_by_weight methods

**Major files changed.**  
- [x] src/westpa/core/we_driver.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

Co-authored-by: Anthony Bogetti <anthony.bogetti@gmail.com>