### PR TITLE
Added pytest and fixed formating for w_timmings

### DIFF
--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -1,0 +1,126 @@
+import numpy as np
+from tqdm.auto import tqdm
+
+from westpa.tools import (
+    WESTTool,
+    WESTDataReader,
+    IterRangeSelection,
+)
+
+
+class WTimings(WESTTool):
+    """
+    Aggregate simulation and wallclock time extraction.
+
+    TODO:
+        * convert to use logging?
+        * convert from tqdm to native westpa progress indicator?
+        * write a simple test: this should be very straitforward (assert time of test h5 file is as expected)
+        * update docs
+    """
+
+    prog = "w_timings"
+    description = "A tool for aggregate simulation and wallclock time extraction."
+
+    def __init__(self, tau=100, count_events=False):
+        """
+        Parameters
+        ----------
+        tau : int
+            WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.
+        count_events : bool
+            Option to also output the number of successfull recycling events.
+        """
+        super().__init__()
+        self.data_reader = WESTDataReader()
+        self.iter_range = IterRangeSelection(self.data_reader)
+        self.iter_start = None
+        self.iter_stop = None
+        self.tau = tau
+        self.count_events = count_events
+
+    def get_event_count(self, we_h5file):
+        """
+        Check if the target state was reached, given the data in a WEST H5 file.
+
+        Parameters
+        ----------
+        we_h5file : h5py.File
+
+        Returns
+        -------
+        int
+            Number of successful recycling events.
+        """
+        events = 0
+        # Get the key to the final iteration.
+        # Need to do -2 instead of -1 because there's an empty-ish final iteration written.
+        for iteration_key in tqdm(list(we_h5file['iterations'].keys())[-2:0:-1]):
+            endpoint_types = we_h5file[f'iterations/{iteration_key}/seg_index']['endpoint_type']
+            if 3 in endpoint_types:
+                # print(f"recycled segment found in file {h5_filename} at iteration {iteration_key}")
+                # count the number of 3s
+                events += np.count_nonzero(endpoint_types == 3)
+        return events
+
+    def go(self):
+        with self.data_reader:
+            we_h5file = self.data_reader.data_manager.we_h5file
+            self.iter_start = self.iter_range.iter_start
+            self.iter_stop = self.iter_range.iter_stop
+
+            walltime = we_h5file['summary']['walltime'][self.iter_start - 1 : self.iter_stop].sum()
+            aggtime = we_h5file['summary']['n_particles'][self.iter_start - 1 : self.iter_stop].sum()
+
+            days = int(walltime) // 86400
+            hours = (int(walltime) % 86400) // 3600
+            minutes = (int(walltime) % 3600) // 60
+            seconds = walltime % 60
+
+            print("\n===== WALLCLOCK  =====")
+            print(f"{'Total Wallclock Time:':30}{days:>2}d {hours:>2}h {minutes:>2}m {seconds:>6.2f}s")
+
+            print("\n===== SIMULATION  =====")
+            print(f"{'Tau:':30} {self.tau} ps")
+            print(f"{'Total Segments:':30} {aggtime}")
+            print(f"{'Simulation time:':30} {((aggtime * self.tau) / 1000):.2f} ns")
+
+            if self.count_events:
+                events = self.get_event_count(we_h5file)
+                print("\n===== RECYCLING =====")
+                print(f"{'Recycled walkers:':30} {events}")
+
+    def add_args(self, parser):
+        self.data_reader.add_args(parser)
+        self.iter_range.add_args(parser)
+        parser.add_argument(
+            "--tau",
+            "-t",
+            dest="tau",
+            type=int,
+            default=100,
+            help="WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.",
+        )
+        parser.add_argument(
+            "--count-events",
+            "-ce",
+            dest="count_events",
+            action="store_true",
+            default=False,
+            help="Include this flag to also output the number of successfull recycling events.",
+        )
+
+    def process_args(self, args):
+        self.data_reader.process_args(args)
+        self.tau = args.tau
+        self.count_events = args.count_events
+        with self.data_reader:
+            self.iter_range.process_args(args)
+
+
+def entry_point():
+    WTimings().main()
+
+
+if __name__ == "__main__":
+    entry_point()

--- a/tests/test_tools/test_w_timings.py
+++ b/tests/test_tools/test_w_timings.py
@@ -4,6 +4,7 @@ import argparse
 import pytest
 from westpa.cli.tools.w_timings import entry_point
 
+
 class Test_W_Timings:
     """Test class for w_timings tool."""
 
@@ -35,11 +36,10 @@ class Test_W_Timings:
         output = captured.out
 
         # Basic checks that output sections are present
-        #TODO: Replace with actual known values from reference
+        # TODO: Replace with actual known values from reference
         assert "===== WALLCLOCK  =====" in output
         assert "Total Wallclock Time:" in output
         assert "===== SIMULATION  =====" in output
         assert "Simulation time:" in output
         assert "===== RECYCLING =====" in output
         assert "Recycled walkers:" in output
-

--- a/tests/test_tools/test_w_timings.py
+++ b/tests/test_tools/test_w_timings.py
@@ -1,0 +1,45 @@
+import os
+from unittest import mock
+import argparse
+import pytest
+from westpa.cli.tools.w_timings import entry_point
+
+class Test_W_Timings:
+    """Test class for w_timings tool."""
+
+    @pytest.fixture
+    def ref_west_file(self):
+        return "tests/refs/west_3iter.h5"
+
+    def test_run_w_timings(self, ref_west_file, capsys):
+        """
+        Currently only checks if sections headers are printing correctly
+        """
+
+        # Mock CLI arguments to simulate running as a script
+        with mock.patch(
+            "argparse.ArgumentParser.parse_args",
+            return_value=argparse.Namespace(
+                verbosity="debug",
+                rcfile=None,
+                we_h5filename=ref_west_file,
+                first_iter=None,
+                last_iter=None,
+                tau=100,
+                count_events=True,
+            ),
+        ):
+            entry_point()
+
+        captured = capsys.readouterr()
+        output = captured.out
+
+        # Basic checks that output sections are present
+        #TODO: Replace with actual known values from reference
+        assert "===== WALLCLOCK  =====" in output
+        assert "Total Wallclock Time:" in output
+        assert "===== SIMULATION  =====" in output
+        assert "Simulation time:" in output
+        assert "===== RECYCLING =====" in output
+        assert "Recycled walkers:" in output
+


### PR DESCRIPTION
## Issue Number
466

## Describe the changes made
Cleaned up the `w_timings` tool’s output:
- Removed unnecessary decimal places  
- Added clear section headers (`===== WALLCLOCK =====`, `===== SIMULATION =====`, `===== RECYCLING =====`)  

Also added a new pytest in `tests/test_tools/test_w_timings.py` that:
- Asserts that each of the three section headers is printed  

## Goals and Outstanding Issues
- Finish the basic test for `w_timings` 
- Add numeric validation to verify the computed wallclock and simulation times  
- Extend tests to cover edge cases (e.g. zero iterations, custom `tau` values)

## Major files changed
- `src/westpa/cli/tools/w_timings.py`  
- `tests/test_tools/test_w_timings.py`  

## Status
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
Ran locally with:
```bash
pytest tests/test_tools/test_w_timings.py
# => 1 passed in 0.24s