### PR TITLE
Fix to recycling events reporting undercounting

### DIFF
--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -695,11 +695,12 @@ class WESimManager:
         recycling_events = {}
         for nw in self.we_driver.new_weights:
             try:
-                recycling_events[nw.target_state_id].add(nw.weight)
+                recycling_events[nw.target_state_id].append(nw.weight)
             except KeyError:
-                recycling_events[nw.target_state_id] = set([nw.weight])
+                recycling_events[nw.target_state_id] = list(nw.weight)
 
         tstates_by_id = {state.state_id: state for state in self.we_driver.target_states.values()}
+
         for tstate_id, weights in recycling_events.items():
             tstate = tstates_by_id[tstate_id]
             self.rc.pstatus(


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Recycling events reporting under-counts when multiple segments have the exact same weight. This is because a set only allows for unique elements. The sets in `recycling_events` are now replaced by lists to allow for duplication.

This seems to be isolated to the reporting in the `west.log`. The behavior of `w_succ` and other parts of the resampler are consistent and work as expected.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fix recycling reporting output

**Major files changed.**  
- [x] /src/westpa/sim_manager.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

