### PR TITLE
HOTFIX: w_multi_west istates logic

### DIFF
--- a/src/westpa/cli/tools/w_multi_west.py
+++ b/src/westpa/cli/tools/w_multi_west.py
@@ -176,6 +176,7 @@ Command-line options
             westh5 = []
             self.source_sinks = []
             self.n_sims = {}
+            istate_addition = [0]
             for ifile, (key, west) in enumerate(self.westH5.items()):
                 d = {'west': west, 'wm': None, 'rt': None, 'remove_next_cycle': [], 'seg_index': None}
                 # We're getting the bin mapper, then setting the recycling target...
@@ -199,6 +200,8 @@ Command-line options
                     self.niters = west.attrs['west_current_iteration'] - 1
                 else:
                     self.niters = min(west.attrs['west_current_iteration'] - 1, self.niters)
+
+                istate_addition.append(istate_addition[-1] + len(west['ibstates/0/istate_index']))
                 # Check to see if all the bstates are identical
                 if self.ibstates:
                     check = [False, False]  # Assuming they're false, so not accidentally outputing anything that errors out.
@@ -309,7 +312,7 @@ Command-line options
                         else:
                             addition = mseg.shape[0]
                         seg_index['parent_id'][np.where(seg_index['parent_id'] >= 0)] += addition
-                        seg_index['parent_id'][np.where(seg_index['parent_id'] < 0)] -= addition
+                        seg_index['parent_id'][np.where(seg_index['parent_id'] < 0)] -= istate_addition[ifile]
                         seg_index['wtg_offset'] += mwtg.shape[0]
                         start_point.append(mseg.shape[0])
                         wtgraph += mwtg.shape[0]


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
`w_multi_west` in its current form doesn't combine `parent_id`s <0 correctly. This means if you've been using something such as `westpa.analysis`, it's likely it had been fetching the wrong initial state and thus the wrong basis state. Here's a fix to that. If you've only had one basis state, this bug (theoretically) should have no effect on the results.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fix incorrect istates parent IDs after merging with `w_multi_west`

**Major files changed.**  
- [x] src/westpa/cli/tools/w_multi_west.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

