### PR TITLE
Allow bins to be autodetected with negative max values.

### DIFF
--- a/src/westpa/cli/tools/w_pdist.py
+++ b/src/westpa/cli/tools/w_pdist.py
@@ -423,7 +423,10 @@ Command-line options
             lb, ub = self.data_range[idim]
             # Advance just beyond the upper bound of the range, so that we catch
             # the maximum in the histogram
-            ub *= 1.01
+            if ub > 0:
+                ub *= 1.01
+            else:
+                ub /= 1.01
 
             boundset = np.linspace(lb, ub, bins + 1)
             midpoints = (boundset[:-1] + boundset[1:]) / 2.0

--- a/src/westpa/cli/tools/w_pdist.py
+++ b/src/westpa/cli/tools/w_pdist.py
@@ -443,7 +443,10 @@ Command-line options
             lb, ub = self.data_range[idim]
             # Advance just beyond the upper bound of the range, so that we catch
             # the maximum in the histogram
-            ub *= 1.01
+            if ub > 0:
+                ub *= 1.01
+            else:
+                ub /= 1.01
 
             boundset = np.linspace(lb, ub, bins[idim] + 1)
             midpoints = (boundset[:-1] + boundset[1:]) / 2.0


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
When running `w_pdist`, If your dataset has negative values, (and that happens to be your upper bound value), then you would likely get an pcoord out of bound error. This fixes it.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Allow auto detection of bin bounds

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/cli/tools/w_pdist.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->
Test code:

```
from westpa.cli.tools.w_pdist import WPDist

a = WPDist()
a.ndim = 1
a.data_range = [(-21,-1)]
a._construct_bins_from_scalar(5)
print(a.binbounds)
# Output: [array([-21.        , -16.9980198 , -12.9960396 ,  -8.99405941, -4.99207921,  -0.99009901])]
```
