### PR TITLE
Duplicate Priority/Function Name Callback Crash Fix

### DIFF
--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -1,12 +1,12 @@
-from datetime import timedelta
-from itertools import zip_longest
 import logging
 import math
 import operator
-from pickle import PickleError
 import random
 import time
-
+from datetime import timedelta
+from pickle import PickleError
+from itertools import zip_longest
+from collections import Counter
 
 import numpy as np
 
@@ -131,11 +131,21 @@ class WESimManager:
         except KeyError:
             self._callback_table[hook] = set([(priority, function.__name__, function)])
 
+        # Raise warning if there are multiple callback with same priority.
+        for key, val in self._callback_table.items():
+            for priority, count in Counter([hook[0] for hook in val]).items():
+                if count > 1:
+                    log.warning(
+                        f'{count} callbacks in {key} have identical priority {priority}. The order of callback execution is not guaranteed.'
+                    )
+                    log.warning(f'{key}: {val}')
+
         log.debug('registered callback {!r} for hook {!r}'.format(function, hook))
 
     def invoke_callbacks(self, hook, *args, **kwargs):
         callbacks = self._callback_table.get(hook, [])
-        sorted_callbacks = sorted(callbacks)
+        # Sort by priority, function name, then module name
+        sorted_callbacks = sorted(callbacks, key=lambda x: (x[0], x[1], x[2].__module__))
         for priority, name, fn in sorted_callbacks:
             log.debug('invoking callback {!r} for hook {!r}'.format(fn, hook))
             fn(*args, **kwargs)

--- a/src/westpa/westext/stringmethod/string_method.py
+++ b/src/westpa/westext/stringmethod/string_method.py
@@ -1,6 +1,10 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
-from collections import Iterable
 import logging
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import numpy as np
 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
#409 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->

WESTPA crashes when callbacks with the same priority and name are called. This adds in an extra key for sorted() where callbacks could be sorted by module name as well (after priority and function name).  An explicit warning is raised when multiple callbacks with the same priority are registered.

A separate PR for WESTPA 1.0 will be made shortly.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Raise warning when multiple callbacks with same priority are added.
- [x] Allow different callbacks with same priority and name to be sorted by module name
- [x] Reorganized import into a cleaner order
- [x] Fix String Method Plugin import

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/sim_manager.py
- [x] src/westpa/westext/stringmethod/string_method.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


