### PR TITLE
add pytest-timeout as an optional dependency

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-rerunfailures
+  - pytest-timeout
   - codecov
   - pip
   - pip:

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ INSTALL_REQUIRES = [
 ]
 
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "pytest-cov", "pytest-rerunfailures"],
+    "tests": ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"],
     "mpi": ["mpi4py"],
 }
 


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
When I removed the nosetest dependency a while back in #325, I didn't add `pytest-timeout` as a dependency. Apparently `pytest.mark.timeout()` is not a default mark and requires a plugin (even though directly referenced in the pytest documentation). This PR makes it so those marks actually work. This should cut down on CI errors and also the amount of warnings outputted.

This is an optional dependency for the CI and other developers and does not affect users at all.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] remove `pytest.mark.timeout()` warning messages

**Major files changed.**  
- [x] devtools/conda-envs/test_env.yaml
- [x] setup.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

