### PR TITLE
Dropping Python 3.8 Testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
         run: "brew install hdf5"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
+        uses: pypa/cibuildwheel@v2.21.2
         env:
           CIBW_SKIP: "pp* *-musllinux*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,10 +24,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-13", "macos-latest"]  # macos-13 is x86_64, macos-latest is arm64
-        python-version: [8, 9, 10, 11, 12] # sub-versions of Python
-        exclude:
-          - os: macos-14
-            python-version: 8
+        python-version: [9, 10, 11, 12] # sub-versions of Python
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-13", "macos-latest"]  # macos-13 is x86-64, macos-latest is arm64
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/tests/test_tools/common.py
+++ b/tests/test_tools/common.py
@@ -5,6 +5,8 @@ import pytest
 
 flaky_on_macos = pytest.mark.flaky(condition=sys.platform.startswith('darwin'), reruns=5, reason='flaky on macos')
 
+flaky_on_all = pytest.mark.flaky(reruns=5, reason='flaky on all platforms')
+
 
 # Placeholder class that will set all kwargs as attributes
 class MockArgs:

--- a/tests/test_tools/test_w_fluxanl.py
+++ b/tests/test_tools/test_w_fluxanl.py
@@ -3,7 +3,7 @@ import pytest
 import h5py
 import numpy
 
-from common import flaky_on_macos
+from common import flaky_on_all
 from westpa.cli.tools.w_fluxanl import WFluxanlTool
 
 
@@ -91,7 +91,7 @@ class Test_W_FLUXANL_NEW:
 class Test_W_Fluxanl_System:
     '''System level tests for w_fluxanl'''
 
-    @flaky_on_macos
+    @flaky_on_all
     def test_alpha(self, ref_50iter):
         '''Confidence interval size decreases as alpha increases'''
 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Since Python 3.8 reached EOL on October 7, 2024, some upstream of an upstream has decided to drop support (`pyparsing`).

This caused issues in the CI on our end. Dropping Python 3.8 testing so the other configurations run. Also added a rerun flag for `w_fluxanl` and updated a ci dependency version.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Drop Python 3.8 testing
- [x] misc ci fixes

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] See below 

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


