### PR TITLE
remove w_fluxanl deprecation warning

### DIFF
--- a/src/westpa/cli/tools/w_fluxanl.py
+++ b/src/westpa/cli/tools/w_fluxanl.py
@@ -1,7 +1,6 @@
 import h5py
 import numpy as np
 from scipy.signal import fftconvolve
-from warnings import warn
 
 import westpa
 
@@ -370,7 +369,6 @@ the true value of ``tau``.
 
 
 def entry_point():
-    warn('w_fluxanl is being deprecated.  Please use w_assign and w_direct instead.')
     WFluxanlTool().main()
 
 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Dropping the deprecation warning for `w_fluxanl`. We're no longer deprecating it.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Drop deprecation warning for `w_fluxanl`

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/cli/tools/w_fluxanl.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


