### PR TITLE
Combine ibstates dataset in w_multi_west

### DIFF
--- a/doc/documentation/cli/w_multi_west.rst
+++ b/doc/documentation/cli/w_multi_west.rst
@@ -9,7 +9,7 @@ Overview
 usage::
 
  w_multi_west [-h] [-m master] [-n sims] [--quiet | --verbose | --debug] [--version] 
-              [-W WEST_H5FILE] [-a aux] [--auxall]
+              [-W WEST_H5FILE] [-a aux] [--auxall] [--ibstates]
               [--serial | --parallel | --work-manager WORK_MANAGER] [--n-workers N_WORKERS]
               [--zmq-mode MODE] [--zmq-comm-mode COMM_MODE] [--zmq-write-host-info INFO_FILE]
               [--zmq-read-host-info INFO_FILE] [--zmq-upstream-rr-endpoint ENDPOINT]
@@ -63,6 +63,10 @@ Both input and output files are *hdf5* format::
 
   -nr, --no-reweight
     Do not perform reweighting. (Default: False)
+
+  -ib, --ibstates
+    Attempt to combine ``ibstates`` dataset if the basis states are identical across 
+    all simulations. Needed when tracing with ``westpa.analysis``. (Default: False)
 
 Examples
 --------

--- a/src/westpa/cli/tools/w_multi_west.py
+++ b/src/westpa/cli/tools/w_multi_west.py
@@ -1,20 +1,3 @@
-# Copyright (C) 2013 Matthew C. Zwier and Lillian T. Chong
-#
-# This file is part of WESTPA.
-#
-# WESTPA is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# WESTPA is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with WESTPA.  If not, see <http://www.gnu.org/licenses/>.
-
 import logging
 import numpy as np
 import pickle

--- a/src/westpa/cli/tools/w_multi_west.py
+++ b/src/westpa/cli/tools/w_multi_west.py
@@ -235,7 +235,7 @@ Command-line options
                 del self.output_file['ibstates/0/istate_pcoord']
                 del self.output_file['ibstates/0/istate_index']
 
-                # Combining athe rest of the istate datasets
+                # Combining the rest of the istate datasets
                 for ifile, (key, west) in enumerate(self.westH5.items()):
                     if ifile == 0:
                         final_istate_index = west['ibstates/0/istate_index']

--- a/src/westpa/cli/tools/w_multi_west.py
+++ b/src/westpa/cli/tools/w_multi_west.py
@@ -216,6 +216,7 @@ Command-line options
                     try:
                         if not np.array_equal(istate_pcoord, west['ibstates/0/istate_pcoord'][:]):  # noqa: F821
                             self.istate = False
+                            self.ibstates = False
                     except UnboundLocalError:
                         istate_pcoord = west['ibstates/0/istate_pcoord'][:]  # noqa: F841
 

--- a/tests/test_tools/test_w_multi_west.py
+++ b/tests/test_tools/test_w_multi_west.py
@@ -24,6 +24,7 @@ class Test_W_Multi_West:
                 aux=None,
                 auxall=True,
                 no_reweight=False,
+                ibstates=False,
             ),
         ):
             entry_point()


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
This PR adds an option to combine ibstates in `w_multi_west`.  This is important when you want to trace trajectories using `westpa.analysis`. Just add in the `--ibstates` flag when running `w_multi_west`

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] update `w_multi_west` with new functionality

**Major files changed.**  
- [x] src/westpa/cli/tools/w_multi_west.py
- [x] doc/documentation/cli/w_multi_west.rst
- [x] tests/test_tools/test_w_multi_west.py

**Status.**
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

