### PR TITLE
Move All CI tests to Mamba Forge

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [7, 8, 9, 10] # sub-versions of Python
+        python-version: [7, 8, 9, 10, 11] # sub-versions of Python
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [7, 8, 9, 10, 11] # sub-versions of Python
+        python-version: [7, 8, 9, 10] # sub-versions of Python
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
+        miniforge-variant: Mambaforge
         environment-file: devtools/conda-envs/test_env.yaml
         activate-environment: test_env
         channel-priority: true


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
https://github.com/westpa/westpa/pull/291#issuecomment-1387678692

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
See comment above. This moves the tests to mambaforge to a) circumvent miniconda+mamba incompatibilities shown [here](https://github.com/conda-incubator/setup-miniconda/issues/274) and b) Speed up the test process.

Example of CI working fine in my fork: https://github.com/jeremyleung521/westpa/actions/runs/3952491197. Slowest step is now installing test-installing WESTPA on mac making wheels for MDTraj and WESTPA. The CI tests each reduced by ~30s as they no longer have to resolve the mamba install.

Skipping wheels building for Py3.11 due to dependencies issues but added Py 3.11 testing onto the CI!

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Migrate CI tests to mamba forge
- [x] Add Python 3.11 to CI tests 

**Major files changed.**  
- [x] .github/workflows/test.yaml

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

