### PR TITLE
Unpin pytables version requirement for python=3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,8 +120,7 @@ INSTALL_REQUIRES = [
     "ipykernel",
     "tqdm",
     "pandas",
-    "tables < 3.9; python_version < '3.9'",
-    "tables; python_version >= '3.9'",
+    "tables",
 ]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#351 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Removing the version pinning for PyTables on Python 3.8 because it's been fixed upstream (https://github.com/PyTables/PyTables/issues/1062)

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Cleaner code in setup.py

**Major files changed.**  
- [x] setup.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

