### PR TITLE
WESTPA 1.0 Bug Fix:  Duplicate Priority/Function Name Callback Crash Fix 

### DIFF
--- a/src/west/sim_manager.py
+++ b/src/west/sim_manager.py
@@ -107,13 +107,12 @@ class WESimManager:
             self._callback_table[hook] = set([(priority,function.__name__,function)])
 
         # Raise warning if there are multiple callback with same priority.
-        for key, val in self._callback_table.items():
-            for priority, count in Counter([hook[0] for hook in val]).items():
-                if count > 1:
-                    log.warning(
-                        f'{count} callbacks in {key} have identical priority {priority}. The order of callback execution is not guaranteed.'
-                    )
-                    log.warning(f'{key}: {val}')
+        for priority, count in Counter([callback[0] for callback in self._callback_table[hook]]).items():
+            if count > 1:
+                log.warning(
+                    f'{count} callbacks in {hook} have identical priority {priority}. The order of callback execution is not guaranteed.'
+                )
+                log.warning(f'{hook}: {self._callback_table[hook]}')
         
         log.debug('registered callback {!r} for hook {!r}'.format(function, hook))
                 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
#409 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->

WESTPA crashes when callbacks with the same priority and name are called. This adds in an extra key for sorted() where callbacks could be sorted by module name as well (after priority and function name).  An explicit warning is raised when multiple callbacks with the same priority are registered.

This is the separate PR for WESTPA 1.0.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Raise warning when multiple callbacks with same priority are added.
- [x] Allow different callbacks with same priority and name to be sorted by module name

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/west/sim_manager.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->