### PR TITLE
w_truncate CLI option to specify H5 filename

### DIFF
--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -23,8 +23,13 @@ def entry_point():
     )
 
     westpa.rc.add_args(parser)
-    parser.add_argument('-W', '--west-data', dest='we_h5filename', metavar='WEST_H5FILE',
-        help='''Take WEST data from WEST_H5FILE (default: read from the HDF5 file specified in west.cfg).''',)
+    parser.add_argument(
+        '-W',
+        '--west-data',
+        dest='we_h5filename',
+        metavar='WEST_H5FILE',
+        help='''Take WEST data from WEST_H5FILE (default: read from the HDF5 file specified in west.cfg).''',
+    )
     parser.add_argument('-n', '--iter', dest='n_iter', type=int, help='Truncate this iteration and those following.')
 
     args = parser.parse_args()

--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -23,10 +23,16 @@ def entry_point():
     )
 
     westpa.rc.add_args(parser)
+    parser.add_argument('-W', '--west-data', dest='we_h5filename', metavar='WEST_H5FILE',
+        help='''Take WEST data from WEST_H5FILE (default: read from the HDF5 file specified in west.cfg).''',)
     parser.add_argument('-n', '--iter', dest='n_iter', type=int, help='Truncate this iteration and those following.')
+
     args = parser.parse_args()
     westpa.rc.process_args(args, config_required=False)
     dm = westpa.rc.get_data_manager()
+    if args.we_h5filename:
+        dm.we_h5filename = args.we_h5filename
+
     dm.open_backing()
     # max_iter = dm.current_iteration
     n_iter = args.n_iter if args.n_iter > 0 else dm.current_iteration

--- a/tests/test_tools/test_w_truncate.py
+++ b/tests/test_tools/test_w_truncate.py
@@ -18,7 +18,7 @@ class Test_W_Truncate:
 
         with mock.patch(
             target='argparse.ArgumentParser.parse_args',
-            return_value=argparse.Namespace(verbosity='debug', rcfile=self.cfg_filepath, n_iter=2),
+            return_value=argparse.Namespace(verbosity='debug', rcfile=self.cfg_filepath, n_iter=2, we_h5filename=None),
         ):
             entry_point()
 


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
`w_truncate` requires the h5 file name to be specified through a west.cfg. This adds in an option to specify the file from the command line.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Allow `w_truncate` to accept h5file name from the commandline

**Major files changed.**  
- [x] src/westpa/cli/core/w_truncate.py

**Status.**
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

