### PR TITLE
Pinning to Numpy < 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "Cython >=0.29.16; python_version >='3.10'",  # Note: sync with setup.py
     "Cython <3.0.3, >=0.29.16; python_version <'3.10'",
     "oldest-supported-numpy; python_version <'3.9'",
-    "numpy >=1.25.0, <3; python_version >='3.9'",
+    "numpy >=1.25.0, <2; python_version >='3.9'",
     "scipy >=0.19.1",
     "versioneer-518"
 ]

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = [
-    "numpy >= 1.16.0, <3",
+    "numpy >= 1.16.0, <2",
     "scipy >= 0.19.1",
     "h5py >= 2.10",
     "mdtraj >= 1.9.5",


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  
#372 #374  

**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
Pinning to numpy < 2 for the time being until official release of numpy 2.0 (and #374). Better be safe than sorry. 

**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Pin to numpy<2 until #374 is merged

**Major files changed.**  
- [x] pyproject.toml
- [x] setup.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  


Played around with the numpy `2.0b1` release and it wasn't working due to the multitude of other WESTPA dependencies that requires `numpy < 2`. I'm getting a lot of import errors, especially in the Cython sections (which may or may not be due to a broken install due to dependencies). 

```
E   ImportError: numpy.core.multiarray failed to import (auto-generated because you didn't call 'numpy.import_array()' after cimporting numpy; use '<void>numpy._import_array' to disable if you are certain you don't need it).      
```

While #374 ruff linting currently says it's fine, I'm not 100% sure our CPython numpy code are well covered and it's very difficult to check until everything else upstream supports `numpy>=2`.


List of dependencies that don't work with numpy 2.0 just yet
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. 
ndfes 1.8 requires joblib, which is not installed. 
scipy 1.12.0 requires numpy<1.29.0,>=1.22.4, but you have numpy 2.0.0b1 which is incompatible.
pandas 2.2.1 requires numpy<2,>=1.23.2; python_version == "3.11", but you have numpy 2.0.0b1 which is incompatible.   
contourpy 1.2.0 requires numpy<2.0,>=1.20, but you have numpy 2.0.0b1 which is incompatible. 
matplotlib 3.8.3 requires numpy<2,>=1.21, but you have numpy 2.0.0b1 which is incompatible. 
```
