### PR TITLE
modify westpa.analysis's hardcoded bytestring decode to h5io.tostr

### DIFF
--- a/src/westpa/analysis/core.py
+++ b/src/westpa/analysis/core.py
@@ -4,7 +4,7 @@ import pandas as pd
 import sys
 
 from westpa.core.binning.assign import BinMapper
-from westpa.core.h5io import WESTPAH5File
+from westpa.core.h5io import WESTPAH5File, tostr
 from westpa.core.segment import Segment
 from westpa.core.states import BasisState, InitialState, TargetState
 from westpa.tools.binning import mapper_from_hdf5
@@ -298,8 +298,8 @@ class Iteration:
     def basis_state_summaries(self):
         """pd.DataFrame: Basis state summary data."""
         df = pd.DataFrame(self.h5group['ibstates']['bstate_index'][:])
-        df['label'] = df['label'].str.decode('UTF-8')
-        df['auxref'] = df['auxref'].str.decode('UTF-8')
+        df['label'] = tostr(df['label'].str)
+        df['auxref'] = tostr(df['auxref'].str)
         return df
 
     @property
@@ -325,7 +325,8 @@ class Iteration:
         """pd.DataFrame or None: Target state summary data."""
         if self.has_target_states:
             df = pd.DataFrame(self.h5group['tstates']['index'][:])
-            df['label'] = df['label'].str.decode('UTF-8')
+            df['label'] = tostr(df['label'].str)
+
             return df
         else:
             return None
@@ -405,10 +406,10 @@ class Iteration:
         row = self.h5group['ibstates']['bstate_index'][index]
         pcoord = self.h5group['ibstates']['bstate_pcoord'][index]
         return BasisState(
-            row['label'].decode(),
+            tostr(row['label']),
             row['probability'],
             pcoord=pcoord,
-            auxref=row['auxref'].decode(),
+            auxref=tostr(row['auxref']),
             state_id=index,
         )
 
@@ -428,7 +429,7 @@ class Iteration:
         """
         row = self.h5group['tstates']['index'][index]
         pcoord = self.h5group['tstates']['pcoord'][index]
-        return TargetState(row['label'].decode(), pcoord, state_id=index)
+        return TargetState(tostr(row['label']), pcoord, state_id=index)
 
     def __iter__(self):
         return iter(self.walkers)


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
`westpa.analysis` assumes that all labels are bytestrings... I had an odd one that wasn't (for some reason). Swapped to the `h5io.tostr()` that allows strings to pass through.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Allow for cases where labels aren't bytestrings in westpa.analysis

**Major files changed.**  
- [x] src/westpa/analysis/core.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

