### PR TITLE
Pinning Cython <3.0.3 for Python <3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = [
     "setuptools>=40.8.0",
     "wheel",
     "Cython>=0.29.16",  # Note: sync with setup.py
+    "Cython<3, >=0.29.16; python_version < '3.10'",
     "oldest-supported-numpy",
     "scipy>=0.19.1",
     "versioneer-518"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "setuptools>=40.8.0",
     "wheel",
     "Cython>=0.29.16",  # Note: sync with setup.py
-    "Cython<3, >=0.29.16; python_version < '3.10'",
+    "Cython<3.0.3, >=0.29.16; python_version < '3.10'",
     "oldest-supported-numpy",
     "scipy>=0.19.1",
     "versioneer-518"


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
Fixes #349 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
This is a workaround for problems with Cython v3.0.3 as described in #349. I pinned it so any Python<3.10 will require Cython <3.0.3.

Cython 3's been giving everyone a lot of headaches, and 3.0.3 is breaking [scipy](https://github.com/cython/cython/issues/5748) and [pandas](https://github.com/cython/cython/issues/5747)'s compiling as well.

Just note that:
With python 3.12's release earlier this month, Python versions <3.10 are technically no longer part of the "three most recent versions". We can leave this pinning, or switch this off when/if cython/scipy fixes this.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x]  Fix installation on python <3.10

**Major files changed.**  
- [x] pyproject.toml

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

