### PR TITLE
Add support for testing and wheel-building on macos-arm64 (Apple Silicon)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,6 @@ jobs:
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
           CIBW_ARCHS_MACOS: "auto64" # x86_64 and arm64, depending on the os
           CIBW_ARCHS_LINUX: "auto64" # x86_64 only
-          CIBW_TEST_SKIP: "*-macosx_arm64"
           CIBW_DEPENDENCY_VERSIONS: "latest"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
@@ -61,51 +60,6 @@ jobs:
           name: artifact-wheels-${{ matrix.os }}-${{ matrix.python-version }}
           path: ./wheelhouse/*.whl
           overwrite: true
-
-#   # Split off macos arm64 building...
-#   # Disabled for now... as of 2022-10-12
-#   # Currently creates broken arm64 wheels due to dependencies; unable to check
-#   # because macos_arm64 tests are not supported in macos_x86-64
-#   build_wheels_macos_arm64:
-#     name: Build py3.${{ matrix.python-version }} wheels on Apple Silicon
-#     runs-on: ${{ matrix.os }}
-#     strategy:
-#       matrix:
-#         os: [macos-latest]
-#         python-version: [8, 9, 10, 11] # sub-versions of Python, there is no py3.7-macosx_arm64
-# 
-#     steps:
-#       - uses: actions/checkout@v4
-# 
-#       - name: Build wheels
-#         uses: pypa/cibuildwheel@v2.16.1
-#         env:
-#           CIBW_SKIP: "pp*"
-#           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
-#           CIBW_ARCHS_MACOS: "arm64"
-#           CIBW_TEST_COMMAND: > 
-#             python -c "import westpa; print(westpa.__version__)" && 
-#             python -c "import westpa.core.propagators" &&
-#             python -c "import westpa.core.binning" &&
-#             python -c "import westpa.core.kinetics" &&
-#             python -c "import westpa.core.reweight" &&
-#             python -c "import westpa.work_managers" &&
-#             python -c "import westpa.tools" &&
-#             python -c "import westpa.fasthist" &&
-#             python -c "import westpa.mclib" &&
-#             echo "All done with the import tests!"
-#             # Currently blocked by https://github.com/westpa/westpa/issues/70
-#             # python -c "import westpa.trajtree"
-#         with:
-#           package-dir: .
-#           output-dir: wheelhouse
-#           config-file: "{package}/pyproject.toml"
-# 
-#       - uses: actions/upload-artifact@v4
-#         with:
-#           name: artifact-wheels-macos-aarch64-${{ matrix.python-version }}
-#           path: ./wheelhouse/*.whl
-#           overwrite: true
 
   build_sdist:
     name: Build source distribution
@@ -143,7 +97,7 @@ jobs:
 
   upload_testpypi:
     name: test.pypi
-    needs: [build_wheels, build_sdist] #, build_wheels_macos_arm64] # Skipping the apple silicon versions...
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment:
       name: test.pypi
@@ -171,7 +125,7 @@ jobs:
 
   upload_pypi:
     name: PyPI
-    needs: [build_wheels, build_sdist] #, build_wheels_macos_arm64] # Skipping the apple silicon versions...
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13, macos-14]  # macos-13 is x86_64, maxos-14 is arm64
         python-version: [8, 9, 10, 11] # sub-versions of Python
 
     steps:
@@ -34,7 +34,7 @@ jobs:
         env:
           CIBW_SKIP: "pp* *-musllinux*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
-          CIBW_ARCHS_MACOS: "auto64" # x86_64 only
+          CIBW_ARCHS_MACOS: "auto64" # x86_64 and arm64, depending on the os
           CIBW_ARCHS_LINUX: "auto64" # x86_64 only
           CIBW_TEST_SKIP: "*-macosx_arm64"
           CIBW_DEPENDENCY_VERSIONS: "latest"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]  # macos-13 is x86_64, maxos-14 is arm64
+        os: [ubuntu-latest, macos-13, macos-14]  # macos-13 is x86_64, macos-14 is arm64
         python-version: [8, 9, 10, 11] # sub-versions of Python
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,6 @@ on:
   pull_request:
     branches:
       - 'westpa2'
-      - 'develop'  # REVERT WHEN MERGING
   release:
     types:
       - published

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, macos-14]  # macos-13 is x86_64, macos-14 is arm64
         python-version: [8, 9, 10, 11] # sub-versions of Python
-
+        exclude:
+          - os: macos-14
+            python-version: 8
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - 'westpa2'
+      - 'develop'  # REVERT WHEN MERGING
   release:
     types:
       - published

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_SKIP: "pp* *-musllinux*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,13 +24,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-latest"]  # macos-13 is x86_64, macos-14 is arm64
+        os: ["ubuntu-latest", "macos-13", "macos-latest"]  # macos-13 is x86_64, macos-latest is arm64
         python-version: [8, 9, 10, 11] # sub-versions of Python
         exclude:
           - os: macos-14
             python-version: 8
     steps:
       - uses: actions/checkout@v4
+
+      - name: "Install HDF5 with brew"
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: "brew install hdf5"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]  # macos-13 is x86_64, macos-14 is arm64
+        os: ["ubuntu-latest", "macos-13", "macos-latest"]  # macos-13 is x86_64, macos-14 is arm64
         python-version: [8, 9, 10, 11] # sub-versions of Python
         exclude:
           - os: macos-14

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - "westpa2"
       - "develop"
-      - "arm64-wheels"  # REMEMBER TO REMOVE THIS AFTER TESTING
   pull_request:
     branches:
       - "westpa2"
@@ -123,7 +122,6 @@ jobs:
       shell: bash -l {0}
       run: |
         conda info --all
-        brew install hdf5
         python -m pip install . -v --no-deps
         conda list
 
@@ -164,14 +162,11 @@ jobs:
   install-dev-macos-arm64:
     name: "Verify dev env"
     runs-on: "macos-latest"
-
     steps:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v5"
         with:
           python-version: "3.11"
-      - name: "Install HDF5 with brew"
-        run: "brew install hdf5"
       - name: "Install in dev mode"
         run: "python -m pip install -e .[dev]"
       - name: "Import package"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - "westpa2"
       - "develop"
+      - "arm64-wheels"  # REMEMBER TO REMOVE THIS AFTER TESTING
   pull_request:
     branches:
       - "westpa2"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,8 +35,8 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-14"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: ["ubuntu-latest", "macos-13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -86,10 +86,67 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  test-macos-arm64:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      matrix:
+        os: ["macos-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+      with: 
+        fetch-depth: 2
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        miniforge-variant: Mambaforge
+        environment-file: devtools/conda-envs/test_env.yaml
+        activate-environment: test_env
+        channel-priority: true
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true
+
+    - name: Install package
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        conda info --all
+        brew install hdf5
+        python -m pip install . -v --no-deps
+        conda list
+
+    - name: Run tests
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        pytest -v --cov=westpa --cov-report=xml --color=yes tests
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-{{ '${{ matrix.os }}' }}-py{{ '${{ matrix.python-version }}' }}
+        fail_ci_if_error: false
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   install-dev:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-14"]
+        os: ["ubuntu-latest", "macos-13"]
 
     name: "Verify dev env"
     runs-on: "${{ matrix.os }}"
@@ -99,6 +156,22 @@ jobs:
       - uses: "actions/setup-python@v5"
         with:
           python-version: "3.11"
+      - name: "Install in dev mode"
+        run: "python -m pip install -e .[dev]"
+      - name: "Import package"
+        run: "python -c 'import westpa; print(westpa.__version__)'"
+
+  install-dev-macos-arm64:
+    name: "Verify dev env"
+    runs-on: "macos-latest"
+
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.11"
+      - with: "Install HDF5 with brew"
+        run: "brew install hdf5"
       - name: "Install in dev mode"
         run: "python -m pip install -e .[dev]"
       - name: "Import package"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-latest"]  # "macos-13" is x86-64, "macos-latest" is arm64
+        os: ["ubuntu-latest", "macos-13", "macos-latest"]  # macos-13 is x86-64, macos-latest is arm64
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   install-dev:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-latest"]  # "macos-13" is x86-64, "macos-latest" is arm64
+        os: ["ubuntu-latest", "macos-13", "macos-latest"]  # macos-13 is x86-64, macos-latest is arm64
 
     name: "Verify dev env"
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-latest"]
+        os: ["ubuntu-latest", "macos-13", "macos-latest"]  # "macos-13" is x86-64, "macos-latest" is arm64
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   install-dev:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13"]
+        os: ["ubuntu-latest", "macos-13", "macos-latest"]  # "macos-13" is x86-64, "macos-latest" is arm64
 
     name: "Verify dev env"
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,63 +34,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-
-    steps:
-    - uses: actions/checkout@v4
-      with: 
-        fetch-depth: 2
-
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
-
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-        miniforge-variant: Mambaforge
-        environment-file: devtools/conda-envs/test_env.yaml
-        activate-environment: test_env
-        channel-priority: true
-        auto-update-conda: true
-        auto-activate-base: false
-        show-channel-urls: true
-
-    - name: Install package
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        conda info --all
-        python -m pip install . -v --no-deps
-        conda list
-
-    - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        pytest -v --cov=westpa --cov-report=xml --color=yes tests
-
-    - name: CodeCov
-      uses: codecov/codecov-action@v4
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-{{ '${{ matrix.os }}' }}-py{{ '${{ matrix.python-version }}' }}
-        fail_ci_if_error: false
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  test-macos-arm64:
-    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
-    runs-on: "${{ matrix.os }}"
-    strategy:
-      matrix:
-        os: ["macos-latest"]
+        os: ["ubuntu-latest", "macos-13", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -154,20 +98,11 @@ jobs:
       - uses: "actions/setup-python@v5"
         with:
           python-version: "3.11"
+      - name: "Install HDF5 with brew if macos-arm64"
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: "brew install hdf5"
       - name: "Install in dev mode"
         run: "python -m pip install -e .[dev]"
       - name: "Import package"
         run: "python -c 'import westpa; print(westpa.__version__)'"
 
-  install-dev-macos-arm64:
-    name: "Verify dev env"
-    runs-on: "macos-latest"
-    steps:
-      - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v5"
-        with:
-          python-version: "3.11"
-      - name: "Install in dev mode"
-        run: "python -m pip install -e .[dev]"
-      - name: "Import package"
-        run: "python -c 'import westpa; print(westpa.__version__)'"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-13", "macos-14"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
@@ -89,7 +89,7 @@ jobs:
   install-dev:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-13", "macos-14"]
 
     name: "Verify dev env"
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -170,7 +170,7 @@ jobs:
       - uses: "actions/setup-python@v5"
         with:
           python-version: "3.11"
-      - with: "Install HDF5 with brew"
+      - name: "Install HDF5 with brew"
         run: "brew install hdf5"
       - name: "Install in dev mode"
         run: "python -m pip install -e .[dev]"


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Adds ability to build macos-arm64 wheels for WESTPA. Users will still have to have their own HDF5 install to install our upstream dependency `PyTables` on Apple Silicon Macs.  See notes [here](https://github.com/westpa/westpa/wiki/Alternate-Installation-Instructions#macos-aarch64-apple-silicon).

Here's a link of the CI (build workflow) showing it works.
https://github.com/jeremyleung521/westpa/actions/runs/8853098441

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] build macos-arm64 wheels for WESTPA
- [x] test on both macos-arm64 and macos-x86-64

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] .github folder

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


