### PR TITLE
Allow WESS and WEED to detect when a simulation has been truncated

### DIFF
--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -1,6 +1,5 @@
 import logging
 from argparse import ArgumentParser
-import numpy as np
 
 import westpa
 
@@ -53,13 +52,6 @@ def entry_point():
 
     for i in range(n_iter, dm.current_iteration + 1):
         dm.del_iter_group(i)
-
-    # check if there has been WESS reweighting, and if so, truncate
-    if 'wess' in dm.we_h5file:
-        reweighting_history = np.array(dm.we_h5file['wess'])
-        reweighting_history = reweighting_history[reweighting_history < n_iter]
-        dm.we_h5file['wess'].resize((reweighting_history.size), axis=0)
-        dm.we_h5file['wess'][:] = reweighting_history
 
     dm.del_iter_summary(n_iter)
     dm.current_iteration = n_iter - 1

--- a/src/westpa/cli/core/w_truncate.py
+++ b/src/westpa/cli/core/w_truncate.py
@@ -1,5 +1,6 @@
 import logging
 from argparse import ArgumentParser
+import numpy as np
 
 import westpa
 
@@ -52,6 +53,13 @@ def entry_point():
 
     for i in range(n_iter, dm.current_iteration + 1):
         dm.del_iter_group(i)
+
+    # check if there has been WESS reweighting, and if so, truncate
+    if 'wess' in dm.we_h5file:
+        reweighting_history = np.array(dm.we_h5file['wess'])
+        reweighting_history = reweighting_history[reweighting_history < n_iter]
+        dm.we_h5file['wess'].resize((reweighting_history.size), axis=0)
+        dm.we_h5file['wess'][:] = reweighting_history
 
     dm.del_iter_summary(n_iter)
     dm.current_iteration = n_iter - 1

--- a/src/westpa/westext/weed/weed_driver.py
+++ b/src/westpa/westext/weed/weed_driver.py
@@ -101,7 +101,7 @@ class WEEDDriver:
             last_reweighting = int(weed_global_group.attrs.get('last_reweighting', 0))
             if last_reweighting > n_iter:
                 last_reweighting = n_iter - 1
-                reweighting_history = np.array(reweighting_history_dataset)
+                reweighting_history = reweighting_history_dataset[:]
                 reweighting_history = reweighting_history[reweighting_history < n_iter]
                 reweighting_history_dataset.resize((reweighting_history.size), axis=0)
 

--- a/src/westpa/westext/weed/weed_driver.py
+++ b/src/westpa/westext/weed/weed_driver.py
@@ -94,8 +94,14 @@ class WEEDDriver:
             return
 
         with self.data_manager.lock:
-            weed_global_group = self.data_manager.we_h5file.require_group('weed')
-            last_reweighting = int(weed_global_group.attrs.get('last_reweighting', 0))
+            weed_global_group = self.data_manager.we_h5file.require_dataset('weed', (1,), maxshape=(None,), dtype=int)
+            last_reweighting = int(weed_global_group[-1])
+
+        if last_reweighting > n_iter:
+            reweighting_history = np.array(weed_global_group)
+            reweighting_history = reweighting_history[reweighting_history < n_iter]
+            weed_global_group.resize((reweighting_history.size), axis=0)
+            weed_global_group[:] = reweighting_history
 
         if n_iter - last_reweighting < self.reweight_period:
             # Not time to reweight yet
@@ -172,7 +178,8 @@ class WEEDDriver:
             for bin, newprob in zip(bins, binprobs):
                 bin.reweight(newprob)
 
-            weed_global_group.attrs['last_reweighting'] = n_iter
+            weed_global_group.resize((weed_global_group.shape[0] + 1), axis=0)
+            weed_global_group[-1] = n_iter
 
         assert (
             abs(1 - np.fromiter(map(operator.attrgetter('weight'), bins), dtype=np.float64, count=n_bins).sum())

--- a/src/westpa/westext/wess/wess_driver.py
+++ b/src/westpa/westext/wess/wess_driver.py
@@ -118,7 +118,7 @@ class WESSDriver:
             last_reweighting = int(wess_global_group.attrs.get('last_reweighting', 0))
             if last_reweighting > n_iter:
                 last_reweighting = n_iter - 1
-                reweighting_history = np.array(reweighting_history_dataset)
+                reweighting_history = reweighting_history_dataset[:]
                 reweighting_history = reweighting_history[reweighting_history < n_iter]
                 reweighting_history_dataset.resize((reweighting_history.size), axis=0)
 

--- a/src/westpa/westext/wess/wess_driver.py
+++ b/src/westpa/westext/wess/wess_driver.py
@@ -114,6 +114,12 @@ class WESSDriver:
             wess_global_group = self.data_manager.we_h5file.require_dataset('wess', (1,), maxshape=(None,), dtype=int)
             last_reweighting = int(wess_global_group[-1])
 
+        if last_reweighting > n_iter:
+            reweighting_history = np.array(wess_global_group)
+            reweighting_history = reweighting_history[reweighting_history < n_iter]
+            wess_global_group.resize((reweighting_history.size), axis=0)
+            wess_global_group[:] = reweighting_history
+
         if n_iter - last_reweighting < self.reweight_period:
             # Not time to reweight yet
             log.debug('not reweighting')

--- a/src/westpa/westext/wess/wess_driver.py
+++ b/src/westpa/westext/wess/wess_driver.py
@@ -111,8 +111,8 @@ class WESSDriver:
             return
 
         with self.data_manager.lock:
-            wess_global_group = self.data_manager.we_h5file.require_group('wess')
-            last_reweighting = int(wess_global_group.attrs.get('last_reweighting', 0))
+            wess_global_group = self.data_manager.we_h5file.require_dataset('wess', (1,), maxshape=(None,), dtype=int)
+            last_reweighting = int(wess_global_group[-1])
 
         if n_iter - last_reweighting < self.reweight_period:
             # Not time to reweight yet
@@ -197,7 +197,8 @@ class WESSDriver:
                 if len(bin):
                     bin.reweight(newprob)
 
-            wess_global_group.attrs['last_reweighting'] = n_iter
+            wess_global_group.resize((wess_global_group.shape[0] + 1), axis=0)
+            wess_global_group[-1] = n_iter
 
         assert (
             abs(1 - np.fromiter(map(operator.attrgetter('weight'), bins), dtype=np.float64, count=n_bins).sum())

--- a/src/westpa/westext/wess/wess_driver.py
+++ b/src/westpa/westext/wess/wess_driver.py
@@ -111,14 +111,16 @@ class WESSDriver:
             return
 
         with self.data_manager.lock:
-            wess_global_group = self.data_manager.we_h5file.require_dataset('wess', (1,), maxshape=(None,), dtype=int)
-            last_reweighting = int(wess_global_group[-1])
-
-        if last_reweighting > n_iter:
-            reweighting_history = np.array(wess_global_group)
-            reweighting_history = reweighting_history[reweighting_history < n_iter]
-            wess_global_group.resize((reweighting_history.size), axis=0)
-            wess_global_group[:] = reweighting_history
+            wess_global_group = self.data_manager.we_h5file.require_group('wess')
+            reweighting_history_dataset = wess_global_group.require_dataset(
+                'reweighting_history', (1,), maxshape=(None,), dtype=int
+            )
+            last_reweighting = int(wess_global_group.attrs.get('last_reweighting', 0))
+            if last_reweighting > n_iter:
+                last_reweighting = n_iter - 1
+                reweighting_history = np.array(reweighting_history_dataset)
+                reweighting_history = reweighting_history[reweighting_history < n_iter]
+                reweighting_history_dataset.resize((reweighting_history.size), axis=0)
 
         if n_iter - last_reweighting < self.reweight_period:
             # Not time to reweight yet
@@ -203,8 +205,9 @@ class WESSDriver:
                 if len(bin):
                     bin.reweight(newprob)
 
-            wess_global_group.resize((wess_global_group.shape[0] + 1), axis=0)
-            wess_global_group[-1] = n_iter
+            reweighting_history_dataset.resize((reweighting_history_dataset.shape[0] + 1), axis=0)
+            reweighting_history_dataset[-1] = n_iter
+            wess_global_group.attrs['last_reweighting'] = n_iter
 
         assert (
             abs(1 - np.fromiter(map(operator.attrgetter('weight'), bins), dtype=np.float64, count=n_bins).sum())


### PR DESCRIPTION
## Issue Number

## Describe the changes made
Previously, when w_truncate was used to truncate a simulation, WESS and WEED would not execute reweighting until the simulation progressed beyond the original last reweighting iteration. This is because they used an attribute field in the west.h5 to store the last reweighting iteration, which would overwrite each time reweighting occurs. This value would stay static after truncating the simulation, leading to undesired behavior of WESS and WEED not reweighting at all after truncating, since the last reweighting occurred in a future iteration.

To fix this, I instead stored the reweighting history data in a dataset. This is more appropriate since attributes should be used for metadata, and it allows a running history of reweighting events to be recorded. I also added a check to evaluate if the last reweighting event is in a future iteration. If this is the case, the reweighting history dataset will be truncated to only include values less than n_iter.

## Goals and Outstanding Issues
- [x] Made WESS and WEED compatible with w_truncate

## Major files changed
- [x] src/westpa/westext/weed/weed_driver.py
- [x] src/westpa/westext/wess/wess_driver.py

## Status
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Additional context


