### PR TITLE
Lower smallest allowed weight default

### DIFF
--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -81,7 +81,7 @@ class WEDriver:
     weight_split_threshold = 2.0
     weight_merge_cutoff = 1.0
     largest_allowed_weight = 1.0
-    smallest_allowed_weight = 1e-323
+    smallest_allowed_weight = 1e-320
 
     def __init__(self, rc=None, system=None):
         self.rc = rc or westpa.rc

--- a/src/westpa/core/we_driver.py
+++ b/src/westpa/core/we_driver.py
@@ -81,7 +81,7 @@ class WEDriver:
     weight_split_threshold = 2.0
     weight_merge_cutoff = 1.0
     largest_allowed_weight = 1.0
-    smallest_allowed_weight = 1e-320
+    smallest_allowed_weight = 1e-310
 
     def __init__(self, rc=None, system=None):
         self.rc = rc or westpa.rc


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Lowering the smallest_allowed_weight default to 1e-310 to prevent crashes. The current default of 1e-323 is too close to the float32 overflow limit such that simulations are still likely to crash. Note that this is not a hard limit. <strike>Segments can still get smaller than the limit. It's just that they are not longer be able to split further once they're under the limit.</strike>

EDITED with the more correct explanation:
WESTPA, while respecting the bins and subgroups, will attempt to merge all trajectories smaller than the threshold together until the resulting trajectory is within the threshold. The same is done by splitting trajectories larger than the define weight threshold.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Prevent crashes from low weight at default

**Major files changed.**  
- [x] src/westpa/core/we_driver.py

**Status.**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

