### PR TITLE
w_multi_west ibstates fix

### DIFF
--- a/src/westpa/cli/tools/w_multi_west.py
+++ b/src/westpa/cli/tools/w_multi_west.py
@@ -259,11 +259,19 @@ Command-line options
                         if addition.dtype != istate_dtype:
                             addition = create_idtype_array(addition)
                         final_istate_index = np.append(final_istate_index, addition)
-                        final_istate_pcoord = np.append(final_istate_pcoord, west['ibstates/0/istate_pcoord'][:])
+                        final_istate_pcoord = np.append(final_istate_pcoord, west['ibstates/0/istate_pcoord'][:], axis=0)
 
                 # Saving them into self.output_file
                 self.output_file['ibstates/0'].create_dataset('istate_index', data=final_istate_index, dtype=istate_dtype)
                 self.output_file['ibstates/0'].create_dataset('istate_pcoord', data=final_istate_pcoord)
+
+                # Remaking the ibstates index link
+                master_index_row = self.output_file['ibstates/index'][0]
+                master_index_row['iter_valid'] = 0
+                master_index_row['n_bstates'] = len(self.output_file['ibstates/0/bstate_index'])
+                master_index_row['group_ref'] = self.output_file['ibstates/0'].ref
+
+                self.output_file['ibstates/index'][0] = master_index_row
 
             for iter in range(self.niters):
                 # We have the following datasets in each iteration:


### PR DESCRIPTION
**Issue Number.** Is this pull request related to any outstanding issues? If so, list the issue number.  


**Describe the changes made.** A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it.  
There were two issues with `w_multi_west`'s `--ibstates` option which 
a) prevented `w_trace` from working properly and
b) combined the `istate_pcoord` incorrectly.

a) is due to a broken link/object reference in the `ibstates/index` dataset, which lead to a failure when attempting to retrieve the `ibstates` dataset using that link.
b) is due to the fact that I forgot to specify `axis=0` when appending the pcoord arrays.


**Goals and Outstanding Issues.** A clear and concise list of goals (to be) accomplished.  
- [x] Allow `w_trace` to run on files combined with `w_multi_west`
- [x] Combine `istates_pcoord` dataset correctly


**Major files changed.**  
- [x] src/westpa/cli/tools/w_multi_west.py

**Status.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

**Additional context.** Add any other context or screenshots about the pull request here.  

