### PR TITLE
fix nested-yaml bug

### DIFF
--- a/src/westpa/core/yamlcfg.py
+++ b/src/westpa/core/yamlcfg.py
@@ -142,6 +142,7 @@ class YAMLConfig:
                     val = val[keypart]
                 except KeyError:
                     val[keypart] = {}
+                    val = val[keypart]
             try:
                 val = val[key[-1]]
             except KeyError:

--- a/tests/test_yamlfe.py
+++ b/tests/test_yamlfe.py
@@ -108,6 +108,6 @@ class TestYAMLFrontEnd:
         assert system.pcoord_dtype == np.float32
 
         # Test __setitem__() method of YAMLConfig()
-        rc.config['west','propagation', 'max_total_iteration'] = 1000
+        rc.config['west', 'propagation', 'max_total_iteration'] = 1000
 
         assert rc.config['west', 'propagation', 'max_total_iteration'] == 1000

--- a/tests/test_yamlfe.py
+++ b/tests/test_yamlfe.py
@@ -106,3 +106,8 @@ class TestYAMLFrontEnd:
         assert (system.bin_mapper.boundaries == np.arange(0.0, 5.0, 0.5)).all()
         assert system.pcoord_len == 10
         assert system.pcoord_dtype == np.float32
+
+        # Test __setitem__() method of YAMLConfig()
+        rc.config['west','propagation', 'max_total_iteration'] = 1000
+
+        assert rc.config['west', 'propagation', 'max_total_iteration'] == 1000


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
When creating a new nested entry with YAMLConfig, it would wrongly place the new entry at the last existing level. This PR fixes the issue by appropriately descending into the newly created levels.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Fixed the bug described above.

**Major files changed.**  
- [x] src/westpa/core/yamlcfg.py
- [x] tests/test_yamlfe.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

Test case in Python session:
```
from westpa.core.yamlcfg import YAMLConfig

config = YAMLConfig()
config._data = {'west': {'system_options': {'pcoord_ndim': 2}}}
config['west', 'test', 'blah'] = 3

print(config)
try:
   # Expected Output
    assert config['west', 'test', 'blah'] == 2
except KeyError:
   # Faulty Output
    assert config['west', 'system_options', 'test'] == {}
    assert config['west', 'system_options', 'blah'] == 3
    raise ValueError('The faulty outputs are produced.')

```
