### PR TITLE
w_assign fix for newest pyyaml version load() function deprecation

### DIFF
--- a/src/westpa/cli/tools/w_assign.py
+++ b/src/westpa/cli/tools/w_assign.py
@@ -353,7 +353,7 @@ Command-line options
     def load_state_file(self, state_filename):
         import yaml
 
-        ydict = yaml.safe_load(open(state_filename, 'rt'))
+        ydict = yaml.load(open(state_filename, 'rt'), Loader=yaml.Loader)
         ystates = ydict['states']
         self.states_from_dict(ystates)
 

--- a/src/westpa/cli/tools/w_assign.py
+++ b/src/westpa/cli/tools/w_assign.py
@@ -353,7 +353,7 @@ Command-line options
     def load_state_file(self, state_filename):
         import yaml
 
-        ydict = yaml.load(open(state_filename, 'rt'))
+        ydict = yaml.safe_load(open(state_filename, 'rt'))
         ystates = ydict['states']
         self.states_from_dict(ystates)
 

--- a/src/westpa/tools/binning.py
+++ b/src/westpa/tools/binning.py
@@ -90,7 +90,7 @@ def mapper_from_hdf5(topol_group, hashval):
 def mapper_from_yaml(yamlfilename):
     import yaml
 
-    ydict = yaml.safe_load(open(yamlfilename, 'rt'))
+    ydict = yaml.load(open(yamlfilename, 'rt'), Loader=yaml.Loader)
     ybins = ydict['bins']
     from westpa.core._rc import bins_from_yaml_dict
 

--- a/src/westpa/tools/binning.py
+++ b/src/westpa/tools/binning.py
@@ -90,7 +90,7 @@ def mapper_from_hdf5(topol_group, hashval):
 def mapper_from_yaml(yamlfilename):
     import yaml
 
-    ydict = yaml.load(open(yamlfilename, 'rt'))
+    ydict = yaml.safe_load(open(yamlfilename, 'rt'))
     ybins = ydict['bins']
     from westpa.core._rc import bins_from_yaml_dict
 

--- a/src/westpa/tools/core.py
+++ b/src/westpa/tools/core.py
@@ -200,7 +200,7 @@ class WESTMultiTool(WESTParallelTool):
         import yaml
 
         with open(yamlfilepath, 'r') as yamlfile:
-            self.yamlargdict = yaml.load(yamlfile)
+            self.yamlargdict = yaml.safe_load(yamlfile)
         # add in options here for intelligent processing of files
 
     def add_args(self, parser):

--- a/src/westpa/tools/core.py
+++ b/src/westpa/tools/core.py
@@ -200,7 +200,7 @@ class WESTMultiTool(WESTParallelTool):
         import yaml
 
         with open(yamlfilepath, 'r') as yamlfile:
-            self.yamlargdict = yaml.safe_load(yamlfile)
+            self.yamlargdict = yaml.load(yamlfile, Loader=yaml.Loader)
         # add in options here for intelligent processing of files
 
     def add_args(self, parser):


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
N/A

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Added `Loader` to `yaml.load()` because using `yaml.load()` without a `Loader` is deprecated:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Not using `yaml.safe_load()` because `a = yaml.safe_load('''- !!python/float "32" ''')` wouldn't work but `a = yaml.load('''- !!python/float "32" ''', Loader=yaml.Loader)` would.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [ ] 

**Major files changed.**  
- [ ]

**Status.**
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

