### PR TITLE
Small w_states reporting bug

### DIFF
--- a/src/westpa/cli/core/w_states.py
+++ b/src/westpa/cli/core/w_states.py
@@ -157,7 +157,7 @@ def initialize(mode, bstates, _bstate_file, tstates, _tstate_file):
                             bstate.probability *= pscale
 
                     # Assign progress coordinates to basis states
-                    sim_manager.get_bstate_pcoords(basis_states, n_iter)
+                    sim_manager.get_bstate_pcoords(basis_states)
                     data_manager.create_ibstate_group(basis_states, n_iter)
                     sim_manager.report_basis_states(basis_states)
 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
When using ``w_states --replace`` on bstate, because of a typo in the code, WESTPA will report

```
Calculating progress coordinate values for <iteration number> states.
```
instead of
```
Calculating progress coordinate values for basis states.
```

This fixes that.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Fix w_states bstate calculation

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/cli/core/w_states.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


