### PR TITLE
Pinning Pytables to < 3.9 for python <3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = [
     "setuptools>=40.8.0",
     "wheel",
     "Cython>=0.29.16",  # Note: sync with setup.py
+    "Cython<3, >=0.29.16; python_version < '3.10'",
     "oldest-supported-numpy",
     "scipy>=0.19.1",
     "versioneer-518"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "setuptools>=40.8.0",
     "wheel",
     "Cython>=0.29.16",  # Note: sync with setup.py
-    "Cython<3, >=0.29.16; python_version < '3.10'",
+    "Cython<3.0.3, >=0.29.16; python_version < '3.10'",
     "oldest-supported-numpy",
     "scipy>=0.19.1",
     "versioneer-518"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'setuptools.build_meta:__legacy__'
 requires = [
     "setuptools>=40.8.0",
     "wheel",
-    "Cython>=0.29.16; python_version > '3.9'",  # Note: sync with setup.py
+    "Cython>=0.29.16; python_version >='3.10'",  # Note: sync with setup.py
     "Cython<3.0.3, >=0.29.16; python_version < '3.10'",
     "oldest-supported-numpy",
     "scipy>=0.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = 'setuptools.build_meta:__legacy__'
 requires = [
     "setuptools>=40.8.0",
     "wheel",
-    "Cython>=0.29.16",  # Note: sync with setup.py
+    "Cython>=0.29.16; python_version > '3.9'",  # Note: sync with setup.py
     "Cython<3.0.3, >=0.29.16; python_version < '3.10'",
     "oldest-supported-numpy",
     "scipy>=0.19.1",

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ INSTALL_REQUIRES = [
     "tqdm",
     "pandas",
     "tables < 3.9; python_version < '3.9'",
-    "tables; python_version >= '3.9'"
+    "tables; python_version >= '3.9'",
 ]
 
 EXTRAS_REQUIRE = {

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,8 @@ INSTALL_REQUIRES = [
     "ipykernel",
     "tqdm",
     "pandas",
-    "tables",
+    "tables < 3.9; python_version < '3.9'",
+    "tables; python_version >= '3.9'"
 ]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#351 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Pytables dropped support for Python 3.8 but released it as a working package that is unresolvable by pip. Pinning pytables to <3.9 for python 3.8.

I'm assuming this pinning can stay as is until we officially drop python 3.8 support in October 2024 (which is the EOL for Python 3.8).

See https://github.com/jeremyleung521/westpa/actions/runs/6433992408 for a working/passing CI for build.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fix PyTables dependency error during installation 

**Major files changed.**  
- [x] pyproject.toml

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

