### PR TITLE
Switch multiprocessing/processes work manager to `fork` on Linux

### DIFF
--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -27,11 +27,12 @@ class ProcessWorkManager(WorkManager):
     -----
 
     On MacOS, as of Python 3.8 the default start method for multiprocessing launching new processes was changed from fork to spawn.
+    On Linux, as of Python 3.14, the default start method for multiprocessing launching new processes was changed from fork to spawn.
     In general, spawn is more robust and efficient, however it requires serializability of everything being passed to the child process.
     In contrast, fork is much less memory efficient, as it makes a full copy of everything in the parent process.
     However, it does not require picklability.
 
-    So, on MacOS, the method for launching new processes is explicitly changed to fork from the (MacOS-specific) default of spawn.
+    So, on MacOS and Linux, the method for launching new processes is explicitly changed to fork from the (UNIX-specific) default of spawn.
     Unix should default to fork.
 
     See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods and
@@ -48,7 +49,7 @@ class ProcessWorkManager(WorkManager):
         super().__init__()
 
         try:
-            if sys.platform == 'darwin':  # MacOS
+            if sys.platform in ['darwin', 'linux']:  # UNIX Platforms
                 multiprocessing.set_start_method('fork')
                 log.debug('setting multiprocessing start method to fork')
         except RuntimeError:


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
#482

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Force `multiprocessing.processes`to run with `fork` on Linux as well. This is an intermediate step before switching work managers to run with `spawn` or `forkserver`. (It will default to `spawn` on Python 3.14)

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Force Linux Python installs to run with `fork`

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/work_managers/processes.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


