### PR TITLE
remove mdtraj.utils.six dependency in h5io

### DIFF
--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -18,7 +18,6 @@ from tables import NaturalNameWarning
 
 from mdtraj import Trajectory, join as join_traj
 from mdtraj.utils import in_units_of, import_, ensure_type
-from mdtraj.utils.six import string_types
 from mdtraj.formats import HDF5TrajectoryFile
 from mdtraj.formats.hdf5 import _check_mode, Frames
 
@@ -554,7 +553,7 @@ class WESTIterationFile(HDF5TrajectoryFile):
                 node = self._get_node(where='/', name=name)
                 data = get_item(node, slice)
                 in_units = node.attrs.units
-                if not isinstance(in_units, string_types):
+                if not isinstance(in_units, str):
                     in_units = in_units.decode()
                 data = in_units_of(data, in_units, out_units)
                 return data


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
MDTraj just released v1.10.0, but that unfortunately removed an import that is a core part of WESTPA. This patches that out.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Make WESTPA MDTraj 1.10.0 compatible

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/h5io.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


