### PR TITLE
Mab lite with direction 86

### DIFF
--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -137,11 +137,15 @@ def map_mab(coords, mask, output, *args, **kwargs):
     bottleneck_base = boundary_base
 
     for i in range(0, ndim):
-        if direction[i] != 0:
+        # for single direction, 1 boundary walker
+        if direction[i] == 1 or direction[i] == -1:
             bottleneck_base += 1
-        # this works for 86 direction as well, where with bottleneck True, use both directions
-        else:
+        # 2 boundary walkers with 0 direction
+        elif direction[i] == 0:
             bottleneck_base += 2
+        # for 86 direction, no boundary walkers so offset of 0
+        elif direction[i] == 86:
+            bottleneck_base += 0
 
     # if a dimension is being "skipped", leave only one bin total as
     # the offset

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -16,7 +16,17 @@ class MABBinMapper(FuncBinMapper):
 
     """
 
-    def __init__(self, nbins, direction=None, skip=None, bottleneck=True, pca=False, mab_log=False, bin_log=False):
+    def __init__(
+        self,
+        nbins,
+        direction=None,
+        skip=None,
+        bottleneck=True,
+        pca=False,
+        mab_log=False,
+        bin_log=False,
+        bin_log_path="$WEST_SIM_ROOT/binbounds.log",
+    ):
         """
         Parameters
         ----------
@@ -39,7 +49,9 @@ class MABBinMapper(FuncBinMapper):
         mab_log : bool, default: False
             Whether to output mab info to west.log.
         bin_log : bool, default: False
-            Whether to output mab bin boundaries to a binbounds.log file.
+            Whether to output mab bin boundaries to bin_log_path file.
+        bin_log_path : str, default: "$WEST_SIM_ROOT/binbounds.log"
+            Path to output bin boundaries.
 
         """
         # Verifying parameters
@@ -60,7 +72,14 @@ class MABBinMapper(FuncBinMapper):
             log.warning("Skip list is not the correct dimensions, setting to defaults.")
 
         kwargs = dict(
-            nbins_per_dim=nbins, direction=direction, skip=skip, bottleneck=bottleneck, pca=pca, mab_log=mab_log, bin_log=bin_log
+            nbins_per_dim=nbins,
+            direction=direction,
+            skip=skip,
+            bottleneck=bottleneck,
+            pca=pca,
+            mab_log=mab_log,
+            bin_log=bin_log,
+            bin_log_path=bin_log_path,
         )
 
         n_total_bins = self.determine_total_bins(**kwargs)
@@ -143,6 +162,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
     skip = kwargs.get("skip", ([0] * ndim))
     mab_log = kwargs.get("mab_log", False)
     bin_log = kwargs.get("bin_log", False)
+    bin_log_path = kwargs.get("bin_log_path", "$WEST_SIM_ROOT/binbounds.log")
 
     if not np.any(mask):
         return output
@@ -388,7 +408,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
     if bin_log and report:
         if westpa.rc.sim_manager.n_iter:
-            with open(expandvars("$WEST_SIM_ROOT/binbounds.log"), 'a') as bb_file:
+            with open(expandvars(bin_log_path), 'a') as bb_file:
                 # Iteration Number
                 bb_file.write(f'{westpa.rc.sim_manager.n_iter}\n')
                 for n in range(ndim):

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -411,6 +411,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
             with open(expandvars(bin_log_path), 'a') as bb_file:
                 # Iteration Number
                 bb_file.write(f'iteration: {westpa.rc.sim_manager.n_iter}\n')
+                bb_file.write('bin boundaries: ')
                 for n in range(ndim):
                     # Write binbounds per dim
                     bb_file.write(f'{np.linspace(minlist[n], maxlist[n], nbins_per_dim[n] + 1)}\t')

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -139,6 +139,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
     for i in range(0, ndim):
         if direction[i] != 0:
             bottleneck_base += 1
+        # this works for 86 direction as well, where with bottleneck True, use both directions
         else:
             bottleneck_base += 2
 
@@ -167,19 +168,21 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
                 # assign bottlenecks, taking directionality into account
                 if bottleneck:
-                    if direction[n] < 0:
+                    if direction[n] == -1:
                         if coord == flipdifflist[n]:
                             holder = bottleneck_base + n
                             special = True
                             break
 
-                    if direction[n] > 0:
+                    if direction[n] == 1:
                         if coord == difflist[n]:
                             holder = bottleneck_base + n
                             special = True
                             break
 
-                    if direction[n] == 0:
+                    # both directions when using 0 or with
+                    # special value of 86 for no lead/lag split
+                    if direction[n] == 0 or direction[n] == 86:
                         if coord == difflist[n]:
                             holder = bottleneck_base + n
                             special = True
@@ -188,15 +191,15 @@ def map_mab(coords, mask, output, *args, **kwargs):
                             holder = bottleneck_base + n + 1
                             special = True
                             break
-
+                
                 # assign boundary walkers, taking directionality into account
-                if direction[n] < 0:
+                if direction[n] == -1:
                     if coord == minlist[n]:
                         holder = boundary_base + n
                         special = True
                         break
 
-                elif direction[n] > 0:
+                elif direction[n] == 1:
                     if coord == maxlist[n]:
                         holder = boundary_base + n
                         special = True
@@ -211,6 +214,14 @@ def map_mab(coords, mask, output, *args, **kwargs):
                         holder = boundary_base + n + 1
                         special = True
                         break
+
+                # special value for direction with no lead/lag split
+                elif direction[n] == 86:
+                    #westpa.rc.pstatus(f"No lead/lag split for dim {n}")
+                    #westpa.rc.pflush()
+                    # nornmally adds to special bin but here just leaving it forever empty
+                    #holder = boundary_base + n
+                    break
 
         # the following are for the "linear" portion
         if not special:

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -106,7 +106,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
     output : list
         The main list that, for each segment, holds the bin assignment
     *args
-    **kwargs 
+    **kwargs
     '''
 
     pca = kwargs.get("pca")
@@ -289,7 +289,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
                             holder = bottleneck_base + n + 1
                             special = True
                             break
-                
+
                 # assign boundary walkers, taking directionality into account
                 if direction[n] == -1:
                     if coord == minlist[n]:
@@ -315,10 +315,10 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
                 # special value for direction with no lead/lag split
                 elif direction[n] == 86:
-                    #westpa.rc.pstatus(f"No lead/lag split for dim {n}")
-                    #westpa.rc.pflush()
+                    # westpa.rc.pstatus(f"No lead/lag split for dim {n}")
+                    # westpa.rc.pflush()
                     # nornmally adds to special bin but here just leaving it forever empty
-                    #holder = boundary_base + n
+                    # holder = boundary_base + n
                     break
 
         # the following are for the "linear" portion
@@ -359,17 +359,16 @@ def map_mab(coords, mask, output, *args, **kwargs):
         if westpa.rc.sim_manager.n_iter:
             with open(expandvars("$WEST_SIM_ROOT/binbounds.log"), 'a') as bb_file:
                 # Iteration Number
-                bb_file.write(f'{westpa.rc.sim_manager.n_iter}\n')  
+                bb_file.write(f'{westpa.rc.sim_manager.n_iter}\n')
                 for n in range(ndim):
                     # Write binbounds per dim
-                    bb_file.write(f'{np.linspace(minlist[n], maxlist[n], nbins_per_dim[n] + 1)}\t')  
+                    bb_file.write(f'{np.linspace(minlist[n], maxlist[n], nbins_per_dim[n] + 1)}\t')
                 # Min/Max pcoord
-                bb_file.write(f'\n{minlist} {maxlist}\n')  
+                bb_file.write(f'\n{minlist} {maxlist}\n')
                 if bottleneck_base > boundary_base:
                     # Bottlenecks
-                    bb_file.write(f'{flipdifflist} {difflist}\n\n')  
+                    bb_file.write(f'{flipdifflist} {difflist}\n\n')
                 else:
                     bb_file.write('\n')
 
     return output
-

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -136,13 +136,13 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
     # Argument Processing
     nbins_per_dim = kwargs.get("nbins_per_dim")
+    ndim = len(nbins_per_dim)
     pca = kwargs.get("pca", False)
     bottleneck = kwargs.get("bottleneck", True)
-    direction = kwargs.get("direction", ([0] * nbins_per_dim))
-    skip = kwargs.get("skip", ([0] * nbins_per_dim))
+    direction = kwargs.get("direction", ([0] * ndim))
+    skip = kwargs.get("skip", ([0] * ndim))
     mab_log = kwargs.get("mab_log", False)
     bin_log = kwargs.get("bin_log", False)
-    ndim = len(nbins_per_dim)
 
     if not np.any(mask):
         return output
@@ -255,6 +255,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
     # which is two per dimension unless there is a direction specified
     # in a particluar dimension, then it's just one
     bottleneck_base = boundary_base
+    n_bottleneck_filled = 0
 
     for i in range(0, ndim):
         # for single direction, 1 boundary walker
@@ -296,12 +297,14 @@ def map_mab(coords, mask, output, *args, **kwargs):
                         if coord == flipdifflist[n]:
                             holder = bottleneck_base + n
                             special = True
+                            n_bottleneck_filled += 1
                             break
 
                     if direction[n] == 1:
                         if coord == difflist[n]:
                             holder = bottleneck_base + n
                             special = True
+                            n_bottleneck_filled += 1
                             break
 
                     # both directions when using 0 or with
@@ -310,10 +313,12 @@ def map_mab(coords, mask, output, *args, **kwargs):
                         if coord == difflist[n]:
                             holder = bottleneck_base + n
                             special = True
+                            n_bottleneck_filled += 1
                             break
                         elif coord == flipdifflist[n]:
                             holder = bottleneck_base + n + 1
                             special = True
+                            n_bottleneck_filled += 1
                             break
 
                 # assign boundary walkers, taking directionality into account
@@ -389,11 +394,12 @@ def map_mab(coords, mask, output, *args, **kwargs):
                 for n in range(ndim):
                     # Write binbounds per dim
                     bb_file.write(f'{np.linspace(minlist[n], maxlist[n], nbins_per_dim[n] + 1)}\t')
-                # Min/Max pcoord
-                bb_file.write(f'\n{minlist} {maxlist}\n')
-                if bottleneck_base > boundary_base:
-                    # Bottlenecks
-                    bb_file.write(f'{flipdifflist} {difflist}\n\n')
+                    # Min/Max pcoord
+                    bb_file.write(f'\nmin/max pcoord: {minlist} {maxlist}\n')
+                if n_bottleneck_filled > 0:
+                    # Bottlenecks bins exist (passes any of the if bottleneck: checks)
+                    bb_file.write(f'bottleneck bins: {n_bottleneck_filled}\n')
+                    bb_file.write(f'bottleneck pcoord: {flipdifflist} {difflist}\n\n')
                 else:
                     bb_file.write('\n')
 

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -410,15 +410,15 @@ def map_mab(coords, mask, output, *args, **kwargs):
         if westpa.rc.sim_manager.n_iter:
             with open(expandvars(bin_log_path), 'a') as bb_file:
                 # Iteration Number
-                bb_file.write(f'{westpa.rc.sim_manager.n_iter}\n')
+                bb_file.write(f'iteration: {westpa.rc.sim_manager.n_iter}\n')
                 for n in range(ndim):
                     # Write binbounds per dim
                     bb_file.write(f'{np.linspace(minlist[n], maxlist[n], nbins_per_dim[n] + 1)}\t')
                     # Min/Max pcoord
-                    bb_file.write(f'\nmin/max pcoord: {minlist} {maxlist}\n')
+                bb_file.write(f'\nmin/max pcoord: {minlist} {maxlist}\n')
+                bb_file.write(f'bottleneck bins: {n_bottleneck_filled}\n')
                 if n_bottleneck_filled > 0:
                     # Bottlenecks bins exist (passes any of the if bottleneck: checks)
-                    bb_file.write(f'bottleneck bins: {n_bottleneck_filled}\n')
                     bb_file.write(f'bottleneck pcoord: {flipdifflist} {difflist}\n\n')
                 else:
                     bb_file.write('\n')

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -11,7 +11,10 @@ log = logging.getLogger(__name__)
 
 
 class MABSimManager(WESimManager):
+    '''Subclass of WESimManager, modifying it so bin assignments will be done after all segments are done propagating.'''
+
     def initialize_simulation(self, basis_states, target_states, start_states, segs_per_state=1, suppress_we=False):
+        '''Making sure that that the MABBinMapper is not the outer bin.'''
         if len(target_states) > 0:
             if isinstance(self.system.bin_mapper, MABBinMapper):
                 log.error("MABBinMapper cannot be an outer binning scheme with a target state\n")


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Added a direction option for the MAB bin mapper to use no boundary walker splitting. Essentially a 'lite' version of normal MAB. Also made the 1 and -1 directions specific instead of >1 or <1. Added docstrings to mab.py and cleaned up a bit.

Users can also add `bin_log_path:` in the west.cfg to specify the file to output path/file name of `bin_log`. Otherwise (like current behavior), it'll save into `$WEST_SIM_ROOT/binbounds.log`

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] A new MAB direction option for no boundary walker splitting

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] mab.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the CONTRIBUTING document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


