### PR TITLE
Matplotlib 3.9 compatibility fix

### DIFF
--- a/src/westpa/oldtools/aframe/plotting.py
+++ b/src/westpa/oldtools/aframe/plotting.py
@@ -66,10 +66,10 @@ else:
     cm_pdr = matplotlib.colors.LinearSegmentedColormap('pdr', _pdr_data, 2048)
     cm_pdr_r = cm_pdr.reversed()
 
-    matplotlib.cm.register_cmap('pdr', cm_pdr)
-    matplotlib.cm.register_cmap('pdr_r', cm_pdr_r)
-    matplotlib.cm.register_cmap('hovmol', cm_hovmol)
-    matplotlib.cm.register_cmap('hovmol_r', cm_hovmol_r)
+    matplotlib.colormaps.register(cmap=cm_pdr, name='pdr')
+    matplotlib.colormaps.register(cmap=cm_pdr_r, name='pdr_r')
+    matplotlib.colormaps.register(cmap=cm_hovmol, name='hovmol')
+    matplotlib.colormaps.register(cmap=cm_hovmol_r, name='hovmol_r')
 
     del cmap_data
 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Changed mpl.cm.register_cmap() to mpl.colormaps.register() because the former was deprecated and deleted in matplotlib 3.9.
https://github.com/westpa/westpa/actions/runs/9750964170/job/26949201014#step:6:29

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] make westpa compatible with matplotlib 3.9

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/oldtools/aframe/plotting.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


