### PR TITLE
Fix w_init when using hdf5 framework with processes work manager

### DIFF
--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -235,7 +235,7 @@ class WESimManager:
         futures = [self.work_manager.submit(wm_ops.get_pcoord, args=(basis_state,)) for basis_state in basis_states]
         fmap = {future: i for (i, future) in enumerate(futures)}
         for future in self.work_manager.as_completed(futures):
-            basis_states[fmap[future]].pcoord = future.get_result().pcoord
+            basis_states[fmap[future]] = future.get_result()
 
     def report_basis_states(self, basis_states, label='basis'):
         pstatus = self.rc.pstatus

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -229,7 +229,9 @@ class WESimManager:
 
     def get_bstate_pcoords(self, basis_states, label='basis'):
         '''For each of the given ``basis_states``, calculate progress coordinate values
-        as necessary.  The HDF5 file is not updated.'''
+        as necessary.  The HDF5 file is not updated. The BasisState objects are explicitly
+        copied from the futures in order to retain auxdata/restart files (under BasisState.data)
+        from certain work managers (e.g., the ``processes`` work manager.)'''
 
         self.rc.pstatus('Calculating progress coordinate values for {} states.'.format(label))
         futures = [self.work_manager.submit(wm_ops.get_pcoord, args=(basis_state,)) for basis_state in basis_states]


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
#456 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Copy the entire BasisState object from work manager during pcoord calculations instead of just the pcoord.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Have w_init work correctly with hdf5 framework + processes work manager

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/sim_manager.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


