### PR TITLE
W_succ ignores -W argument

### DIFF
--- a/src/westpa/oldtools/aframe/data_reader.py
+++ b/src/westpa/oldtools/aframe/data_reader.py
@@ -61,7 +61,7 @@ class WESTDataReaderMixin(AnalysisMixin):
         westpa.rc.pstatus("Using WEST data from '{}'".format(self.west_h5name))
 
         self.data_manager = westpa.rc.get_data_manager()
-        self.data_manager.backing_file = self.west_h5name
+        self.data_manager.we_h5filename = self.west_h5name
         self.data_manager.open_backing(mode='r')
 
         if upcall:


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
N/A

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
`w_succ` currently ignores the `-W` argument (despite accepting it) because of a typo in `WESTDataReaderMixin`. Probably affects `w_ttimes` as well, but I haven't seen anyone actually use that tool.

`backing_file` is currently NOT an attribute of the `data_manager` so no other consequences stems from this change.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x]  Have `w_succ` respect the h5file name given

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x]  src/westpa/oldtools/aframe/data_reader.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


