### PR TITLE
w_truncate accepts truncate iterations > current_iteration

### DIFF
--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -40,7 +40,7 @@ def entry_point():
 
     dm.open_backing()
     # max_iter = dm.current_iteration
-    n_iter = args.n_iter if args.n_iter > 0 else dm.current_iteration
+    n_iter = args.n_iter if dm.current_iteration > args.n_iter > 0 else dm.current_iteration
 
     for i in range(n_iter, dm.current_iteration + 1):
         dm.del_iter_group(i)

--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -42,7 +42,7 @@ def entry_point():
     # max_iter = dm.current_iteration
 
     if args.n_iter > dm.current_iteration:
-        raise argparse.InvalidArgumentError(
+        raise ValueError(
             'Provided iteration {} > current iteration {} of the {} HDF5 file. Exiting.'.format(
                 args.n_iter, dm.current_iteration, dm.we_h5filename
             )

--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -1,5 +1,5 @@
-import argparse
 import logging
+from argparse import ArgumentParser
 
 import westpa
 
@@ -14,7 +14,7 @@ traj_segs directory) is deleted or moved for the corresponding iterations.
 
 
 def entry_point():
-    parser = argparse.ArgumentParser(
+    parser = ArgumentParser(
         'w_truncate',
         description='''\
     Remove all iterations after a certain point in a WESTPA simulation.
@@ -42,9 +42,9 @@ def entry_point():
     # max_iter = dm.current_iteration
 
     if args.n_iter > dm.current_iteration:
-        raise ValueError(
-            'Provided iteration {} > current iteration {} of the {} HDF5 file. Exiting.'.format(
-                args.n_iter, dm.current_iteration, dm.we_h5filename
+        parser.error(
+            'Provided iteration {} > current iteration {} of the {} HDF5 file. Exiting without doing anything.'.format(
+                args.n_iter, dm.current_iteration, dm.we_h5filename.split('/')[-1]
             )
         )
     else:

--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -40,14 +40,15 @@ def entry_point():
 
     dm.open_backing()
     # max_iter = dm.current_iteration
-    n_iter = args.n_iter if dm.current_iteration >= args.n_iter > 0 else dm.current_iteration
 
     if args.n_iter > dm.current_iteration:
-        log.warning(
-            'Provided iteration {} > final iteration {} of HDF file. Defaulting to iteration {}.'.format(
-                args.n_iter, dm.current_iteration, n_iter
+        raise argparse.InvalidArgumentError(
+            'Provided iteration {} > current iteration {} of the {} HDF5 file. Exiting.'.format(
+                args.n_iter, dm.current_iteration, dm.we_h5filename
             )
         )
+    else:
+        n_iter = args.n_iter if args.n_iter > 0 else dm.current_iteration
 
     for i in range(n_iter, dm.current_iteration + 1):
         dm.del_iter_group(i)

--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -40,7 +40,14 @@ def entry_point():
 
     dm.open_backing()
     # max_iter = dm.current_iteration
-    n_iter = args.n_iter if dm.current_iteration > args.n_iter > 0 else dm.current_iteration
+    n_iter = args.n_iter if dm.current_iteration >= args.n_iter > 0 else dm.current_iteration
+
+    if args.n_iter > dm.current_iteration:
+        log.warning(
+            'Provided iteration {} > final iteration {} of HDF file. Defaulting to iteration {}.'.format(
+                args.n_iter, dm.current_iteration, n_iter
+            )
+        )
 
     for i in range(n_iter, dm.current_iteration + 1):
         dm.del_iter_group(i)
@@ -48,8 +55,9 @@ def entry_point():
     dm.del_iter_summary(n_iter)
     dm.current_iteration = n_iter - 1
 
-    print('simulation data truncated after iteration {}'.format(dm.current_iteration))
-    print('\n' + warning_string)
+    westpa.rc.pstatus('simulation data truncated after iteration {}'.format(dm.current_iteration))
+    westpa.rc.pstatus('\n' + warning_string)
+    westpa.rc.pflush()
 
     dm.flush_backing()
     dm.close_backing()

--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -30,7 +30,7 @@ def entry_point():
         metavar='WEST_H5FILE',
         help='''Take WEST data from WEST_H5FILE (default: read from the HDF5 file specified in west.cfg).''',
     )
-    parser.add_argument('-n', '--iter', dest='n_iter', type=int, help='Truncate this iteration and those following.')
+    parser.add_argument('-n', '--iter', dest='n_iter', type=int, default=0, help='Truncate this iteration and those following.')
 
     args = parser.parse_args()
     westpa.rc.process_args(args, config_required=False)

--- a/tests/test_tools/test_w_truncate.py
+++ b/tests/test_tools/test_w_truncate.py
@@ -1,5 +1,6 @@
 import h5py
 import argparse
+import pytest
 from unittest import mock
 
 from westpa.cli.core.w_truncate import entry_point
@@ -40,3 +41,13 @@ class Test_W_Truncate:
             assert 'iter_00000003' not in list(_hfile['/iterations'].keys())
             assert 'iter_00000002' in list(_hfile['/iterations'].keys())
             assert _hfile.attrs['west_current_iteration'] == 2
+
+    @pytest.mark.xfail(raises=SystemExit)
+    def test_run_w_truncate_fail(self, ref_3iter):
+        '''Tests running w_truncate on a 3 iteration h5 file, but running with n_iter=0'''
+
+        with mock.patch(
+            target='argparse.ArgumentParser.parse_args',
+            return_value=argparse.Namespace(verbosity='debug', rcfile=self.cfg_filepath, n_iter=5, we_h5filename=None),
+        ):
+            entry_point()

--- a/tests/test_tools/test_w_truncate.py
+++ b/tests/test_tools/test_w_truncate.py
@@ -1,10 +1,8 @@
+import h5py
 import argparse
+from unittest import mock
 
 from westpa.cli.core.w_truncate import entry_point
-from unittest import mock
-import h5py
-
-import os
 
 
 class Test_W_Truncate:
@@ -22,9 +20,28 @@ class Test_W_Truncate:
         ):
             entry_point()
 
-        print(os.getcwd())
         _hfile = h5py.File(self.h5_filepath, mode='r')
-        print(_hfile['/iterations'].keys())
         assert 'iter_00000003' not in list(_hfile['/iterations'].keys())
         assert 'iter_00000002' not in list(_hfile['/iterations'].keys())
+        assert _hfile.attrs['west_current_iteration'] == 1
+        _hfile.close()
+
+    def test_run_w_truncate_default(self, ref_3iter):
+        '''Tests running w_truncate on a 3 iteration h5 file, but running with n_iter=0'''
+
+        _hfile = h5py.File(self.h5_filepath, mode='r')
+        assert 'iter_00000003' in list(_hfile['/iterations'].keys())
+        _hfile.close()
+        del _hfile
+
+        with mock.patch(
+            target='argparse.ArgumentParser.parse_args',
+            return_value=argparse.Namespace(verbosity='debug', rcfile=self.cfg_filepath, n_iter=0, we_h5filename=None),
+        ):
+            entry_point()
+
+        _hfile = h5py.File(self.h5_filepath, mode='r')
+        assert 'iter_00000003' not in list(_hfile['/iterations'].keys())
+        assert 'iter_00000002' in list(_hfile['/iterations'].keys())
+        assert _hfile.attrs['west_current_iteration'] == 2
         _hfile.close()

--- a/tests/test_tools/test_w_truncate.py
+++ b/tests/test_tools/test_w_truncate.py
@@ -9,10 +9,8 @@ class Test_W_Truncate:
     def test_run_w_truncate(self, ref_3iter):
         '''Tests running w_truncate on a 3 iteration h5 file'''
 
-        _hfile = h5py.File(self.h5_filepath, mode='r')
-        assert 'iter_00000003' in list(_hfile['/iterations'].keys())
-        _hfile.close()
-        del _hfile
+        with h5py.File(self.h5_filepath, mode='r') as _hfile:
+            assert 'iter_00000003' in list(_hfile['/iterations'].keys())
 
         with mock.patch(
             target='argparse.ArgumentParser.parse_args',
@@ -20,19 +18,17 @@ class Test_W_Truncate:
         ):
             entry_point()
 
-        _hfile = h5py.File(self.h5_filepath, mode='r')
-        assert 'iter_00000003' not in list(_hfile['/iterations'].keys())
-        assert 'iter_00000002' not in list(_hfile['/iterations'].keys())
-        assert _hfile.attrs['west_current_iteration'] == 1
+        with h5py.File(self.h5_filepath, mode='r') as _hfile:
+            assert 'iter_00000003' not in list(_hfile['/iterations'].keys())
+            assert 'iter_00000002' not in list(_hfile['/iterations'].keys())
+            assert _hfile.attrs['west_current_iteration'] == 1
         _hfile.close()
 
     def test_run_w_truncate_default(self, ref_3iter):
         '''Tests running w_truncate on a 3 iteration h5 file, but running with n_iter=0'''
 
-        _hfile = h5py.File(self.h5_filepath, mode='r')
-        assert 'iter_00000003' in list(_hfile['/iterations'].keys())
-        _hfile.close()
-        del _hfile
+        with h5py.File(self.h5_filepath, mode='r') as _hfile:
+            assert 'iter_00000003' in list(_hfile['/iterations'].keys())
 
         with mock.patch(
             target='argparse.ArgumentParser.parse_args',
@@ -40,8 +36,7 @@ class Test_W_Truncate:
         ):
             entry_point()
 
-        _hfile = h5py.File(self.h5_filepath, mode='r')
-        assert 'iter_00000003' not in list(_hfile['/iterations'].keys())
-        assert 'iter_00000002' in list(_hfile['/iterations'].keys())
-        assert _hfile.attrs['west_current_iteration'] == 2
-        _hfile.close()
+        with h5py.File(self.h5_filepath, mode='r') as _hfile:
+            assert 'iter_00000003' not in list(_hfile['/iterations'].keys())
+            assert 'iter_00000002' in list(_hfile['/iterations'].keys())
+            assert _hfile.attrs['west_current_iteration'] == 2


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Added additional check such that it's not possible to `w_truncate` to an iteration > current iteration

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Make w_truncate bug-free

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/cli/core/w_truncate.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


