### PR TITLE
w_timings tool for calculating aggregate simulation and wallclocktimes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ console_scripts_tools = [
     'plothist = westpa.cli.tools.plothist:entry_point',
     'w_multi_west = westpa.cli.tools.w_multi_west:entry_point',
     'w_red = westpa.cli.tools.w_red:entry_point',
+    'w_timings = westpa.cli.tools.w_timings:entry_point',
 ]
 
 console_scripts = console_scripts_core + console_scripts_tools

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -1,0 +1,113 @@
+import numpy as np
+from tqdm.auto import tqdm
+
+from westpa.tools import (
+    WESTTool,
+    WESTDataReader,
+    IterRangeSelection,
+)
+
+class WTimings(WESTTool):
+    """
+    Aggregate simulation and wallclock time extraction.
+
+    TODO:
+        * convert to use logging?
+        * convert from tqdm to native westpa progress indicator?
+        * write a simple test: this should be very straitforward (assert time of test h5 file is as expected)
+        * update docs
+    """
+    prog = "w_timings"
+    description = "A tool for aggregate simulation and wallclock time extraction."
+
+    def __init__(self, tau=100, count_events=False):
+        """
+        Parameters
+        ----------
+        tau : int
+            WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.
+        count_events : bool
+            Option to also output the number of successfull recycling events.
+        """
+        super().__init__()
+        self.data_reader = WESTDataReader()
+        self.iter_range = IterRangeSelection(self.data_reader)
+        self.iter_start = None
+        self.iter_stop = None
+        self.tau = tau
+        self.count_events = count_events
+
+    def get_event_count(self, we_h5file):
+        """
+        Check if the target state was reached, given the data in a WEST H5 file.
+
+        Parameters
+        ----------
+        we_h5file : h5py.File
+        
+        Returns
+        -------
+        int
+            Number of successful recycling events.
+        """
+        events = 0
+        # Get the key to the final iteration. 
+        # Need to do -2 instead of -1 because there's an empty-ish final iteration written.
+        for iteration_key in tqdm(list(we_h5file['iterations'].keys())[-2:0:-1]):
+            endpoint_types = we_h5file[f'iterations/{iteration_key}/seg_index']['endpoint_type']
+            if 3 in endpoint_types:
+                #print(f"recycled segment found in file {h5_filename} at iteration {iteration_key}")
+                # count the number of 3s
+                events += np.count_nonzero(endpoint_types == 3)
+        return events
+
+    def go(self):
+        with self.data_reader:
+            we_h5file = self.data_reader.data_manager.we_h5file
+            self.iter_start = self.iter_range.iter_start
+            self.iter_stop = self.iter_range.iter_stop
+
+            walltime = we_h5file['summary']['walltime'][self.iter_start-1:self.iter_stop].sum()
+            aggtime = we_h5file['summary']['n_particles'][self.iter_start-1:self.iter_stop].sum()
+
+            print("\nwalltime: ", walltime, "seconds")
+            print("walltime: ", walltime/60, "minutes")
+            print("walltime: ", walltime/60/60, "hours")
+            print("walltime: ", walltime/60/60/24, "days")
+            print(f"\nassuming tau of {self.tau} ps:")
+            print("aggtime: ", aggtime, "segments ran for tau intervals")
+            print("aggtime: ", (aggtime * self.tau)/1000, "ns")
+            print("aggtime: ", (aggtime * self.tau)/1000/1000, "µs\n")
+            if self.count_events:
+                print("successful recycling events:", self.get_event_count(we_h5file), "\n")
+
+    def add_args(self, parser):
+        self.data_reader.add_args(parser)
+        self.iter_range.add_args(parser)
+        parser.add_argument(
+        "--tau", "-t",
+        dest="tau",
+        type=int,
+        default=100,
+            help="WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps."
+        )
+        parser.add_argument(
+            "--count-events", "-ce",
+            dest="count_events",
+            action="store_true",
+            default=False,
+            help="Include this flag to also output the number of successfull recycling events."
+        )
+
+    def process_args(self, args):
+        self.data_reader.process_args(args)
+        self.tau = args.tau
+        self.count_events = args.count_events
+        with self.data_reader:
+            self.iter_range.process_args(args)
+
+def entry_point():
+    WTimings().main()
+
+if __name__ == "__main__":
+    entry_point()

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -7,6 +7,7 @@ from westpa.tools import (
     IterRangeSelection,
 )
 
+
 class WTimings(WESTTool):
     """
     Aggregate simulation and wallclock time extraction.
@@ -17,6 +18,7 @@ class WTimings(WESTTool):
         * write a simple test: this should be very straitforward (assert time of test h5 file is as expected)
         * update docs
     """
+
     prog = "w_timings"
     description = "A tool for aggregate simulation and wallclock time extraction."
 
@@ -44,19 +46,19 @@ class WTimings(WESTTool):
         Parameters
         ----------
         we_h5file : h5py.File
-        
+
         Returns
         -------
         int
             Number of successful recycling events.
         """
         events = 0
-        # Get the key to the final iteration. 
+        # Get the key to the final iteration.
         # Need to do -2 instead of -1 because there's an empty-ish final iteration written.
         for iteration_key in tqdm(list(we_h5file['iterations'].keys())[-2:0:-1]):
             endpoint_types = we_h5file[f'iterations/{iteration_key}/seg_index']['endpoint_type']
             if 3 in endpoint_types:
-                #print(f"recycled segment found in file {h5_filename} at iteration {iteration_key}")
+                # print(f"recycled segment found in file {h5_filename} at iteration {iteration_key}")
                 # count the number of 3s
                 events += np.count_nonzero(endpoint_types == 3)
         return events
@@ -67,17 +69,17 @@ class WTimings(WESTTool):
             self.iter_start = self.iter_range.iter_start
             self.iter_stop = self.iter_range.iter_stop
 
-            walltime = we_h5file['summary']['walltime'][self.iter_start-1:self.iter_stop].sum()
-            aggtime = we_h5file['summary']['n_particles'][self.iter_start-1:self.iter_stop].sum()
+            walltime = we_h5file['summary']['walltime'][self.iter_start - 1 : self.iter_stop].sum()
+            aggtime = we_h5file['summary']['n_particles'][self.iter_start - 1 : self.iter_stop].sum()
 
             print("\nwalltime: ", walltime, "seconds")
-            print("walltime: ", walltime/60, "minutes")
-            print("walltime: ", walltime/60/60, "hours")
-            print("walltime: ", walltime/60/60/24, "days")
+            print("walltime: ", walltime / 60, "minutes")
+            print("walltime: ", walltime / 60 / 60, "hours")
+            print("walltime: ", walltime / 60 / 60 / 24, "days")
             print(f"\nassuming tau of {self.tau} ps:")
             print("aggtime: ", aggtime, "segments ran for tau intervals")
-            print("aggtime: ", (aggtime * self.tau)/1000, "ns")
-            print("aggtime: ", (aggtime * self.tau)/1000/1000, "µs\n")
+            print("aggtime: ", (aggtime * self.tau) / 1000, "ns")
+            print("aggtime: ", (aggtime * self.tau) / 1000 / 1000, "µs\n")
             if self.count_events:
                 print("successful recycling events:", self.get_event_count(we_h5file), "\n")
 
@@ -85,18 +87,20 @@ class WTimings(WESTTool):
         self.data_reader.add_args(parser)
         self.iter_range.add_args(parser)
         parser.add_argument(
-        "--tau", "-t",
-        dest="tau",
-        type=int,
-        default=100,
-            help="WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps."
+            "--tau",
+            "-t",
+            dest="tau",
+            type=int,
+            default=100,
+            help="WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.",
         )
         parser.add_argument(
-            "--count-events", "-ce",
+            "--count-events",
+            "-ce",
             dest="count_events",
             action="store_true",
             default=False,
-            help="Include this flag to also output the number of successfull recycling events."
+            help="Include this flag to also output the number of successfull recycling events.",
         )
 
     def process_args(self, args):
@@ -106,8 +110,10 @@ class WTimings(WESTTool):
         with self.data_reader:
             self.iter_range.process_args(args)
 
+
 def entry_point():
     WTimings().main()
+
 
 if __name__ == "__main__":
     entry_point()


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
This provides a native tool for calculating aggregate wallclock times, simulation times, and optionally the number of successful recycling events from the `west.h5` file output. Most users tend to run these calculations individually but now there is a simplified way to do it.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [ ] Convert from print statements to logging?
- [ ] Need to update the doc pages
- [ ] write a simple test for this
- [ ] might be nice to cut the decimals of the output

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] setup.py
- [x] w_timings.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the CONTRIBUTING document.
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->
Example output:
![image](https://github.com/user-attachments/assets/ad48348a-42a6-433e-ba1d-63a8e62dfe8a)

