### PR TITLE
small CI workflow update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,7 +116,7 @@ jobs:
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     if: |
       github.repository == 'westpa/westpa' &&
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      (github.event_name == 'release' && github.event.action == 'published')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -132,7 +132,7 @@ jobs:
 
   upload_pypi:
     name: PyPI
-    needs: [build_wheels, build_sdist]
+    needs: [upload_testpypi]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,10 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    branches:
+      - 'westpa2'
+      - 'develop'
 
 jobs:
   build_wheels:

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -5,6 +5,8 @@ on:
     # Once a month on the 28th day at 4 pm UTC, which is ~11 am EST.
     - cron: "00 16 28 * *"
   workflow_dispatch:
+    branches:
+      - 'westpa2'
 
 jobs:
   mirror-develop-to-westpa2:

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -12,6 +12,7 @@ jobs:
   mirror-develop-to-westpa2:
     runs-on: ubuntu-latest
     name: Mirror develop branch to westpa2 branch
+    if: github.repository_owner == 'westpa'
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,10 @@ on:
     #   Scheduled workflows run on the latest commit on the default or base branch.
     #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
     - cron: "30 15 * * 4"
+  workflow_dispatch:
+    branches:
+      - 'westpa2'
+      - 'develop'
 
 jobs:
   lint:


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
Addendum to #472 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Only allow dispatch for mirror.yaml to run on `westpa2` branch. Doesn't really matter too much, since the workflow is hard coded to sync `develop` --> `westpa2`, but does simplify the amount of clicks if you want to rerun.

Also added the ability to manually start test.yaml and build.yaml from GH.

This also restructures the workflows so `upload_testpypi` will always execute before `upload_pypi`. The previous setup had little to no advantage and the `upload_testpypi` workflow always finished after it's reached the production pypi servers.

Also made it so the mirror job will be skipped on forks.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Only allow dispatch to run on `westpa2` branch.
- [x] Allow manual rerun of build and test CI
- [x] restructure build/upload workflows

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] .github/workflows/mirror.yaml
- [x] .github/workflows/build.yaml
- [x] .github/workflows/test.yaml

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


