### PR TITLE
Swapping CI env to install mdtraj with conda

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -15,12 +15,10 @@ dependencies:
   - ipykernel
   - mpi4py
   - tqdm
+  - mdtraj
   # testing
   - pytest
   - pytest-cov
   - pytest-rerunfailures
   - pytest-timeout
   - codecov
-  - pip
-  - pip:
-    - mdtraj


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
MDTraj updated their conda recipe and we FINALLY have builds for osx (and python 3.12!). This should speed up the CI by quite a bit because we no longer have to install from source using `pip`.

Seems like at least a minute savings during the `setup-miniconda` step.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] faster CI by installing mdtraj with conda

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] devtools/conda-envs/test_env.yaml

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


