### PR TITLE
Bug fix to data manager when getting a subset of the segments

### DIFF
--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -1128,7 +1128,8 @@ class WESTDataManager:
                         ds = None
 
                     if ds is not None:
-                        for (seg_id, segment) in enumerate(segments):
+                        for segment in segments:
+                            seg_id = segment.seg_id
                             segment.data[dsname] = ds[seg_id]
 
         return segments


### PR DESCRIPTION
**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
The auxiliary coordinates can be wrong when getting a subset of the segments using `WEDataManager.get_segments`. For example, `data_manager.get_segments(1, seg_ids=[10, 11, 12])` would actually assign auxiliary coordinates of segments 0, 1, 2 to the output segments 10, 11, 12. This PR fixes this issue.

**Major files changed.**  
- [x] src/westpa/core/data_manager.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

