### PR TITLE
w_direct/w_kinetics outputfile inheritance + w_assign output folder creation

### DIFF
--- a/src/westpa/cli/tools/w_assign.py
+++ b/src/westpa/cli/tools/w_assign.py
@@ -340,14 +340,20 @@ Command-line options
         from westpa.core._rc import bins_from_yaml_dict
 
         self.binning.mapper = bins_from_yaml_dict(config['analysis_schemes'][scheme]['bins'][0])
+
+        # Output file/folder wrangling
         path = os.path.join(os.getcwd(), config['directory'], scheme)
+        self.output_filename = os.path.join(path, 'assign.h5')
+
         try:
             os.mkdir(config['directory'])
-            os.mkdir(path)
         except Exception:
             pass
 
-        self.output_filename = os.path.join(path, 'assign.h5')
+        try:
+            os.mkdir(path)
+        except Exception:
+            pass
 
     def load_state_file(self, state_filename):
         import yaml

--- a/src/westpa/cli/tools/w_assign.py
+++ b/src/westpa/cli/tools/w_assign.py
@@ -346,12 +346,7 @@ Command-line options
         self.output_filename = os.path.join(path, 'assign.h5')
 
         try:
-            os.mkdir(config['directory'])
-        except Exception:
-            pass
-
-        try:
-            os.mkdir(path)
+            os.makedirs(path, exist_ok=True)
         except Exception:
             pass
 

--- a/src/westpa/cli/tools/w_direct.py
+++ b/src/westpa/cli/tools/w_direct.py
@@ -302,6 +302,9 @@ Command-line options
         self.output_file.replace_dataset('target_flux_evolution', data=rate_evol, shuffle=True, compression=9)
 
     def go(self):
+        # Have class inherit user-provided self.output_filename as self.kinetics_filename
+        self.kinetics_filename = self.output_filename
+
         pi = self.progress.indicator
         with pi:
             self.w_kinavg()
@@ -474,6 +477,9 @@ Command-line options
         self.output_file.replace_dataset(name='state_pop_evolution', data=pop_evol, shuffle=True, compression=9)
 
     def go(self):
+        # Have class inherit user-provided self.output_filename as self.kinetics_filename
+        self.kinetics_filename = self.output_filename
+
         pi = self.progress.indicator
         with pi:
             self.w_stateprobs()
@@ -498,8 +504,9 @@ Command-line options
 '''
 
     def go(self):
-        # One minor issue; as this stands now, since it's inheriting from all the other classes, it needs
-        # a kinetics file to instantiate the other attributes.  We'll need to modify how the loading works, there.
+        # Have class inherit user-provided self.output_filename as self.kinetics_filename
+        self.kinetics_filename = self.output_filename
+
         pi = self.progress.indicator
         with pi:
             self.w_kinetics()
@@ -526,6 +533,9 @@ Command-line options
 '''
 
     def go(self):
+        # Have class inherit user-provided self.output_filename as self.kinetics_filename
+        self.kinetics_filename = self.output_filename
+
         pi = self.progress.indicator
         with pi:
             self.w_kinavg()

--- a/src/westpa/tools/kinetics_tool.py
+++ b/src/westpa/tools/kinetics_tool.py
@@ -91,8 +91,9 @@ class AverageCommands(WESTKineticsBase):
     def __init__(self, parent):
         # Ideally, this is stuff general to all the calculations we want to perform.
         super().__init__(parent)
-        self.kinetics_filename = None
-        self.kinetics_file = None
+        if not hasattr(self, 'kinetics_filename'):
+            self.kinetics_filename = None
+            self.kinetics_file = None
 
     def add_args(self, parser):
         iogroup = parser.add_argument_group('input/output options')
@@ -174,7 +175,9 @@ class AverageCommands(WESTKineticsBase):
         )
 
     def process_args(self, args):
-        self.kinetics_filename = args.kinetics
+        if self.kinetics_filename is None:
+            # Use default name if not inherited.
+            self.kinetics_filename = args.kinetics
 
         # Disable the bootstrap or the correlation analysis.
         self.mcbs_enable = args.bootstrap if args.bootstrap is not None else True


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->

`w_direct` is a wrapper around various older kinetics tools (e.g. `w_kinetics`), but it is not coded in a way such that the `self.output_filename` is correctly passed to those kinetic tools as `self.kinetics_filename`. This will lead to a `FileNotFoundError` when not using the default output_filename (i.e. not `direct.h5`) via variations of the following command: `w_direct [any subtool]  -o [NOT-DEFAULT-FILE-NAME].h5`. 

In other words, I'm fixing what this inline comment is pointing out:
```
# One minor issue; as this stands now, since it's inheriting from all the other classes, it needs
# a kinetics file to instantiate the other attributes.  We'll need to modify how the loading works, there.
```
https://github.com/jeremyleung521/westpa/blob/develop/src/westpa/cli/tools/w_direct.py#L501-L502

Also bundled in a fix to cases where `w_assign` will error out with `FileNotFoundError` when the `ANALYSIS` folder is made but the specific scheme folder is not.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Have `w_direct` respect user-provided output file name

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/cli/tools/w_direct.py
- [x] src/westpa/tools/kinetics_tool.py
- [x] src/westpa/cli/tools/w_assign.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->

Try running:
`w_direct all -o NON-DEFAULT-FILE.h5`. 
