### PR TITLE
force x86-64 macos GitHub Action Runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-12"]
+        os: ["ubuntu-latest", "macos-13"]
         python-version: [8, 9, 10, 11] # sub-versions of Python
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-14-large"]
+        os: ["ubuntu-latest", "macos-13-large"]
         python-version: [8, 9, 10, 11] # sub-versions of Python
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest-large]
+        os: ["ubuntu-latest", "macos-14-large"]
         python-version: [8, 9, 10, 11] # sub-versions of Python
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13-large"]
+        os: ["ubuntu-latest", "macos-12"]
         python-version: [8, 9, 10, 11] # sub-versions of Python
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest-large]
         python-version: [8, 9, 10, 11] # sub-versions of Python
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest-large"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   install-dev:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest-large"]
 
     name: "Verify dev env"
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest-large"]
+        os: ["ubuntu-latest", "macos-14-large"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   install-dev:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest-large"]
+        os: ["ubuntu-latest", "macos-14-large"]
 
     name: "Verify dev env"
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-13"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-14-large"]
+        os: ["ubuntu-latest", "macos-13-large"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   install-dev:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-14-large"]
+        os: ["ubuntu-latest", "macos-13-large"]
 
     name: "Verify dev env"
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-12"]
+        os: ["ubuntu-latest", "macos-13"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   install-dev:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-12"]
+        os: ["ubuntu-latest", "macos-13"]
 
     name: "Verify dev env"
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13-large"]
+        os: ["ubuntu-latest", "macos-12"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   install-dev:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13-large"]
+        os: ["ubuntu-latest", "macos-12"]
 
     name: "Verify dev env"
     runs-on: "${{ matrix.os }}"

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -404,7 +404,7 @@ class WESimManager:
         )
 
         total_prob = float(sum(segment.weight for segment in segments))
-        pstatus(f'1-prob: {1-total_prob:.4e}')
+        pstatus(f'1-prob: {1 - total_prob:.4e}')
 
         target_counts = self.we_driver.bin_target_counts
         # Do not include bins with target count zero (e.g. sinks, never-filled bins) in the (non)empty bins statistics

--- a/src/westpa/westext/hamsm_restarting/restart_driver.py
+++ b/src/westpa/westext/hamsm_restarting/restart_driver.py
@@ -790,7 +790,7 @@ class RestartDriver:
 
                 westpa.rc.pstatus(
                     f"\n\n===== Restart {restart_state['restarts_completed']}, "
-                    + f"Run {restart_state['runs_completed']+1} initializing =====\n"
+                    + f"Run {restart_state['runs_completed'] + 1} initializing =====\n"
                 )
 
                 westpa.rc.pstatus(
@@ -811,7 +811,7 @@ class RestartDriver:
                 log.info("New WE run ready!")
                 westpa.rc.pstatus(
                     f"\n\n===== Restart {restart_state['restarts_completed']}, "
-                    + f"Run {restart_state['runs_completed']+1} running =====\n"
+                    + f"Run {restart_state['runs_completed'] + 1} running =====\n"
                 )
 
                 w_run.run_simulation()
@@ -1144,7 +1144,7 @@ class RestartDriver:
         westpa.rc.pstatus(
             f"\n\n"
             f"===== Restart {restart_state['restarts_completed']}, "
-            + f"Run {restart_state['runs_completed']+1} initializing =====\n"
+            + f"Run {restart_state['runs_completed'] + 1} initializing =====\n"
         )
 
         westpa.rc.pstatus(


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
If you noticed, the CI tests are failing because some header files are not found. This is due to how `macos-latest` runners now default to the arm64 versions, since 2024-04-22.

https://github.com/actions/runner-images

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Fix CI by pinning to macos-13 (last non-arm64 macos standard runner)
- [x] Drop Python 3.7 testing
- [x] Some flake8 lint caught by the pre-commit runner (but not the GH Action linter).

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] .github/workflows/test.yaml
- [x] .github/workflows/build.yaml
- [x] src/westpa/core/sim_manager.py
- [x] src/westpa/westext/hamsm_restarting/restart_driver.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


