### PR TITLE
hotfix for propagator

### DIFF
--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -16,7 +16,7 @@ import numpy as np
 import westpa
 from westpa.core.extloader import get_object
 from westpa.core.propagators import WESTPropagator
-from westpa.core.states import BasisState, InitialState
+from westpa.core.states import BasisState, InitialState, return_state_type
 from westpa.core.segment import Segment
 from westpa.core.yamlcfg import check_bool
 
@@ -571,6 +571,9 @@ class ExecutablePropagator(WESTPropagator):
         files that contain the returned data. ``del_return_files`` is a ``dict`` where the keys are the
         names of datasets to be deleted (if the corresponding value is set to ``True``) once the data is
         retrieved.'''
+
+        state_name, state_id = return_state_type(segment)
+
         for dataset in self.data_info:
             if dataset not in return_files:
                 continue
@@ -584,7 +587,7 @@ class ExecutablePropagator(WESTPropagator):
             try:
                 loader(dataset, filename, segment, single_point=single_point)
             except Exception as e:
-                log.error('could not read {} for segment {} from {!r}: {!r}'.format(dataset, segment.seg_id, filename, e))
+                log.error('could not read {} for {} {} from {!r}: {!r}'.format(dataset, state_name, state_id, filename, e))
                 segment.status = Segment.SEG_STATUS_FAILED
                 break
             else:
@@ -596,10 +599,10 @@ class ExecutablePropagator(WESTPropagator):
                             shutil.rmtree(filename)
                     except Exception as e:
                         log.warning(
-                            'could not delete {} file {!r} for segment {}: {!r}'.format(dataset, filename, segment.seg_id, e)
+                            'could not delete {} file {!r} for {} {}: {!r}'.format(dataset, filename, state_name, state_id, e)
                         )
                     else:
-                        log.debug('deleted {} file {!r} for segment {}'.format(dataset, filename, segment.seg_id))
+                        log.debug('deleted {} file {!r} for {} {}'.format(dataset, filename, state_name, state_id))
 
     # Specific functions required by the WEST framework
     def get_pcoord(self, state):

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -564,15 +564,15 @@ class ExecutablePropagator(WESTPropagator):
 
         return addtl_env, return_files, del_return_files
 
-    def retrieve_dataset_return(self, segment, return_files, del_return_files, single_point):
+    def retrieve_dataset_return(self, state, return_files, del_return_files, single_point):
         '''Retrieve returned data from the temporary locations directed by the environment variables.
-        ``segment`` is the ``Segment`` object that the return data is associated with. ``return_files``
-        is a ``dict`` where the keys are the dataset names and the values are the paths to the temporarily
-        files that contain the returned data. ``del_return_files`` is a ``dict`` where the keys are the
-        names of datasets to be deleted (if the corresponding value is set to ``True``) once the data is
-        retrieved.'''
+        ``state`` is a ``Segment``, ``BasisState`` , or ``InitialState``object that the return data is
+        associated with. ``return_files`` is a ``dict`` where the keys are the dataset names and
+        the values are the paths to the temporarily files that contain the returned data.
+        ``del_return_files`` is a ``dict`` where the keys are the names of datasets to be deleted
+        (if the corresponding value is set to ``True``) once the data is retrieved.'''
 
-        state_name, state_id = return_state_type(segment)
+        state_name, state_id = return_state_type(state)
 
         for dataset in self.data_info:
             if dataset not in return_files:
@@ -585,10 +585,11 @@ class ExecutablePropagator(WESTPropagator):
             filename = return_files[dataset]
             loader = self.data_info[dataset]['loader']
             try:
-                loader(dataset, filename, segment, single_point=single_point)
+                loader(dataset, filename, state, single_point=single_point)
             except Exception as e:
                 log.error('could not read {} for {} {} from {!r}: {!r}'.format(dataset, state_name, state_id, filename, e))
-                segment.status = Segment.SEG_STATUS_FAILED
+                if isinstance(state, Segment):
+                    state.status = state.SEG_STATUS_FAILED
                 break
             else:
                 if del_return_files.get(dataset, False):

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -148,6 +148,7 @@ def seglog_loader(fieldname, log_file, segment, single_point):
 
         segment.data['iterh5/log'] = d.getvalue() + b'\x01'  # add tail protection
     except Exception as e:
+
         log.warning('could not read any data for {}: {}'.format(fieldname, str(e)))
     finally:
         d.close()
@@ -289,7 +290,7 @@ class ExecutablePropagator(WESTPropagator):
                 # can never disable pcoord collection
                 dsinfo['enabled'] = True
 
-            loader_directive = dsinfo.get('loader')
+            loader_directive = dsinfo.get('loader', None)
             if callable(loader_directive):
                 loader = loader_directive
             elif loader_directive in data_loaders.keys():
@@ -299,8 +300,12 @@ class ExecutablePropagator(WESTPropagator):
                     loader = get_object(loader_directive)
             elif dsname not in ['pcoord', 'seglog', 'restart', 'trajectory']:
                 loader = aux_data_loader
+            else:
+                # YOLO. Or maybe it wasn't specified.
+                loader = loader_directive
 
-            dsinfo['loader'] = loader
+            if loader:
+                dsinfo['loader'] = loader
             self.data_info.setdefault(dsname, {}).update(dsinfo)
 
         log.debug('data_info: {!r}'.format(self.data_info))

--- a/src/westpa/core/states.py
+++ b/src/westpa/core/states.py
@@ -344,3 +344,16 @@ def pare_basis_initial_states(basis_states, initial_states, segments=None):
     )
 
     return return_bstates, return_istates
+
+
+def return_state_type(state_obj):
+    '''Convinience function for returning the state ID and type of the state_obj pointer'''
+
+    if isinstance(state_obj, Segment):
+        return type(state_obj).__name__, state_obj.seg_id
+    elif isinstance(state_obj, InitialState):
+        return type(state_obj).__name__, state_obj.basis_state_id
+    elif isinstance(state_obj, BasisState):
+        return type(state_obj).__name__, state_obj.state_id
+    else:
+        return 'Unknown', float('inf')

--- a/src/westpa/core/states.py
+++ b/src/westpa/core/states.py
@@ -352,7 +352,7 @@ def return_state_type(state_obj):
     if isinstance(state_obj, Segment):
         return type(state_obj).__name__, state_obj.seg_id
     elif isinstance(state_obj, InitialState):
-        return type(state_obj).__name__, state_obj.basis_state_id
+        return type(state_obj).__name__, state_obj.state_id
     elif isinstance(state_obj, BasisState):
         return type(state_obj).__name__, state_obj.state_id
     else:

--- a/src/westpa/core/trajectory.py
+++ b/src/westpa/core/trajectory.py
@@ -294,6 +294,7 @@ def load_trajectory(folder):
     '''
     traj_file = top_file = None
     file_list = [f_name for f_name in os.listdir(folder) if not f_name.startswith('.')]
+
     for filename in file_list:
         filepath = os.path.join(folder, filename)
         if not os.path.isfile(filepath):

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -1,5 +1,6 @@
 import numpy as np
-from westpa.core.states import BasisState, TargetState
+from westpa.core.states import BasisState, TargetState, InitialState, return_state_type
+from westpa.core.segment import Segment
 from io import StringIO
 
 
@@ -36,3 +37,30 @@ class TestStates:
         for answer, state in zip(true_answers, tstates):
             assert state.label == answer[0]
             assert np.all(state.pcoord == answer[1])
+
+    def test_return_state_type_bstate(self):
+        bstate = BasisState(label=0, probability=0.1, state_id=10)
+        state_name, state_id = return_state_type(bstate)
+
+        assert state_name == 'BasisState'
+        assert state_id == 10
+
+    def test_return_state_type_istate(self):
+        istate = InitialState(state_id=2, basis_state_id=10, iter_created=3)
+        state_name, state_id = return_state_type(istate)
+
+        assert state_name == 'InitialState'
+        assert state_id == 2
+
+    def test_return_state_type_segment(self):
+        segment = Segment(seg_id=3)
+        state_name, state_id = return_state_type(segment)
+
+        assert state_name == 'Segment'
+        assert state_id == 3
+
+    def test_return_state_type_unknown(self):
+        state_name, state_id = return_state_type(3)
+
+        assert state_name == 'Unknown'
+        assert state_id == float('inf')


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Hot Fix. Error message for propagator calls for state_id but the `segment` being called in could be a bstate or istate, which doesn't have a segid.

Also fixes a different error where a different loader might be chosen for `trajectory` or `seglog` or `restart`.


## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Hot Fix for error message problem
- [x] Potential case where the wrong loader might be picked for the "reserved" dataset

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/propagators/executable.py
- [x] src/westpa/core/states.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->

