### PR TITLE
make sure output_map is correct for RecursiveBinMapper

### DIFF
--- a/src/westpa/core/binning/assign.py
+++ b/src/westpa/core/binning/assign.py
@@ -370,9 +370,8 @@ class RecursiveBinMapper(BinMapper):
             # This looks like uninitialized access, but self._output_map is always set during __init__
             # (by self.start_index = 0, or whatever value was passed in), so this modifies the existing
             # set chosen above
-            # start_value will be offsetted if the non-recursive bin is not the first bin in sequential order.
-            start_value = self._start_index + np.argmax(not_recursed)
-            self._output_map[not_recursed] = np.arange(start_value, start_value + n_not_recursed, dtype=index_dtype)
+            all_output_map_indices = np.arange(self._start_index, self._start_index + len(self._recursion_map), dtype=index_dtype)
+            self._output_map[not_recursed] = all_output_map_indices[not_recursed]
         else:
             # No un-replaced bins
             self._output_map = None

--- a/src/westpa/core/binning/assign.py
+++ b/src/westpa/core/binning/assign.py
@@ -370,7 +370,9 @@ class RecursiveBinMapper(BinMapper):
             # This looks like uninitialized access, but self._output_map is always set during __init__
             # (by self.start_index = 0, or whatever value was passed in), so this modifies the existing
             # set chosen above
-            self._output_map[not_recursed] = np.arange(self._start_index, self._start_index + n_not_recursed, dtype=index_dtype)
+            # start_value will be offsetted if the non-recursive bin is not the first bin in sequential order.
+            start_value = self._start_index + np.argmax(not_recursed)
+            self._output_map[not_recursed] = np.arange(start_value, start_value + n_not_recursed, dtype=index_dtype)
         else:
             # No un-replaced bins
             self._output_map = None


### PR DESCRIPTION
[STILL WORK IN PROGRESS]

## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
An extension of #384 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
`RecursiveBinMapper._output_map` could be wrong (with duplicates) if the bin mapper contains a combination of recursive and non-recursive bins AND that the non-recursive bin is not sequentially the first bin in pcoord order.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Fix Recursive Bin mapping

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/binning/assign.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->

Test code... Maybe it's not actually a problem when we get duplicates in output_map?
```
from westpa.core.binning import RecursiveBinMapper, RectilinearBinMapper

def make_mapper3():
    mapper_outer=RectilinearBinMapper([[0,5,10,float('inf')],[0, float('inf')]])
    first_bin=RectilinearBinMapper([[0,5], [0,15.0, float('inf')]])
    second_bin=RectilinearBinMapper([[10,float('inf')], [0, 1, 3, 5, 15, float('inf')]])
    third_bin=RectilinearBinMapper([[10,float('inf')], [0, 0.5, 0.75]])
    forth_bin=RectilinearBinMapper([[10,float('inf')], [0, 5, 10, 15]])
    
    bin_mapper = RecursiveBinMapper(mapper_outer)
    bin_mapper.add_mapper(first_bin, [1, 2])
    bin_mapper.add_mapper(second_bin, [11, 2])
    bin_mapper.add_mapper(forth_bin, [11, 6])
    bin_mapper.add_mapper(third_bin, [11, 0.5])


    print(bin_mapper.__dict__)
    # The following is the wrong output
    # {'base_mapper': <RectilinearBinMapper at 0x106d3fb10 with 3 bins>,
    # 'nbins': 10,
    # '_recursion_targets': {0: <RecursiveBinMapper at 0x129154dd0 with 2 bins>,
    #  2: <RecursiveBinMapper at 0x1071902d0 with 7 bins>},
    # '_recursion_map': array([ True, False,  True]),
    # '_start_index': 0,
    # '_output_map': array([0, 0, 1], dtype=uint16)}
    # 
    #
    # The following is the correct output after the fix
    # {'base_mapper': <RectilinearBinMapper at 0x106d3fb10 with 3 bins>,
    # 'nbins': 10,
    # '_recursion_targets': {0: <RecursiveBinMapper at 0x129154dd0 with 2 bins>,
    #  2: <RecursiveBinMapper at 0x1071902d0 with 7 bins>},
    # '_recursion_map': array([ True, False,  True]),
    # '_start_index': 0,
    # '_output_map': array([0, 1, 1], dtype=uint16)}

    return bin_mapper


bin_mapper = make_mapper3()

print(bin_mapper._recursion_target[2].__dict__)
# The following is the wrong output
# {'base_mapper': <RectilinearBinMapper at 0x107c3cc50 with 5 bins>,
# 'nbins': 8,
# '_recursion_targets': {0: <RecursiveBinMapper at 0x103646cd0 with 2 bins>,
#  3: <RecursiveBinMapper at 0x1035cb650 with 3 bins>},
# '_recursion_map': array([ True, False, False,  True, False]), 
# '_start_index': 3,
# '_output_map': array([3, 4, 5, 6, 6], dtype=uint16)}
# 
#
# The following is the correct output after the fix
# {'base_mapper': <RectilinearBinMapper at 0x107c3cc50 with 5 bins>,
# 'nbins': 8,
# '_recursion_targets': {0: <RecursiveBinMapper at 0x103646cd0 with 2 bins>,
#  3: <RecursiveBinMapper at 0x1035cb650 with 3 bins>},
# '_recursion_map': array([ True, False, False,  True, False]), 
# '_start_index': 3,
# '_output_map': array([3, 4, 5, 6, 7], dtype=uint16)}

```