### PR TITLE
add check for hdf5 where formats can be both topology and traj

### DIFF
--- a/src/westpa/core/trajectory.py
+++ b/src/westpa/core/trajectory.py
@@ -293,12 +293,20 @@ def load_trajectory(folder):
     trajectory file contains topology data (e.g., HDF5 format).
     '''
     traj_file = top_file = None
-    for filename in os.listdir(folder):
+    file_list = [f_name for f_name in os.listdir(folder) if not f_name.startswith('.')]
+    for filename in file_list:
         filepath = os.path.join(folder, filename)
         if not os.path.isfile(filepath):
             continue
 
         ext = get_extension(filename).lower()
+        # Catching trajectory formats that can be topology and trajectories at the same time.
+        # Only activates when there is a single file.
+        if len(file_list) < 2 and ext in TOPOLOGY_EXTS and ext in TRAJECTORY_EXTS:
+            top_file = filename
+            traj_file = filename
+
+        # Assuming topology file is copied first.
         if ext in TOPOLOGY_EXTS and top_file is None:
             top_file = filename
         elif ext in TRAJECTORY_EXTS and traj_file is None:


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
When copying a file that could be both a topology and trajectory (e.g. '.pdb', '.gro') to `$WEST_TRAJECTORY_RETURN`, `westpa.core.trajectory.load_trajectories()` directly assigns the file as topology and then moves on. This requires users to copy the same file twice if the file could be used as topology and trajectory at the same time. And no, you can't make a symbolic link because the extension of the link is not correctly recognized by mdtraj. This doubles the amount of file transfers (related to bandwidth and space) needed.

Also added logic ignores "hidden" files (ones that start with '.') during the check. This is useful on macOS systems, where spotlight/finder loves to make hidden files (e.g. '._FILE.EXT') along side the copied file.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Remove hidden files from `load_trajectory` file extension check.
- [x] Allow files that could be both trajectory and topology to only be copied once.

**Major files changed.**  
- [x] src/westpa/core/trajectory.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

