### PR TITLE
Prevent zombie/orphaned processes in processes work manager

### DIFF
--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -186,7 +186,7 @@ class ProcessWorkManager(WorkManager):
                 except ValueError:
                     try:
                         if worker.is_alive():
-                            log.debug('worker process {:d} could not be closed'.format(worker.id))
+                            log.debug('worker process {:d} could not be closed'.format(worker.pid))
                     except ValueError:
                         pass  # Already closed.
 

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -181,7 +181,10 @@ class ProcessWorkManager(WorkManager):
                 else:
                     log.debug('worker process {:d} terminated gracefully with code {:d}'.format(worker.pid, worker.exitcode))
 
-                worker.close()  # Release all resources
+                try:
+                    worker.close()  # Release all resources
+                except ValueError:
+                    pass  # Already closed.
 
             self._empty_queues()
             self.result_queue.put(result_shutdown_sentinel)

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -181,6 +181,8 @@ class ProcessWorkManager(WorkManager):
                 else:
                     log.debug('worker process {:d} terminated gracefully with code {:d}'.format(worker.pid, worker.exitcode))
 
+                worker.close()  # Release all resources
+
             self._empty_queues()
             self.result_queue.put(result_shutdown_sentinel)
 

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -184,7 +184,11 @@ class ProcessWorkManager(WorkManager):
                 try:
                     worker.close()  # Release all resources
                 except ValueError:
-                    pass  # Already closed.
+                    try:
+                        if worker.is_alive():
+                            log.debug('worker process {:d} could not be closed'.format(worker.id))
+                    except ValueError:
+                        pass  # Already closed.
 
             self._empty_queues()
             self.result_queue.put(result_shutdown_sentinel)

--- a/tests/test_work_managers/test_processes.py
+++ b/tests/test_work_managers/test_processes.py
@@ -34,7 +34,7 @@ class TestProcessWorkManagerAux:
         work_manager = ProcessWorkManager()
         work_manager.shutdown_timeout = 0.1
         work_manager.startup()
-        for i in range(5):
+        for _ in range(5):
             work_manager.submit(will_busyhang)
         work_manager.shutdown()
         for worker in work_manager.workers:
@@ -48,7 +48,7 @@ class TestProcessWorkManagerAux:
         work_manager = ProcessWorkManager()
         work_manager.shutdown_timeout = 0.1
         work_manager.startup()
-        for i in range(5):
+        for _ in range(5):
             work_manager.submit(will_busyhang_uninterruptible)
         work_manager.shutdown()
         for worker in work_manager.workers:
@@ -63,7 +63,7 @@ class TestProcessWorkManagerAux:
         work_manager.install_sigint_handler()
         work_manager.shutdown_timeout = 0.1
         work_manager.startup()
-        for i in range(5):
+        for _ in range(5):
             work_manager.submit(will_busyhang)
 
         with pytest.raises(KeyboardInterrupt):
@@ -76,6 +76,24 @@ class TestProcessWorkManagerAux:
                     except ValueError:
                         pass  # probably closed already
                 raise
+
+    @pytest.mark.timeout(2)
+    def test_worker_close_fail(self, monkeypatch):
+        work_manager = ProcessWorkManager()
+        work_manager.install_sigint_handler()
+        work_manager.shutdown_timeout = 0.1
+        work_manager.startup()
+
+        work_manager.submit(will_busyhang_uninterruptible)
+        worker = work_manager.workers[0]
+
+        with monkeypatch.context() as m:
+            m.setattr(worker, 'close', lambda: exec('raise(ValueError)'))
+            m.setattr(work_manager, '_empty_queues', lambda: 0)
+            work_manager.shutdown()
+
+        # Clean up
+        work_manager.shutdown()
 
     @pytest.mark.timeout(2)
     def test_worker_ids(self):

--- a/tests/test_work_managers/test_processes.py
+++ b/tests/test_work_managers/test_processes.py
@@ -89,6 +89,7 @@ class TestProcessWorkManagerAux:
 
         with monkeypatch.context() as m:
             m.setattr(worker, 'close', lambda: exec('raise(ValueError)'))
+            m.setattr(worker, 'is_alive', lambda: True)
             m.setattr(work_manager, '_empty_queues', lambda: 0)
             work_manager.shutdown()
 

--- a/tests/test_work_managers/test_processes.py
+++ b/tests/test_work_managers/test_processes.py
@@ -24,7 +24,10 @@ class TestProcessWorkManagerAux:
         work_manager.startup()
         work_manager.shutdown()
         for worker in work_manager.workers:
-            assert not worker.is_alive()
+            try:
+                assert not worker.is_alive()
+            except ValueError:
+                pass  # probably closed already
 
     @pytest.mark.timeout(2)
     def test_hang_shutdown(self):
@@ -35,7 +38,10 @@ class TestProcessWorkManagerAux:
             work_manager.submit(will_busyhang)
         work_manager.shutdown()
         for worker in work_manager.workers:
-            assert not worker.is_alive()
+            try:
+                assert not worker.is_alive()
+            except ValueError:
+                pass  # probably closed already
 
     @pytest.mark.timeout(2)
     def test_hang_shutdown_ignoring_sigint(self):
@@ -46,7 +52,10 @@ class TestProcessWorkManagerAux:
             work_manager.submit(will_busyhang_uninterruptible)
         work_manager.shutdown()
         for worker in work_manager.workers:
-            assert not worker.is_alive()
+            try:
+                assert not worker.is_alive()
+            except ValueError:
+                pass  # probably closed already
 
     @pytest.mark.timeout(2)
     def test_sigint_shutdown(self):
@@ -62,7 +71,10 @@ class TestProcessWorkManagerAux:
                 os.kill(os.getpid(), signal.SIGINT)
             except KeyboardInterrupt:
                 for worker in work_manager.workers:
-                    assert not worker.is_alive()
+                    try:
+                        assert not worker.is_alive()
+                    except ValueError:
+                        pass  # probably closed already
                 raise
 
     @pytest.mark.timeout(2)


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
Extension to #412 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Untested just yet, but I've been noticing there are quite often zombie/orphaned workers lingering after a SIGINT with the processes work manager. Hopefully this change is more comprehensive.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Shutdown processes work manager cleanly

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/work_managers/processes.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


