### PR TITLE
allow tstate files to contain empty line(s) and comments

### DIFF
--- a/src/westpa/core/states.py
+++ b/src/westpa/core/states.py
@@ -293,6 +293,10 @@ class TargetState:
             open_statefile = statefile
 
         for line in open_statefile:
+            line = line.partition('#')[0].strip()
+            if not line:
+                continue
+
             fields = line.split()
             labels.append(fields[0])
             pcoord_values.append(np.array(list(map(dtype, fields[1:])), dtype=dtype))

--- a/src/westpa/core/states.py
+++ b/src/westpa/core/states.py
@@ -66,7 +66,7 @@ class BasisState:
             )
 
     @classmethod
-    def states_from_file(cls, filename):
+    def states_from_file(cls, statefile):
         '''Read a file defining basis states.  Each line defines a state, and contains a label, the probability,
         and optionally a data reference, separated by whitespace, as in::
 
@@ -80,7 +80,13 @@ class BasisState:
         '''
         states = []
         lineno = 0
-        for line in open(filename, 'rt'):
+
+        try:
+            open_statefile = open(statefile, 'rt')
+        except TypeError:
+            open_statefile = statefile
+
+        for line in open_statefile:
             lineno += 1
 
             # remove comment portion
@@ -93,7 +99,7 @@ class BasisState:
             try:
                 probability = float(fields[1])
             except ValueError:
-                raise ValueError('invalid probability ({!r}) {} line {:d}'.format(fields[1], filename, lineno))
+                raise ValueError('invalid probability ({!r}) {} line {:d}'.format(fields[1], statefile, lineno))
 
             try:
                 auxref = fields[2].strip()
@@ -101,6 +107,12 @@ class BasisState:
                 auxref = None
 
             states.append(cls(state_id=None, probability=probability, label=label, auxref=auxref))
+
+        try:
+            open_statefile.close()
+        except Exception:
+            pass
+
         return states
 
     def as_numpy_record(self):

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -1,0 +1,38 @@
+import numpy as np
+from westpa.core.states import BasisState, TargetState
+from io import StringIO
+
+
+class TestStates:
+    def test_gen_bstate_from_file(self):
+        bstate_txt = """
+        # Comment
+        0 0.1 a.rst
+        1 1e-3 b.rst
+
+        """
+        true_answers = [['0', 1e-1, 'a.rst'], ['1', 1e-3, 'b.rst']]
+
+        fake_file = StringIO(bstate_txt)
+        bstates = BasisState.states_from_file(fake_file)
+
+        for answer, state in zip(true_answers, bstates):
+            assert state.label == answer[0]
+            assert state.probability == answer[1]
+            assert state.auxref == answer[2]
+
+    def test_gen_tstate_from_file(self):
+        tstate_txt = """
+        # Comment
+        0 1 1
+        1 2 3
+
+        """
+        true_answers = [['0', np.array([1.0, 1.0])], ['1', np.array([2.0, 3.0])]]
+
+        fake_file = StringIO(tstate_txt)
+        tstates = TargetState.states_from_file(fake_file, float)
+
+        for answer, state in zip(true_answers, tstates):
+            assert state.label == answer[0]
+            assert np.all(state.pcoord == answer[1])


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Line parsing of the target state file is written differently from the code for basis state, such that you can't have comments or empty lines at the bottom of the file. This PR will allow empty lines, trailing spaces and comments to be added into the target state file.

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Better user experience when specifying target states 

**Major files changed.**  
- [x] src/westpa/core/states.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

