### PR TITLE
Dropping `oldest-supported-numpy` for python>=3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ To install from source (**not recommended**), start by downloading the correspon
 
 .. _`releases page`: https://github.com/westpa/westpa/releases
 .. _`Anaconda Python distribution`: https://www.anaconda.com/products/individual
-.. _`wiki`: https://github.com/westpa/westpa/wiki/WESTPA-Quick-Install
+.. _`wiki`: https://github.com/westpa/westpa/wiki/Installing-WESTPA
 
 ---------------
 Getting started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@ build-backend = 'setuptools.build_meta:__legacy__'
 # Minimum requirements for the build system to execute.
 # See current numpy pinning in https://github.com/scipy/oldest-supported-numpy
 requires = [
-    "setuptools>=40.8.0",
+    "setuptools >=40.8.0",
     "wheel",
-    "Cython>=0.29.16; python_version >='3.10'",  # Note: sync with setup.py
-    "Cython<3.0.3, >=0.29.16; python_version < '3.10'",
-    "oldest-supported-numpy; python_version < '3.9'",
-    "numpy>=1.25.0; python_version >= '3.9'",
-    "scipy>=0.19.1",
+    "Cython >=0.29.16; python_version >='3.10'",  # Note: sync with setup.py
+    "Cython <3.0.3, >=0.29.16; python_version <'3.10'",
+    "oldest-supported-numpy; python_version <'3.9'",
+    "numpy >=1.25.0; python_version >='3.9'",
+    "scipy >=0.19.1",
     "versioneer-518"
 ]
 # Uncommenting this requires adding the top level of the repo to sys.path in the setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "Cython>=0.29.16; python_version >='3.10'",  # Note: sync with setup.py
     "Cython<3.0.3, >=0.29.16; python_version < '3.10'",
     "oldest-supported-numpy; python_version < '3.9'",
-    "numpy>=1.25; python_version >= '3.9'",
+    "numpy>=1.25.0; python_version >= '3.9'",
     "scipy>=0.19.1",
     "versioneer-518"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires = [
     "wheel",
     "Cython>=0.29.16; python_version >='3.10'",  # Note: sync with setup.py
     "Cython<3.0.3, >=0.29.16; python_version < '3.10'",
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; python_version < '3.9'",
+    "numpy>=1.25; python_version >= '3.9'",
     "scipy>=0.19.1",
     "versioneer-518"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "Cython >=0.29.16; python_version >='3.10'",  # Note: sync with setup.py
     "Cython <3.0.3, >=0.29.16; python_version <'3.10'",
     "oldest-supported-numpy; python_version <'3.9'",
-    "numpy >=1.25.0; python_version >='3.9'",
+    "numpy >=1.25.0, <3; python_version >='3.9'",
     "scipy >=0.19.1",
     "versioneer-518"
 ]

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = [
-    "numpy >= 1.16.0",
+    "numpy >= 1.16.0, <3",
     "scipy >= 0.19.1",
     "h5py >= 2.10",
     "mdtraj >= 1.9.5",

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,8 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = [
-    "numpy >= 1.16.0",
+    "numpy >= 1.16.0; python_version < '3.9'",
+    "numpy >= 1.25.0; python_version >= '3.9'",
     "scipy >= 0.19.1",
     "h5py >= 2.10",
     "mdtraj >= 1.9.5",

--- a/setup.py
+++ b/setup.py
@@ -109,8 +109,7 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = [
-    "numpy >= 1.16.0; python_version < '3.9'",
-    "numpy >= 1.25.0; python_version >= '3.9'",
+    "numpy >= 1.16.0",
     "scipy >= 0.19.1",
     "h5py >= 2.10",
     "mdtraj >= 1.9.5",


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#372 

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  

As I mentioned in https://github.com/westpa/westpa/issues/372#issuecomment-1900828939, `oldest-supported-numpy` has been [deprecated](https://github.com/scipy/oldest-supported-numpy) in favor of the built-in C API exporting feature of numpy>=1.25.0.

This drops `oldest-support-numpy` for python >=3.9 in light of `numpy2`'s eventual release.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] drop `oldest-support-numpy` for python >=3.9

**Major files changed.**  
- [x] pyproject.toml

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

