### PR TITLE
MAB bin boundary output to text file

### DIFF
--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -251,7 +251,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
             with open(expandvars("$WEST_SIM_ROOT/binbounds.log"), 'a') as bb_file:
                 bb_file.write(f'{westpa.rc.sim_manager.n_iter}\n')  # Iteration Number
                 for n in range(ndim):
-                    bb_file.write(f'{np.linspace(minlist[n], maxlist[n], nbins + 1)}\t')  # Write binbounds per dim
+                    bb_file.write(f'{np.linspace(minlist[n], maxlist[n], nbins_per_dim[n] + 1)}\t')  # Write binbounds per dim
                 bb_file.write(f'\n{minlist} {maxlist}\n')  # Min/Max pcoord
                 if bottleneck_base > boundary_base:
                     bb_file.write(f'{flipdifflist} {difflist}\n\n')  # Bottlenecks

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -1,7 +1,9 @@
-import numpy as np
-from westpa.core.binning import FuncBinMapper
 import logging
+import numpy as np
 import westpa
+from westpa.core.binning import FuncBinMapper
+from os.path import expandvars
+
 
 log = logging.getLogger(__name__)
 
@@ -19,6 +21,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
     skip = kwargs.get("skip")
     nbins_per_dim = kwargs.get("nbins_per_dim")
     mab_log = kwargs.get("mab_log")
+    bin_log = kwargs.get("bin_log")
     ndim = len(nbins_per_dim)
 
     if not np.any(mask):
@@ -242,6 +245,11 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
         # output is the main list that, for each segment, holds the bin assignment
         output[i] = holder
+
+    if bin_log and report:
+        with expandvars("$WEST_SIM_ROOT/binbounds.log", 'a') as file:
+            file.write(westpa.rc.sim_manager.n_iter)
+            file.write(bins)
 
     return output
 

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -212,8 +212,6 @@ def map_mab(coords, mask, output, *args, **kwargs):
                         special = True
                         break
 
-        binbounds = []
-
         # the following are for the "linear" portion
         if not special:
             for n in range(ndim):
@@ -229,7 +227,6 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
                 bins = np.linspace(minp, maxp, nbins + 1)
                 bin_number = np.digitize(coord, bins) - 1
-                binbounds.append(bins)
 
                 if isfinal is None or not isfinal[i]:
                     if bin_number >= nbins:
@@ -253,8 +250,8 @@ def map_mab(coords, mask, output, *args, **kwargs):
         if westpa.rc.sim_manager.n_iter:
             with open(expandvars("$WEST_SIM_ROOT/binbounds.log"), 'a') as bb_file:
                 bb_file.write(f'{westpa.rc.sim_manager.n_iter}\n')  # Iteration Number
-                for ibins in binbounds:
-                    bb_file.write(f'{ibins}\t')  # Write binbounds per dim
+                for n in range(ndim):
+                    bb_file.write(f'{np.linspace(minlist[n], maxlist[n], nbins + 1)}\t')  # Write binbounds per dim
                 bb_file.write(f'\n{minlist} {maxlist}\n')  # Min/Max pcoord
                 if bottleneck_base > boundary_base:
                     bb_file.write(f'{flipdifflist} {difflist}\n\n')  # Bottlenecks

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -247,9 +247,13 @@ def map_mab(coords, mask, output, *args, **kwargs):
         output[i] = holder
 
     if bin_log and report:
-        with expandvars("$WEST_SIM_ROOT/binbounds.log", 'a') as file:
-            file.write(westpa.rc.sim_manager.n_iter)
-            file.write(bins)
+        if westpa.rc.sim_manager.n_iter:
+            with open(expandvars("$WEST_SIM_ROOT/binbounds.log"), 'a') as file:
+                file.write(f'{westpa.rc.sim_manager.n_iter}\n{bins}\n{minlist} {maxlist}\n')
+                if bottleneck_base > boundary_base:
+                    file.write(f'{flipdifflist} {difflist}\n')
+                else:
+                    file.write('\n')
 
     return output
 
@@ -259,7 +263,7 @@ class MABBinMapper(FuncBinMapper):
     the progress coordinte. Extrema and bottleneck segments are assigned
     to their own bins.'''
 
-    def __init__(self, nbins, direction=None, skip=None, bottleneck=True, pca=False, mab_log=False):
+    def __init__(self, nbins, direction=None, skip=None, bottleneck=True, pca=False, mab_log=False, bin_log=False):
         # Verifying parameters
         if nbins is None:
             raise ValueError("nbins_per_dim is missing")
@@ -277,7 +281,9 @@ class MABBinMapper(FuncBinMapper):
             skip = [0] * ndim
             log.warning("Skip list is not the correct dimensions, setting to defaults.")
 
-        kwargs = dict(nbins_per_dim=nbins, direction=direction, skip=skip, bottleneck=bottleneck, pca=pca, mab_log=mab_log)
+        kwargs = dict(
+            nbins_per_dim=nbins, direction=direction, skip=skip, bottleneck=bottleneck, pca=pca, mab_log=mab_log, bin_log=bin_log
+        )
         # the following is neccessary because functional bin mappers need to "reserve"
         # bins and tell the sim manager how many bins they will need to use, this is
         # determined by taking all direction/skipping info into account

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -212,6 +212,8 @@ def map_mab(coords, mask, output, *args, **kwargs):
                         special = True
                         break
 
+        binbounds = []
+
         # the following are for the "linear" portion
         if not special:
             for n in range(ndim):
@@ -227,6 +229,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
                 bins = np.linspace(minp, maxp, nbins + 1)
                 bin_number = np.digitize(coord, bins) - 1
+                binbounds.append(bins)
 
                 if isfinal is None or not isfinal[i]:
                     if bin_number >= nbins:
@@ -248,12 +251,15 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
     if bin_log and report:
         if westpa.rc.sim_manager.n_iter:
-            with open(expandvars("$WEST_SIM_ROOT/binbounds.log"), 'a') as file:
-                file.write(f'{westpa.rc.sim_manager.n_iter}\n{bins}\n{minlist} {maxlist}\n')
+            with open(expandvars("$WEST_SIM_ROOT/binbounds.log"), 'a') as bb_file:
+                bb_file.write(f'{westpa.rc.sim_manager.n_iter}\n')  # Iteration Number
+                for ibins in binbounds:
+                    bb_file.write(f'{ibins}\t')  # Write binbounds per dim
+                bb_file.write(f'\n{minlist} {maxlist}\n')  # Min/Max pcoord
                 if bottleneck_base > boundary_base:
-                    file.write(f'{flipdifflist} {difflist}\n')
+                    bb_file.write(f'{flipdifflist} {difflist}\n\n')  # Bottlenecks
                 else:
-                    file.write('\n')
+                    bb_file.write('\n')
 
     return output
 


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  

I just went ahead and added the functionality to output A) Iteration Number, B) the bin bounds, C) Min/Max pcoord and D) Bottle neck pcoord  into a file called `binbounds.log` that will exist in `$WEST_SIM_ROOT`. Users will have to specify `bin_log: True` similar to `mab_log` to activate functionality.

Tested on 1D and 2D MAB.  Feel free to test on more cases (e.g., multi-MAB).

Obviously it'll be nice if it's saved in the west.h5 file, but that'll require some specifications-planning (assuming to replace the bin_mapper pickle) and write some functions into the data_manager. I'll leave that to someone else or when I have more time.

Documention here: https://github.com/westpa/westpa/wiki/Binning#user-content-How_to_Print_MAB_Bins_into_binboundslog_File

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Add functionality to output MAB bin boundaries on the fly

**Major files changed.**  
- [x] src/westpa/core/binning/mab.py

**Status.**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

