### PR TITLE
NumPy2 support fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,3 @@ exclude = '''
 )
 '''
 
-[tool.ruff.lint]
-extend-select = ["NPY201"]
-preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,8 @@ exclude = '''
       | _version.py
      )
 )
+
+[tool.ruff.lint]
+extend-select = ["NPY201"]
+preview = true
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ exclude = '''
       | _version.py
      )
 )
+'''
 
 [tool.ruff.lint]
 extend-select = ["NPY201"]
 preview = true
-'''

--- a/src/westpa/cli/tools/w_assign.py
+++ b/src/westpa/cli/tools/w_assign.py
@@ -474,17 +474,17 @@ Command-line options
 
             # Recursive mappers produce a generator rather than a list of labels
             # so consume the entire generator into a list
-            labels = [np.string_(label) for label in self.binning.mapper.labels]
+            labels = [np.bytes_(label) for label in self.binning.mapper.labels]
 
             self.output_file.create_dataset('bin_labels', data=labels, compression=9)
 
             if self.states:
                 nstates = len(self.states)
                 state_map[:] = nstates  # state_id == nstates => unknown state
-                state_labels = [np.string_(state['label']) for state in self.states]
+                state_labels = [np.bytes_(state['label']) for state in self.states]
 
                 for istate, sdict in enumerate(self.states):
-                    assert state_labels[istate] == np.string_(sdict['label'])  # sanity check
+                    assert state_labels[istate] == np.bytes_(sdict['label'])  # sanity check
                     state_assignments = assign(sdict['coords'])
                     for assignment in state_assignments:
                         state_map[assignment] = istate
@@ -558,7 +558,7 @@ Command-line options
                 shuffle=True,
                 chunks=h5io.calc_chunksize(pops_shape, weight_dtype),
             )
-            h5io.label_axes(pops_ds, [np.string_(i) for i in ['iteration', 'state', 'bin']])
+            h5io.label_axes(pops_ds, [np.bytes_(i) for i in ['iteration', 'state', 'bin']])
 
             pi.new_operation('Assigning to bins', iter_stop - iter_start)
             last_labels = None  # mapping of seg_id to last macrostate inhabited

--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -1545,7 +1545,7 @@ def create_dataset_from_dsopts(group, dsopts, shape=None, dtype=None, data=None,
         #        dsopts['file'] = str(dsopts['file']).format(n_iter=n_iter)
         h5_auxfile = h5io.WESTPAH5File(dsopts['file'].format(n_iter=n_iter))
         h5group = group
-        if not ("iter_" + str(n_iter).zfill(8)) in h5_auxfile:
+        if ("iter_" + str(n_iter).zfill(8)) not in h5_auxfile:
             h5_auxfile.create_group("iter_" + str(n_iter).zfill(8))
         group = h5_auxfile[('/' + "iter_" + str(n_iter).zfill(8))]
 
@@ -1648,7 +1648,7 @@ def create_dataset_from_dsopts(group, dsopts, shape=None, dtype=None, data=None,
     if 'file' in list(dsopts.keys()):
         import h5py
 
-        if not dsopts['h5path'] in h5group:
+        if dsopts['h5path'] not in h5group:
             h5group[dsopts['h5path']] = h5py.ExternalLink(
                 dsopts['file'].format(n_iter=n_iter), ("/" + "iter_" + str(n_iter).zfill(8) + "/" + dsopts['h5path'])
             )

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -342,10 +342,10 @@ def label_axes(h5object, labels, units=None):
     if len(units) and len(units) != len(labels):
         raise ValueError('number of units labels does not match number of axes')
 
-    h5object.attrs['axis_labels'] = np.array([np.string_(i) for i in labels])
+    h5object.attrs['axis_labels'] = np.array([np.bytes_(i) for i in labels])
 
     if len(units):
-        h5object.attrs['axis_units'] = np.array([np.string_(i) for i in units])
+        h5object.attrs['axis_units'] = np.array([np.bytes_(i) for i in units])
 
 
 NotGiven = object()

--- a/src/westpa/core/states.py
+++ b/src/westpa/core/states.py
@@ -20,7 +20,7 @@ class BasisState:
     '''
 
     def __init__(self, label, probability, pcoord=None, auxref=None, state_id=None):
-        self.label = str(label, encoding="UTF-8") if type(label) is bytes else label
+        self.label = str(label, encoding="UTF-8") if isinstance(label, bytes) else label
         self.probability = probability
         self.pcoord = np.atleast_1d(pcoord)
         self.auxref = auxref

--- a/src/westpa/westext/stringmethod/string_method.py
+++ b/src/westpa/westext/stringmethod/string_method.py
@@ -176,7 +176,7 @@ class DefaultStringMethod(WESTStringMethod):
                 ud[2:] = -self._kappan[ulen]
                 ld[:-2] = -self._kappan[ulen]
 
-                self._A[ulen] = np.mat([ud, d, ld])
+                self._A[ulen] = np.asmatrix([ud, d, ld])
 
             else:
                 self._A[ulen] = np.eye(ulen)

--- a/tests/test_tools/h5diff.py
+++ b/tests/test_tools/h5diff.py
@@ -33,11 +33,11 @@ class H5Diff:
             #   .dtype is referencing an attribute of a numpy array.
             if test_object[()].dtype.names is not None:
                 non_reference_test_elements = [
-                    x for i, x in enumerate(test_object[()][0]) if not test_object[()].dtype.names[i] in ref_names
+                    x for i, x in enumerate(test_object[()][0]) if test_object[()].dtype.names[i] not in ref_names
                 ]
 
                 non_reference_ref_elements = [
-                    x for i, x in enumerate(ref_object[()][0]) if not ref_object[()].dtype.names[i] in ref_names
+                    x for i, x in enumerate(ref_object[()][0]) if ref_object[()].dtype.names[i] not in ref_names
                 ]
 
             else:


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
Fixes #372 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Ran ruff to support numpy2
<s>There are no instances of NPY201 errors found</s> 7 instances of NPY201 errors found, easily fixed.
There are unrelated unfixed errors below:

```
ruff check .
src/westpa/__init__.py:16:1: E402 Module level import not at top of file
src/westpa/cli/tools/w_assign.py:477:23: NPY201 [*] `np.string_` will be removed in NumPy 2.0. Use `numpy.bytes_` instead.
src/westpa/cli/tools/w_assign.py:484:33: NPY201 [*] `np.string_` will be removed in NumPy 2.0. Use `numpy.bytes_` instead.
src/westpa/cli/tools/w_assign.py:487:52: NPY201 [*] `np.string_` will be removed in NumPy 2.0. Use `numpy.bytes_` instead.
src/westpa/cli/tools/w_assign.py:561:39: NPY201 [*] `np.string_` will be removed in NumPy 2.0. Use `numpy.bytes_` instead.
src/westpa/cli/tools/w_eddist.py:493:20: F841 Local variable `n_iter` is assigned to but never used
src/westpa/cli/tools/w_ipa.py:163:29: E741 Ambiguous variable name: `l`
src/westpa/cli/tools/w_multi_west.py:6:1: E402 Module level import not at top of file
src/westpa/cli/tools/w_multi_west.py:7:1: E402 Module level import not at top of file
src/westpa/cli/tools/w_multi_west.py:8:1: E402 Module level import not at top of file
src/westpa/cli/tools/w_multi_west.py:9:1: E402 Module level import not at top of file
src/westpa/cli/tools/w_multi_west.py:10:1: E402 Module level import not at top of file
src/westpa/cli/tools/w_multi_west.py:13:1: E402 Module level import not at top of file
src/westpa/cli/tools/w_pdist.py:496:20: F841 Local variable `n_iter` is assigned to but never used
src/westpa/cli/tools/w_red.py:226:20: F841 Local variable `cilb` is assigned to but never used
src/westpa/cli/tools/w_red.py:226:26: F841 Local variable `ciub` is assigned to but never used
src/westpa/core/_rc.py:46:16: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
src/westpa/core/binning/mab.py:70:9: F841 Local variable `eigval` is assigned to but never used
src/westpa/core/h5io.py:345:47: NPY201 [*] `np.string_` will be removed in NumPy 2.0. Use `numpy.bytes_` instead.
src/westpa/core/h5io.py:348:50: NPY201 [*] `np.string_` will be removed in NumPy 2.0. Use `numpy.bytes_` instead.
src/westpa/core/propagators/executable.py:625:13: F841 Local variable `rusage` is assigned to but never used
src/westpa/core/propagators/executable.py:634:13: F841 Local variable `rusage` is assigned to but never used
src/westpa/core/propagators/executable.py:654:21: F841 Local variable `rusage` is assigned to but never used
src/westpa/core/propagators/executable.py:665:21: F841 Local variable `rusage` is assigned to but never used
src/westpa/core/sim_manager.py:347:17: F841 Local variable `rbstate` is assigned to but never used
src/westpa/core/we_driver.py:550:26: F841 Local variable `parent` is assigned to but never used
src/westpa/core/we_driver.py:591:37: F841 Local variable `parent` is assigned to but never used
src/westpa/core/we_driver.py:614:26: F841 Local variable `parent` is assigned to but never used
src/westpa/core/we_driver.py:679:35: F841 Local variable `parent` is assigned to but never used
src/westpa/oldtools/aframe/trajwalker.py:5:1: E402 Module level import not at top of file
src/westpa/westext/hamsm_restarting/example_overrides.py:10:1: E402 Module level import not at top of file
src/westpa/westext/stringmethod/string_method.py:179:33: NPY201 [*] `np.mat` will be removed in NumPy 2.0. Use `numpy.asmatrix` instead.
src/westpa/westext/stringmethod/string_method.py:244:17: E731 Do not assign a `lambda` expression, use a `def`
src/westpa/work_managers/zeromq/node.py:12:1: E402 Module level import not at top of file
src/westpa/work_managers/zeromq/node.py:14:1: E402 Module level import not at top of file
src/westpa/work_managers/zeromq/node.py:15:1: E402 Module level import not at top of file
src/westpa/work_managers/zeromq/work_manager.py:397:13: F841 Local variable `task_id` is assigned to but never used
tests/test_binning.py:54:9: E731 Do not assign a `lambda` expression, use a `def`
tests/test_binning.py:55:9: E731 Do not assign a `lambda` expression, use a `def`
tests/test_functional/test_mclib.py:43:40: F841 Local variable `k_` is assigned to but never used
tests/test_tools/test_w_states.py:18:14: F841 Local variable `err` is assigned to but never used
Found 41 errors.
[*] 7 fixable with the `--fix` option (19 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

All tests passed when numpy commit [539dafa](https://github.com/numpy/numpy/commit/539dafa3fbd823bfb490f6355ac2d76d16eddc23) was installed

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Make sure numpy2 is supported 
- [x] Fixed additional ruff lint errors

**Major files changed.**  
- [x] see below

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

