### PR TITLE
Fix for istate_futures race condition

### DIFF
--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -75,8 +75,23 @@ class BinlessSimManager(WESimManager):
                 log.error('unknown future {!r} received from work manager'.format(future))
                 raise AssertionError('untracked future {!r}'.format(future))
 
+        # Collectively assign all segments to their bins...
         self.we_driver.assign(self.segments.values())
-        self.get_istate_futures()
+
+        # For cases where we need even more istates for recycled trajectories
+        # futures should be empty at this point.
+        istate_gen_futures = self.get_istate_futures()
+        futures.update(istate_gen_futures)
+
+        while futures:
+            istate_gen_futures.remove(future)
+            _basis_state, initial_state = future.get_result()
+            log.debug('received newly-prepared initial state {!r}'.format(initial_state))
+            initial_state.istate_status = InitialState.ISTATE_STATUS_PREPARED
+            with self.data_manager.expiring_flushing_lock():
+                self.data_manager.update_initial_states([initial_state], n_iter=self.n_iter + 1)
+            self.we_driver.avail_initial_states[initial_state.state_id] = initial_state
+
         log.debug('done with propagation')
         self.save_bin_data()
         self.data_manager.flush_backing()

--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -83,14 +83,19 @@ class BinlessSimManager(WESimManager):
         istate_gen_futures = self.get_istate_futures()
         futures.update(istate_gen_futures)
 
+        # Wait for istate_gen_futures and catch untracked futures.
         while futures:
-            istate_gen_futures.remove(future)
-            _basis_state, initial_state = future.get_result()
-            log.debug('received newly-prepared initial state {!r}'.format(initial_state))
-            initial_state.istate_status = InitialState.ISTATE_STATUS_PREPARED
-            with self.data_manager.expiring_flushing_lock():
-                self.data_manager.update_initial_states([initial_state], n_iter=self.n_iter + 1)
-            self.we_driver.avail_initial_states[initial_state.state_id] = initial_state
+            if future in istate_gen_futures:
+                istate_gen_futures.remove(future)
+                _basis_state, initial_state = future.get_result()
+                log.debug('received newly-prepared initial state {!r}'.format(initial_state))
+                initial_state.istate_status = InitialState.ISTATE_STATUS_PREPARED
+                with self.data_manager.expiring_flushing_lock():
+                    self.data_manager.update_initial_states([initial_state], n_iter=self.n_iter + 1)
+                self.we_driver.avail_initial_states[initial_state.state_id] = initial_state
+            else:
+                log.error('unknown future {!r} received from work manager'.format(future))
+                raise AssertionError('untracked future {!r}'.format(future))
 
         log.debug('done with propagation')
         self.save_bin_data()

--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -85,6 +85,9 @@ class BinlessSimManager(WESimManager):
 
         # Wait for istate_gen_futures and catch untracked futures.
         while futures:
+            future = self.work_manager.wait_any(futures)
+            futures.remove(future)
+
             if future in istate_gen_futures:
                 istate_gen_futures.remove(future)
                 _basis_state, initial_state = future.get_result()

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -262,13 +262,13 @@ class MABBinMapper(FuncBinMapper):
             direction = [0] * ndim
         elif len(direction) != ndim:
             direction = [0] * ndim
-            log.warn("Direction list is not the correct dimensions, setting to defaults.")
+            log.warning("Direction list is not the correct dimensions, setting to defaults.")
 
         if skip is None:
             skip = [0] * ndim
         elif len(skip) != ndim:
             skip = [0] * ndim
-            log.warn("Skip list is not the correct dimensions, setting to defaults.")
+            log.warning("Skip list is not the correct dimensions, setting to defaults.")
 
         kwargs = dict(nbins_per_dim=nbins, direction=direction, skip=skip, bottleneck=bottleneck, pca=pca, mab_log=mab_log)
         # the following is neccessary because functional bin mappers need to "reserve"

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -85,6 +85,9 @@ class MABSimManager(WESimManager):
 
         # Wait for istate_gen_futures and catch untracked futures.
         while futures:
+            future = self.work_manager.wait_any(futures)
+            futures.remove(future)
+
             if future in istate_gen_futures:
                 istate_gen_futures.remove(future)
                 _basis_state, initial_state = future.get_result()

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -220,7 +220,7 @@ def load_west(filename):
 
             raw_pcoord = iter_group['pcoord'][:]
             if raw_pcoord.ndim != 3:
-                log.warn('pcoord is expected to be a 3-d ndarray instead of {}-d'.format(raw_pcoord.ndim))
+                log.warning('pcoord is expected to be a 3-d ndarray instead of {}-d'.format(raw_pcoord.ndim))
                 continue
             # ignore the first frame of each segment
             if raw_pcoord.shape[1] == traj.n_frames + 1:

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -439,7 +439,7 @@ class ZMQCore:
                 self.log.error('message validation falied: {!s}'.format(e))
                 sys.exit(1)
             elif self.validation_fail_action == 'warn':
-                self.log.warn('message validation falied: {!s}'.format(e))
+                self.log.warning('message validation falied: {!s}'.format(e))
 
     def recv_message(self, socket, flags=0, validate=True, timeout=None):
         '''Receive a message object from the given socket, using the given flags.

--- a/tests/fixtures/odld/odld_system.py
+++ b/tests/fixtures/odld/odld_system.py
@@ -4,6 +4,8 @@ from numpy.random import normal as random_normal
 from westpa.core.binning import RectilinearBinMapper
 from westpa.core.propagators import WESTPropagator
 from westpa.core.systems import WESTSystem
+from westpa.core.binning.mab import MABBinMapper
+from westpa.core.binning.binless import BinlessMapper
 
 PI = np.pi
 
@@ -101,5 +103,29 @@ class ODLDSystem(WESTSystem):
 
         # self.bin_mapper = RectilinearBinMapper([[0,1.3] + list(np.arange(1.4, 10.1, 0.1)) + [float('inf')]])
         self.bin_mapper = RectilinearBinMapper([list(np.arange(0.0, 10.1, 0.1))])
+        self.bin_target_counts = np.empty((self.bin_mapper.nbins,), np.int_)
+        self.bin_target_counts[...] = 10
+
+
+class MABODLDSystem(WESTSystem):
+    def initialize(self):
+        self.pcoord_ndim = 1
+        self.pcoord_dtype = pcoord_dtype
+        self.pcoord_len = pcoord_len
+
+        # self.bin_mapper = RectilinearBinMapper([[0,1.3] + list(np.arange(1.4, 10.1, 0.1)) + [float('inf')]])
+        self.bin_mapper = MABBinMapper([10])
+        self.bin_target_counts = np.empty((self.bin_mapper.nbins,), np.int_)
+        self.bin_target_counts[...] = 10
+
+
+class BinlessODLDSystem(WESTSystem):
+    def initialize(self):
+        self.pcoord_ndim = 1
+        self.pcoord_dtype = pcoord_dtype
+        self.pcoord_len = pcoord_len
+
+        # self.bin_mapper = RectilinearBinMapper([[0,1.3] + list(np.arange(1.4, 10.1, 0.1)) + [float('inf')]])
+        self.bin_mapper = BinlessMapper(ngroups=10, ndims=1, group_function='westpa.core.we_driver._group_walkers_identity')
         self.bin_target_counts = np.empty((self.bin_mapper.nbins,), np.int_)
         self.bin_target_counts[...] = 10

--- a/tests/fixtures/odld/west_binless.cfg
+++ b/tests/fixtures/odld/west_binless.cfg
@@ -1,0 +1,36 @@
+# The master WEST configuration file for a simulation.
+# vi: set filetype=yaml :
+---
+west: 
+  system:
+    driver: odld_system.BinlessODLDSystem
+    module_path: $WEST_SIM_ROOT
+  propagation:
+    max_total_iterations: 100
+    max_run_wallclock: 3:00:00
+    propagator: odld_system.ODLDPropagator
+    gen_istates: true
+    block_size: 10000
+  data:
+    west_data_file: west.h5
+    aux_compression_threshold: 16384 # data sets bigger than this are compressed
+                                     # unless overridden by an entry in ``datasets`` below
+    datasets: # dataset storage options
+      - name: displacement            # name used to refer to this in segment.data/env vars
+        #h5path: auxdata/displacement # HDF5 storage path, overrides default
+        #store: true                  # store when writing segment data (defaults to true)
+        #load:  true                  # load when reading segment data (defaults to false)
+        store: false
+        load: false
+        dtype: float32                # numpy dtype
+        compression: false            # whether to store compressed
+        scaleoffset: 4                # whether to store with scale/offset filter
+        chunks: null                  # custom chunking, or null for auto/no chunking
+                                      #  - ignored if necessary for other options
+      - name: pcoord                  # you can mess CAREFULLY with pcoord as well
+        scaleoffset: 4
+        
+    data_refs: # how to convert segments and states to paths, etc
+      segment:       $WEST_SIM_ROOT/traj_segs/{segment.n_iter:06d}/{segment.seg_id:06d}
+      basis_state:   $WEST_SIM_ROOT/bstates/{basis_state.auxref}
+      initial_state: $WEST_SIM_ROOT/istates/{initial_state.iter_created}/{initial_state.state_id}.gro

--- a/tests/fixtures/odld/west_mab.cfg
+++ b/tests/fixtures/odld/west_mab.cfg
@@ -1,0 +1,36 @@
+# The master WEST configuration file for a simulation.
+# vi: set filetype=yaml :
+---
+west: 
+  system:
+    driver: odld_system.MABODLDSystem
+    module_path: $WEST_SIM_ROOT
+  propagation:
+    max_total_iterations: 100
+    max_run_wallclock: 3:00:00
+    propagator: odld_system.ODLDPropagator
+    gen_istates: true
+    block_size: 10000
+  data:
+    west_data_file: west.h5
+    aux_compression_threshold: 16384 # data sets bigger than this are compressed
+                                     # unless overridden by an entry in ``datasets`` below
+    datasets: # dataset storage options
+      - name: displacement            # name used to refer to this in segment.data/env vars
+        #h5path: auxdata/displacement # HDF5 storage path, overrides default
+        #store: true                  # store when writing segment data (defaults to true)
+        #load:  true                  # load when reading segment data (defaults to false)
+        store: false
+        load: false
+        dtype: float32                # numpy dtype
+        compression: false            # whether to store compressed
+        scaleoffset: 4                # whether to store with scale/offset filter
+        chunks: null                  # custom chunking, or null for auto/no chunking
+                                      #  - ignored if necessary for other options
+      - name: pcoord                  # you can mess CAREFULLY with pcoord as well
+        scaleoffset: 4
+        
+    data_refs: # how to convert segments and states to paths, etc
+      segment:       $WEST_SIM_ROOT/traj_segs/{segment.n_iter:06d}/{segment.seg_id:06d}
+      basis_state:   $WEST_SIM_ROOT/bstates/{basis_state.auxref}
+      initial_state: $WEST_SIM_ROOT/istates/{initial_state.iter_created}/{initial_state.state_id}.gro


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
fixes #333 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Added a `while futures:` block to wait for istates generations after propagation in mab_manager and sim_manager.

<strike>Not extensively tested.</strike>

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Wait for istates_futures before moving on in mab/binless managers
- [x] ODLD Tests for `mab_manager` and `binless_manager`...
- [x] replaced instances of deprecated `logging.warn` with `logging.warning`

**Major files changed.**  
- [x] src/westpa/core/binning/binless_manager.py
- [x] src/westpa/core/binning/mab_manager.py
- [x] tests
- [x] See below

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

