### PR TITLE
Suppress NaturalNameWarning when using HDF5 Framework

### DIFF
--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -9,10 +9,12 @@ import socket
 import sys
 import time
 import logging
+import warnings
 
 import h5py
 import numpy as np
 from numpy import index_exp
+from tables import NaturalNameWarning
 
 from mdtraj import Trajectory, join as join_traj
 from mdtraj.utils import in_units_of, import_, ensure_type
@@ -28,6 +30,7 @@ except ImportError:
     psutil = None
 
 log = logging.getLogger(__name__)
+warnings.filterwarnings('ignore', category=NaturalNameWarning)
 
 #
 # Constants and globals


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Depending on the verbosity, ``Pytables`` raises ``NaturalNameWarning`` when we use the HDF5 Framework because some of our datasets/nodes are name like ``0_0`` (or the format ``<iteration>_<stateid>``). This PR suppresses such error because it's not helpful.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Silent common NaturalNameWarning from PyTables (via mdtraj)

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/h5io.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->

```
/usr/local/lib/python3.10/dist-packages/tables/path.py:137: NaturalNameWarning: object name is not a valid Python identifier: '0_12'; it does not match the pattern ``^[a-zA-Z_][a-zA-Z0-9_]*$``; you will not be able to use natural naming to access this object; using ``getattr()`` will still work, though
  check_attribute_name(name)
```