### PR TITLE
fix w_multi_west istate ids

### DIFF
--- a/lib/west_tools/w_multi_west.py
+++ b/lib/west_tools/w_multi_west.py
@@ -177,6 +177,7 @@ Command-line options
             westh5 = []
             self.source_sinks = []
             self.n_sims = {}
+            istate_addition = [0]
             for ifile, (key, west) in enumerate(self.westH5.items()):
                 d = { 'west': west, 'wm': None, 'rt': None, 'remove_next_cycle': [], 'seg_index': None}
                 # We're getting the bin mapper, then setting the recycling target...
@@ -200,6 +201,8 @@ Command-line options
                     self.niters = west.attrs['west_current_iteration'] - 1
                 else:
                     self.niters = min(west.attrs['west_current_iteration'] - 1, self.niters)
+                istate_addition.append(istate_addition[-1] + len(west['ibstates/0/istate_index']))
+
             start_point = []
             self.source_sinks = list(set(self.source_sinks))
             # We'll need a global list of walkers to add to and take care of during the next round of simulations, as well as the current one.
@@ -275,7 +278,7 @@ Command-line options
                         else:
                             addition = mseg.shape[0]
                         seg_index['parent_id'][np.where(seg_index['parent_id'] >= 0)] += addition
-                        seg_index['parent_id'][np.where(seg_index['parent_id'] < 0)] -= addition
+                        seg_index['parent_id'][np.where(seg_index['parent_id'] < 0)] -= istate_addition[ifile]
                         seg_index['wtg_offset'] += mwtg.shape[0]
                         start_point.append(mseg.shape[0])
                         wtgraph += mwtg.shape[0]


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#295 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Essentially #295 but for WESTPA 1.0.  Fixes so `w_multi_west` combines `parent_id`s < 0 correctly.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fix incorrect istates parent IDs after merging with `w_multi_west`

**Major files changed.**  
- [x] src/westpa/cli/tools/w_multi_west.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

