### PR TITLE
Add w_timings CLI tool

### DIFF
--- a/doc/documentation/cli.rst
+++ b/doc/documentation/cli.rst
@@ -29,6 +29,7 @@ westpa.cli package
     w_ntop       <cli/w_ntop>
     w_multi_west <cli/w_multi_west>
     w_red        <cli/w_red>
+    w_timings    <cli/w_timings>
     
 .. toctree::
    :maxdepth: 1

--- a/doc/documentation/cli/w_timings.rst
+++ b/doc/documentation/cli/w_timings.rst
@@ -24,8 +24,8 @@ Tool-specific arguments:
 Examples
 --------
 
-The default output includes the wall-clock time and (if per-segment CPU times
-were recorded by the propagator) the total CPU time:
+The default output includes the wall-clock time and, if per-segment CPU times
+were recorded by the propagator, the total CPU time:
 
 .. code-block:: console
 

--- a/doc/documentation/cli/w_timings.rst
+++ b/doc/documentation/cli/w_timings.rst
@@ -33,8 +33,8 @@ The default output includes the wall-clock time:
   Total segments: 9985
   Wall-clock time: 0:00:01.452625
 
-To output the aggregate and "molecular" simulation times, the resampling
-time (``-t`` or ``--tau``) must be specified:
+To determine the simulated time, the resampling time (``-t`` or ``--tau``)
+must be provided:
 
 .. code-block:: console
 

--- a/doc/documentation/cli/w_timings.rst
+++ b/doc/documentation/cli/w_timings.rst
@@ -13,7 +13,7 @@ Usage:
   w_timings [-h] [-r RCFILE] [--quiet | --verbose | --debug] [--version]
             [-W WEST_H5FILE] [--first-iter N_ITER] [--last-iter N_ITER] [-t TAU]
 
-Optional arguments:
+Tool-specific arguments:
 
 .. code-block:: shell
 
@@ -33,8 +33,12 @@ The default output includes the wall-clock time:
   Total segments: 9985
   Wall-clock time: 0:00:01.452625
 
-To determine the simulated time, the resampling time (``-t`` or ``--tau``)
-must be provided:
+If CPU times were recorded by the propagator, the total CPU time will also
+be reported. (This example is based on a toy model in which CPU times were
+not recorded.)
+
+To determine the maximum trajectory length and aggregate simulation time,
+the resampling interval (``TAU``) must be specified:
 
 .. code-block:: console
 
@@ -42,5 +46,5 @@ must be provided:
   Iterations: 50
   Total segments: 9985
   Wall-clock time: 0:00:01.452625
-  Simulated physical time ("molecular time"): 5.0 ns
+  Maximum trajectory length: 5.0 ns
   Aggregate simulation time: 998.5 ns

--- a/doc/documentation/cli/w_timings.rst
+++ b/doc/documentation/cli/w_timings.rst
@@ -8,14 +8,14 @@ Overview
 
 Usage:
 
-.. code-block:: shell
+.. code-block:: text
 
   w_timings [-h] [-r RCFILE] [--quiet | --verbose | --debug] [--version]
             [-W WEST_H5FILE] [--first-iter N_ITER] [--last-iter N_ITER] [-t TAU]
 
 Tool-specific arguments:
 
-.. code-block:: shell
+.. code-block:: text
 
   -t TAU, --tau TAU     WE resampling interval (format: <value>_<unit>, where
                         <value> is a positive integer and <unit> is 'as', 'fs',

--- a/doc/documentation/cli/w_timings.rst
+++ b/doc/documentation/cli/w_timings.rst
@@ -24,27 +24,26 @@ Tool-specific arguments:
 Examples
 --------
 
-The default output includes the wall-clock time:
+The default output includes the wall-clock time and (if per-segment CPU times
+were recorded by the propagator) the total CPU time:
 
 .. code-block:: console
 
   $ w_timings -W west.h5
-  Iterations: 50
-  Total segments: 9985
-  Wall-clock time: 0:00:01.452625
-
-If CPU times were recorded by the propagator, the total CPU time will also
-be reported. (This example is based on a toy model in which CPU times were
-not recorded.)
+  Iterations: 100
+  Total segments: 7775
+  Wall-clock time: 2 days, 4:35:11.749094
+  Total CPU time: 17 days, 9:09:00.556985
 
 To determine the maximum trajectory length and aggregate simulation time,
 the resampling interval (``TAU``) must be specified:
 
 .. code-block:: console
 
-  $ w_timings -W west.h5 -t 100_ps
-  Iterations: 50
-  Total segments: 9985
-  Wall-clock time: 0:00:01.452625
+  $ w_timings -W west.h5 -t 50_ps
+  Iterations: 100
+  Total segments: 7775
+  Wall-clock time: 2 days, 4:35:11.749094
+  Total CPU time: 17 days, 9:09:00.556985
   Maximum trajectory length: 5.0 ns
-  Aggregate simulation time: 998.5 ns
+  Aggregate simulation time: 388.75 ns

--- a/doc/documentation/cli/w_timings.rst
+++ b/doc/documentation/cli/w_timings.rst
@@ -1,0 +1,46 @@
+w_timings
+=========
+
+``w_timings`` prints timing information for a WESTPA simulation.
+
+Overview
+--------
+
+Usage:
+
+.. code-block:: shell
+
+  w_timings [-h] [-r RCFILE] [--quiet | --verbose | --debug] [--version]
+            [-W WEST_H5FILE] [--first-iter N_ITER] [--last-iter N_ITER] [-t TAU]
+
+Optional arguments:
+
+.. code-block:: shell
+
+  -t TAU, --tau TAU     WE resampling interval (format: <value>_<unit>, where
+                        <value> is a positive integer and <unit> is 'as', 'fs',
+                        'ps', 'ns', 'us', 'ms', 's', 'm', 'h', 'D', or 'W').
+
+Examples
+--------
+
+The default output includes the wall-clock time:
+
+.. code-block:: console
+
+  $ w_timings -W west.h5
+  Iterations: 50
+  Total segments: 9985
+  Wall-clock time: 0:00:01.452625
+
+To output the aggregate and "molecular" simulation times, the resampling
+time (``-t`` or ``--tau``) must be specified:
+
+.. code-block:: console
+
+  $ w_timings -W west.h5 -t 100_ps
+  Iterations: 50
+  Total segments: 9985
+  Wall-clock time: 0:00:01.452625
+  Simulated physical time ("molecular time"): 5.0 ns
+  Aggregate simulation time: 998.5 ns

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ console_scripts_tools = [
     'plothist = westpa.cli.tools.plothist:entry_point',
     'w_multi_west = westpa.cli.tools.w_multi_west:entry_point',
     'w_red = westpa.cli.tools.w_red:entry_point',
+    'w_timings = westpa.cli.tools.w_timings:entry_point',
 ]
 
 console_scripts = console_scripts_core + console_scripts_tools

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -1,0 +1,113 @@
+import numpy as np
+from tqdm.auto import tqdm
+
+from westpa.tools import (
+    WESTTool,
+    WESTDataReader,
+    IterRangeSelection,
+)
+
+class WTimings(WESTTool):
+    """
+    Aggregate simulation and wallclock time extraction.
+
+    TODO:
+        * convert to use logging?
+        * convert from tqdm to native westpa progress indicator?
+        * write a simple test: this should be very straitforward (assert time of test h5 file is as expected)
+        * update docs
+    """
+    prog = "w_timings"
+    description = "A tool for aggregate simulation and wallclock time extraction."
+
+    def __init__(self, tau=100, count_events=False):
+        """
+        Parameters
+        ----------
+        tau : int
+            WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.
+        count_events : bool
+            Option to also output the number of successfull recycling events.
+        """
+        super().__init__()
+        self.data_reader = WESTDataReader()
+        self.iter_range = IterRangeSelection(self.data_reader)
+        self.iter_start = None
+        self.iter_stop = None
+        self.tau = tau
+        self.count_events = count_events
+
+    def get_event_count(self, we_h5file):
+        """
+        Check if the target state was reached, given the data in a WEST H5 file.
+
+        Parameters
+        ----------
+        we_h5file : h5py.File
+        
+        Returns
+        -------
+        int
+            Number of successful recycling events.
+        """
+        events = 0
+        # Get the key to the final iteration. 
+        # Need to do -2 instead of -1 because there's an empty-ish final iteration written.
+        for iteration_key in tqdm(list(we_h5file['iterations'].keys())[-2:0:-1]):
+            endpoint_types = we_h5file[f'iterations/{iteration_key}/seg_index']['endpoint_type']
+            if 3 in endpoint_types:
+                #print(f"recycled segment found in file {h5_filename} at iteration {iteration_key}")
+                # count the number of 3s
+                events += np.count_nonzero(endpoint_types == 3)
+        return events
+
+    def go(self):
+        with self.data_reader:
+            we_h5file = self.data_reader.data_manager.we_h5file
+            self.iter_start = self.iter_range.iter_start
+            self.iter_stop = self.iter_range.iter_stop
+
+            walltime = we_h5file['summary']['walltime'][self.iter_start-1:self.iter_stop].sum()
+            aggtime = we_h5file['summary']['n_particles'][self.iter_start-1:self.iter_stop].sum()
+
+            print("\nwalltime: ", walltime, "seconds")
+            print("walltime: ", walltime/60, "minutes")
+            print("walltime: ", walltime/60/60, "hours")
+            print("walltime: ", walltime/60/60/24, "days")
+            print(f"\nassuming tau of {self.tau} ps:")
+            print("aggtime: ", aggtime, "segments ran for tau intervals")
+            print("aggtime: ", (aggtime * self.tau)/1000, "ns")
+            print("aggtime: ", (aggtime * self.tau)/1000/1000, "µs\n")
+            if self.count_events:
+                print("successful recycling events:", self.get_event_count(we_h5file), "\n")
+
+    def add_args(self, parser):
+        self.data_reader.add_args(parser)
+        self.iter_range.add_args(parser)
+        parser.add_argument(
+        "--tau", "-t",
+        dest="tau",
+        type=int,
+        default=100,
+            help="WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps."
+        )
+        parser.add_argument(
+            "--count-events", "-ce",
+            dest="count_events",
+            action="store_true",
+            default=False,
+            help="Include this flag to also output the number of successfull recycling events."
+        )
+
+    def process_args(self, args):
+        self.data_reader.process_args(args)
+        self.tau = args.tau
+        self.count_events = args.count_events
+        with self.data_reader:
+            self.iter_range.process_args(args)
+
+def entry_point():
+    WTimings().main()
+
+if __name__ == "__main__":
+    entry_point()

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -7,6 +7,7 @@ from westpa.tools import (
     IterRangeSelection,
 )
 
+
 class WTimings(WESTTool):
     """
     Aggregate simulation and wallclock time extraction.
@@ -17,6 +18,7 @@ class WTimings(WESTTool):
         * write a simple test: this should be very straitforward (assert time of test h5 file is as expected)
         * update docs
     """
+
     prog = "w_timings"
     description = "A tool for aggregate simulation and wallclock time extraction."
 
@@ -44,19 +46,19 @@ class WTimings(WESTTool):
         Parameters
         ----------
         we_h5file : h5py.File
-        
+
         Returns
         -------
         int
             Number of successful recycling events.
         """
         events = 0
-        # Get the key to the final iteration. 
+        # Get the key to the final iteration.
         # Need to do -2 instead of -1 because there's an empty-ish final iteration written.
         for iteration_key in tqdm(list(we_h5file['iterations'].keys())[-2:0:-1]):
             endpoint_types = we_h5file[f'iterations/{iteration_key}/seg_index']['endpoint_type']
             if 3 in endpoint_types:
-                #print(f"recycled segment found in file {h5_filename} at iteration {iteration_key}")
+                # print(f"recycled segment found in file {h5_filename} at iteration {iteration_key}")
                 # count the number of 3s
                 events += np.count_nonzero(endpoint_types == 3)
         return events
@@ -67,17 +69,17 @@ class WTimings(WESTTool):
             self.iter_start = self.iter_range.iter_start
             self.iter_stop = self.iter_range.iter_stop
 
-            walltime = we_h5file['summary']['walltime'][self.iter_start-1:self.iter_stop].sum()
-            aggtime = we_h5file['summary']['n_particles'][self.iter_start-1:self.iter_stop].sum()
+            walltime = we_h5file['summary']['walltime'][self.iter_start - 1 : self.iter_stop].sum()
+            aggtime = we_h5file['summary']['n_particles'][self.iter_start - 1 : self.iter_stop].sum()
 
             print("\nwalltime: ", walltime, "seconds")
-            print("walltime: ", walltime/60, "minutes")
-            print("walltime: ", walltime/60/60, "hours")
-            print("walltime: ", walltime/60/60/24, "days")
+            print("walltime: ", walltime / 60, "minutes")
+            print("walltime: ", walltime / 60 / 60, "hours")
+            print("walltime: ", walltime / 60 / 60 / 24, "days")
             print(f"\nassuming tau of {self.tau} ps:")
             print("aggtime: ", aggtime, "segments ran for tau intervals")
-            print("aggtime: ", (aggtime * self.tau)/1000, "ns")
-            print("aggtime: ", (aggtime * self.tau)/1000/1000, "µs\n")
+            print("aggtime: ", (aggtime * self.tau) / 1000, "ns")
+            print("aggtime: ", (aggtime * self.tau) / 1000 / 1000, "µs\n")
             if self.count_events:
                 print("successful recycling events:", self.get_event_count(we_h5file), "\n")
 
@@ -85,18 +87,20 @@ class WTimings(WESTTool):
         self.data_reader.add_args(parser)
         self.iter_range.add_args(parser)
         parser.add_argument(
-        "--tau", "-t",
-        dest="tau",
-        type=int,
-        default=100,
-            help="WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps."
+            "--tau",
+            "-t",
+            dest="tau",
+            type=int,
+            default=100,
+            help="WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.",
         )
         parser.add_argument(
-            "--count-events", "-ce",
+            "--count-events",
+            "-ce",
             dest="count_events",
             action="store_true",
             default=False,
-            help="Include this flag to also output the number of successfull recycling events."
+            help="Include this flag to also output the number of successfull recycling events.",
         )
 
     def process_args(self, args):
@@ -106,8 +110,10 @@ class WTimings(WESTTool):
         with self.data_reader:
             self.iter_range.process_args(args)
 
+
 def entry_point():
     WTimings().main()
+
 
 if __name__ == "__main__":
     entry_point()

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -1,6 +1,3 @@
-import numpy as np
-from tqdm.auto import tqdm
-
 from westpa.tools import (
     WESTTool,
     WESTDataReader,
@@ -14,7 +11,6 @@ class WTimings(WESTTool):
 
     TODO:
         * convert to use logging?
-        * convert from tqdm to native westpa progress indicator?
         * write a simple test: this should be very straitforward (assert time of test h5 file is as expected)
         * update docs
     """
@@ -22,14 +18,13 @@ class WTimings(WESTTool):
     prog = "w_timings"
     description = "A tool for aggregate simulation and wallclock time extraction."
 
-    def __init__(self, tau=100, count_events=False):
+    def __init__(self, tau=100):
         """
         Parameters
         ----------
         tau : int
             WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.
-        count_events : bool
-            Option to also output the number of successfull recycling events.
+
         """
         super().__init__()
         self.data_reader = WESTDataReader()
@@ -37,31 +32,6 @@ class WTimings(WESTTool):
         self.iter_start = None
         self.iter_stop = None
         self.tau = tau
-        self.count_events = count_events
-
-    def get_event_count(self, we_h5file):
-        """
-        Check if the target state was reached, given the data in a WEST H5 file.
-
-        Parameters
-        ----------
-        we_h5file : h5py.File
-
-        Returns
-        -------
-        int
-            Number of successful recycling events.
-        """
-        events = 0
-        # Get the key to the final iteration.
-        # Need to do -2 instead of -1 because there's an empty-ish final iteration written.
-        for iteration_key in tqdm(list(we_h5file['iterations'].keys())[-2:0:-1]):
-            endpoint_types = we_h5file[f'iterations/{iteration_key}/seg_index']['endpoint_type']
-            if 3 in endpoint_types:
-                # print(f"recycled segment found in file {h5_filename} at iteration {iteration_key}")
-                # count the number of 3s
-                events += np.count_nonzero(endpoint_types == 3)
-        return events
 
     def go(self):
         with self.data_reader:
@@ -85,11 +55,6 @@ class WTimings(WESTTool):
             print(f"{'Total Segments:':30} {aggtime}")
             print(f"{'Simulation time:':30} {((aggtime * self.tau) / 1000):.2f} ns")
 
-            if self.count_events:
-                events = self.get_event_count(we_h5file)
-                print("\n===== RECYCLING =====")
-                print(f"{'Recycled walkers:':30} {events}")
-
     def add_args(self, parser):
         self.data_reader.add_args(parser)
         self.iter_range.add_args(parser)
@@ -101,19 +66,10 @@ class WTimings(WESTTool):
             default=100,
             help="WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.",
         )
-        parser.add_argument(
-            "--count-events",
-            "-ce",
-            dest="count_events",
-            action="store_true",
-            default=False,
-            help="Include this flag to also output the number of successfull recycling events.",
-        )
 
     def process_args(self, args):
         self.data_reader.process_args(args)
         self.tau = args.tau
-        self.count_events = args.count_events
         with self.data_reader:
             self.iter_range.process_args(args)
 

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -29,18 +29,16 @@ class WTimings(WESTTool):
         super().__init__()
         self.data_reader = WESTDataReader()
         self.iter_range = IterRangeSelection(self.data_reader)
-        self.iter_start = None
-        self.iter_stop = None
         self.tau = tau
 
     def go(self):
         with self.data_reader:
             we_h5file = self.data_reader.data_manager.we_h5file
-            self.iter_start = self.iter_range.iter_start
-            self.iter_stop = self.iter_range.iter_stop
+            iter_start = self.iter_range.iter_start
+            iter_stop = self.iter_range.iter_stop
 
-            walltime = we_h5file['summary']['walltime'][self.iter_start - 1 : self.iter_stop].sum()
-            aggtime = we_h5file['summary']['n_particles'][self.iter_start - 1 : self.iter_stop].sum()
+            walltime = we_h5file['summary']['walltime'][iter_start - 1 : iter_stop].sum()
+            aggtime = we_h5file['summary']['n_particles'][iter_start - 1 : iter_stop].sum()
 
             days = int(walltime) // 86400
             hours = (int(walltime) % 86400) // 3600

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -1,3 +1,4 @@
+import math
 from datetime import timedelta
 
 from westpa.tools import (
@@ -40,9 +41,12 @@ class WTimings(WESTTool):
             iter_stop = self.iter_range.iter_stop
 
             walltime = we_h5file['summary']['walltime'][iter_start - 1 : iter_stop].sum()
+            cputime = we_h5file['summary']['cputime'][iter_start - 1 : iter_stop].sum()
             aggtime = we_h5file['summary']['n_particles'][iter_start - 1 : iter_stop].sum()
 
         print(f'Total wall-clock time: {timedelta(seconds=walltime)}')
+        if not math.isclose(cputime, 0):  # Only print CPU time if it was recorded.
+            print(f'Total CPU time: {timedelta(seconds=cputime)}')
 
         print("\n===== SIMULATION  =====")
         print(f"{'Tau:':30} {self.tau} ps")

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -72,16 +72,23 @@ class WTimings(WESTTool):
             walltime = we_h5file['summary']['walltime'][self.iter_start - 1 : self.iter_stop].sum()
             aggtime = we_h5file['summary']['n_particles'][self.iter_start - 1 : self.iter_stop].sum()
 
-            print("\nwalltime: ", walltime, "seconds")
-            print("walltime: ", walltime / 60, "minutes")
-            print("walltime: ", walltime / 60 / 60, "hours")
-            print("walltime: ", walltime / 60 / 60 / 24, "days")
-            print(f"\nassuming tau of {self.tau} ps:")
-            print("aggtime: ", aggtime, "segments ran for tau intervals")
-            print("aggtime: ", (aggtime * self.tau) / 1000, "ns")
-            print("aggtime: ", (aggtime * self.tau) / 1000 / 1000, "µs\n")
+            days = int(walltime) // 86400
+            hours = (int(walltime) % 86400) // 3600
+            minutes = (int(walltime) % 3600) // 60
+            seconds = walltime % 60
+
+            print("\n===== WALLCLOCK  =====")
+            print(f"{'Total Wallclock Time:':30}{days:>2}d {hours:>2}h {minutes:>2}m {seconds:>6.2f}s")
+
+            print("\n===== SIMULATION  =====")
+            print(f"{'Tau:':30} {self.tau} ps")
+            print(f"{'Total Segments:':30} {aggtime}")
+            print(f"{'Simulation time:':30} {((aggtime * self.tau) / 1000):.2f} ns")
+
             if self.count_events:
-                print("successful recycling events:", self.get_event_count(we_h5file), "\n")
+                events = self.get_event_count(we_h5file)
+                print("\n===== RECYCLING =====")
+                print(f"{'Recycled walkers:':30} {events}")
 
     def add_args(self, parser):
         self.data_reader.add_args(parser)

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from westpa.tools import (
     WESTTool,
     WESTDataReader,
@@ -40,18 +42,12 @@ class WTimings(WESTTool):
             walltime = we_h5file['summary']['walltime'][iter_start - 1 : iter_stop].sum()
             aggtime = we_h5file['summary']['n_particles'][iter_start - 1 : iter_stop].sum()
 
-            days = int(walltime) // 86400
-            hours = (int(walltime) % 86400) // 3600
-            minutes = (int(walltime) % 3600) // 60
-            seconds = walltime % 60
+        print(f'Total wall-clock time: {timedelta(seconds=walltime)}')
 
-            print("\n===== WALLCLOCK  =====")
-            print(f"{'Total Wallclock Time:':30}{days:>2}d {hours:>2}h {minutes:>2}m {seconds:>6.2f}s")
-
-            print("\n===== SIMULATION  =====")
-            print(f"{'Tau:':30} {self.tau} ps")
-            print(f"{'Total Segments:':30} {aggtime}")
-            print(f"{'Simulation time:':30} {((aggtime * self.tau) / 1000):.2f} ns")
+        print("\n===== SIMULATION  =====")
+        print(f"{'Tau:':30} {self.tau} ps")
+        print(f"{'Total Segments:':30} {aggtime}")
+        print(f"{'Simulation time:':30} {((aggtime * self.tau) / 1000):.2f} ns")
 
     def add_args(self, parser):
         self.data_reader.add_args(parser)

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -1,5 +1,6 @@
-import math
 from datetime import timedelta
+
+import numpy as np
 
 from westpa.tools import (
     WESTTool,
@@ -8,31 +9,39 @@ from westpa.tools import (
 )
 
 
+TIME_UNITS = ['as', 'fs', 'ps', 'ns', 'us', 'ms', 's', 'm', 'h']
+
+
+def _unit(delta):
+    words = str(delta.dtype).split('[')
+    if len(words) == 1:
+        return None
+    return words[1][:-1]
+
+
+def _str(delta):
+    unit = _unit(delta)
+    if unit is None:
+        return str(delta)
+    for new_unit in TIME_UNITS[TIME_UNITS.index(unit) + 1 :]:
+        if delta < np.timedelta64(1, new_unit):
+            break
+        unit = new_unit
+        if delta % np.timedelta64(1, unit):
+            return f'{delta / np.timedelta64(1, unit)} {unit}'
+        delta = delta.astype(f'timedelta64[{unit}]')
+    return f'{delta.astype(int)} {unit}'
+
+
 class WTimings(WESTTool):
-    """
-    Aggregate simulation and wallclock time extraction.
+    prog = 'w_timings'
+    description = 'Print timing information for a WESTPA simulation.'
 
-    TODO:
-        * convert to use logging?
-        * write a simple test: this should be very straitforward (assert time of test h5 file is as expected)
-        * update docs
-    """
-
-    prog = "w_timings"
-    description = "A tool for aggregate simulation and wallclock time extraction."
-
-    def __init__(self, tau=100):
-        """
-        Parameters
-        ----------
-        tau : int
-            WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.
-
-        """
+    def __init__(self):
         super().__init__()
         self.data_reader = WESTDataReader()
         self.iter_range = IterRangeSelection(self.data_reader)
-        self.tau = tau
+        self.tau = None
 
     def go(self):
         start = self.iter_range.iter_start - 1
@@ -42,34 +51,37 @@ class WTimings(WESTTool):
 
         walltime = iter_summaries['walltime'].sum()
         cputime = iter_summaries['cputime'].sum()
-        aggtime = iter_summaries['n_particles'].sum()
+        n_particles = iter_summaries['n_particles'].sum()
+        n_iters = len(iter_summaries)
 
-        print(f'Total wall-clock time: {timedelta(seconds=walltime)}')
-        if not math.isclose(cputime, 0):  # Only print CPU time if it was recorded.
+        print(f'Iterations: {n_iters}')
+        print(f'Total segments: {n_particles}')
+        print(f'Wall-clock time: {timedelta(seconds=walltime)}')
+        if not np.isclose(cputime, 0):  # only print CPU time if it was recorded
             print(f'Total CPU time: {timedelta(seconds=cputime)}')
-
-        print("\n===== SIMULATION  =====")
-        print(f"{'Tau:':30} {self.tau} ps")
-        print(f"{'Total Segments:':30} {aggtime}")
-        print(f"{'Simulation time:':30} {((aggtime * self.tau) / 1000):.2f} ns")
+        if self.tau is not None:
+            print(f'Simulated physical time ("molecular time"): {_str(n_iters * self.tau)}')
+            print(f'Aggregate simulation time: {_str(n_particles * self.tau)}')
 
     def add_args(self, parser):
         self.data_reader.add_args(parser)
         self.iter_range.add_args(parser)
         parser.add_argument(
-            "--tau",
-            "-t",
-            dest="tau",
-            type=int,
-            default=100,
-            help="WESTPA dynamics propagation time in picoseconds. Default 100 = 100ps.",
+            '-t',
+            '--tau',
+            help=(
+                'WE resampling interval (format: <value>_<unit>, where <value> '
+                'is a positive integer and <unit> is a NumPy time unit code).'
+            ),
         )
 
     def process_args(self, args):
         self.data_reader.process_args(args)
-        self.tau = args.tau
         with self.data_reader:
             self.iter_range.process_args(args)
+        if args.tau is not None:
+            value, *unit = args.tau.split('_')
+            self.tau = np.timedelta64(int(value), *unit)
 
 
 def entry_point():

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -69,11 +69,12 @@ class WTimings(WESTTool):
         n_particles = iter_summaries['n_particles'].sum()
         n_iters = len(iter_summaries)
 
-        print('Iterations:', n_iters)
-        print('Total segments:', n_particles)
-        print('Wall-clock time:', timedelta(seconds=walltime))
+        width = 26
+        print('Iterations:'.ljust(width), n_iters)
+        print('Total segments:'.ljust(width), n_particles)
+        print('Wall-clock time:'.ljust(width), timedelta(seconds=walltime))
         if not np.isclose(cputime, 0):  # only print CPU time if it was recorded
-            print('Total CPU time:', timedelta(seconds=cputime))
+            print('Total CPU time:'.ljust(width), timedelta(seconds=cputime))
         if self.tau is not None:
             print('Maximum trajectory length:', _str(n_iters * self.tau))
             print('Aggregate simulation time:', _str(n_particles * self.tau))

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -36,6 +36,18 @@ def _str(delta):
     return f'{delta / unit_delta} {unit}'
 
 
+def _delta(arg):
+    # Construct a NumPy timedelta from an argument string.
+    # Example: '100_ps' -> timedelta64(100, 'ps')
+    try:
+        value, unit = arg.split('_')
+    except ValueError:
+        raise ValueError('must be formatted as <value>_<unit>')
+    if unit not in TIME_UNITS:
+        raise ValueError(f'{unit!r} is not a recognized time unit')
+    return np.timedelta64(int(value), unit)
+
+
 class WTimings(WESTTool):
     prog = 'w_timings'
     description = 'Print timing information for a WESTPA simulation.'
@@ -86,10 +98,10 @@ class WTimings(WESTTool):
             self.iter_range.process_args(args)
 
         if args.tau is not None:
-            value, unit = args.tau.split('_')
-            if unit not in TIME_UNITS:
-                raise ValueError(f'{unit!r} is not a recognized time unit')
-            self.tau = np.timedelta64(int(value), unit)
+            try:
+                self.tau = _delta(args.tau)
+            except (TypeError, ValueError) as e:
+                self.parser.error(f'argument -t/--tau: {e}')
 
 
 def entry_point():

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -57,14 +57,14 @@ class WTimings(WESTTool):
         n_particles = iter_summaries['n_particles'].sum()
         n_iters = len(iter_summaries)
 
-        print(f'Iterations: {n_iters}')
-        print(f'Total segments: {n_particles}')
-        print(f'Wall-clock time: {timedelta(seconds=walltime)}')
+        print('Iterations:', n_iters)
+        print('Total segments:', n_particles)
+        print('Wall-clock time:', timedelta(seconds=walltime))
         if not np.isclose(cputime, 0):  # only print CPU time if it was recorded
-            print(f'Total CPU time: {timedelta(seconds=cputime)}')
+            print('Total CPU time:', timedelta(seconds=cputime))
         if self.tau is not None:
-            print(f'Maximum trajectory length: {_str(n_iters * self.tau)}')
-            print(f'Aggregate simulation time: {_str(n_particles * self.tau)}')
+            print('Maximum trajectory length:', _str(n_iters * self.tau))
+            print('Aggregate simulation time:', _str(n_particles * self.tau))
 
     def add_args(self, parser):
         self.data_reader.add_args(parser)

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -63,7 +63,7 @@ class WTimings(WESTTool):
         if not np.isclose(cputime, 0):  # only print CPU time if it was recorded
             print(f'Total CPU time: {timedelta(seconds=cputime)}')
         if self.tau is not None:
-            print(f'Simulated physical time ("molecular time"): {_str(n_iters * self.tau)}')
+            print(f'Maximum trajectory length: {_str(n_iters * self.tau)}')
             print(f'Aggregate simulation time: {_str(n_particles * self.tau)}')
 
     def add_args(self, parser):

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -35,14 +35,14 @@ class WTimings(WESTTool):
         self.tau = tau
 
     def go(self):
+        start = self.iter_range.iter_start - 1
+        stop = self.iter_range.iter_stop - 1
         with self.data_reader:
-            we_h5file = self.data_reader.data_manager.we_h5file
-            iter_start = self.iter_range.iter_start
-            iter_stop = self.iter_range.iter_stop
+            iter_summaries = self.data_reader.we_h5file['summary'][start:stop]
 
-            walltime = we_h5file['summary']['walltime'][iter_start - 1 : iter_stop].sum()
-            cputime = we_h5file['summary']['cputime'][iter_start - 1 : iter_stop].sum()
-            aggtime = we_h5file['summary']['n_particles'][iter_start - 1 : iter_stop].sum()
+        walltime = iter_summaries['walltime'].sum()
+        cputime = iter_summaries['cputime'].sum()
+        aggtime = iter_summaries['n_particles'].sum()
 
         print(f'Total wall-clock time: {timedelta(seconds=walltime)}')
         if not math.isclose(cputime, 0):  # Only print CPU time if it was recorded.

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -43,7 +43,7 @@ def _delta(arg):
         value, unit = arg.split('_')
     except ValueError:
         raise ValueError('must be formatted as <value>_<unit>')
-    if unit not in TIME_UNITS:
+    if unit not in TIME_UNITS + ('μs',):  # accept either μs or us for microsecond
         raise ValueError(f'{unit!r} is not a recognized time unit')
     return np.timedelta64(int(value), unit)
 

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -9,7 +9,7 @@ from westpa.tools import (
 )
 
 
-# NumPy linear time units
+# NumPy fixed time units (excludes nonlinear units 'Y and 'M')
 TIME_UNITS = ('W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns', 'ps', 'fs', 'as')
 
 
@@ -68,12 +68,14 @@ class WTimings(WESTTool):
     def add_args(self, parser):
         self.data_reader.add_args(parser)
         self.iter_range.add_args(parser)
+
+        unit_list = ', '.join(map(repr, TIME_UNITS[-1:0:-1])) + f', or {TIME_UNITS[0]!r}'
         parser.add_argument(
             '-t',
             '--tau',
             help=(
                 'WE resampling interval (format: <value>_<unit>, where <value> '
-                'is a positive integer and <unit> is a NumPy time unit code).'
+                f'is a positive integer and <unit> is {unit_list}).'
             ),
         )
 
@@ -81,9 +83,12 @@ class WTimings(WESTTool):
         self.data_reader.process_args(args)
         with self.data_reader:
             self.iter_range.process_args(args)
+
         if args.tau is not None:
-            value, *unit = args.tau.split('_')
-            self.tau = np.timedelta64(int(value), *unit)
+            value, unit = args.tau.split('_')
+            if unit not in TIME_UNITS:
+                raise ValueError(f'{unit!r} is not a recognized time unit')
+            self.tau = np.timedelta64(int(value), unit)
 
 
 def entry_point():

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -9,10 +9,12 @@ from westpa.tools import (
 )
 
 
-TIME_UNITS = ['as', 'fs', 'ps', 'ns', 'us', 'ms', 's', 'm', 'h']
+# NumPy linear time units
+TIME_UNITS = ('W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns', 'ps', 'fs', 'as')
 
 
 def _unit(delta):
+    # Return the unit of a NumPy timedelta.
     words = str(delta.dtype).split('[')
     if len(words) == 1:
         return None
@@ -20,17 +22,17 @@ def _unit(delta):
 
 
 def _str(delta):
-    unit = _unit(delta)
-    if unit is None:
+    # Return a compact string representation of a NumPy timedelta.
+    if _unit(delta) is None:
         return str(delta)
-    for new_unit in TIME_UNITS[TIME_UNITS.index(unit) + 1 :]:
-        if delta < np.timedelta64(1, new_unit):
-            break
-        unit = new_unit
-        if delta % np.timedelta64(1, unit):
-            return f'{delta / np.timedelta64(1, unit)} {unit}'
-        delta = delta.astype(f'timedelta64[{unit}]')
-    return f'{delta.astype(int)} {unit}'
+    for unit in TIME_UNITS:
+        unit_delta = np.timedelta64(1, unit)
+        try:
+            if delta >= unit_delta:
+                break
+        except OverflowError:
+            continue
+    return f'{delta / unit_delta:g} {unit}'
 
 
 class WTimings(WESTTool):

--- a/src/westpa/cli/tools/w_timings.py
+++ b/src/westpa/cli/tools/w_timings.py
@@ -22,7 +22,8 @@ def _unit(delta):
 
 
 def _str(delta):
-    # Return a compact string representation of a NumPy timedelta.
+    # Return a string representation of a NumPy timedelta.
+    # Example: timedelta64(5380000, 'ps') -> '5.38 us'
     if _unit(delta) is None:
         return str(delta)
     for unit in TIME_UNITS:
@@ -32,7 +33,7 @@ def _str(delta):
                 break
         except OverflowError:
             continue
-    return f'{delta / unit_delta:g} {unit}'
+    return f'{delta / unit_delta} {unit}'
 
 
 class WTimings(WESTTool):

--- a/tests/test_tools/test_w_timings.py
+++ b/tests/test_tools/test_w_timings.py
@@ -1,0 +1,44 @@
+import os
+from unittest import mock
+import argparse
+import pytest
+from westpa.cli.tools.w_timings import entry_point
+
+class Test_W_Timings:
+    """Test class for w_timings tool."""
+
+    @pytest.fixture
+    def ref_west_file(self):
+        return "tests/refs/west_3iter.h5"
+
+    def test_run_w_timings(self, ref_west_file, capsys):
+        """
+        Currently only checks if sections headers are printing correctly
+        """
+
+        with mock.patch(
+            "argparse.ArgumentParser.parse_args",
+            return_value=argparse.Namespace(
+                verbosity="debug",
+                rcfile=None,
+                we_h5filename=ref_west_file,
+                first_iter=None,
+                last_iter=None,
+                tau=100,
+                count_events=True,
+            ),
+        ):
+            entry_point()
+
+        captured = capsys.readouterr()
+        output = captured.out
+
+        # Basic checks that output sections are present
+        #TODO: Replace with actual known values from reference
+        assert "===== WALLCLOCK  =====" in output
+        assert "Total Wallclock Time:" in output
+        assert "===== SIMULATION  =====" in output
+        assert "Simulation time:" in output
+        assert "===== RECYCLING =====" in output
+        assert "Recycled walkers:" in output
+

--- a/tests/test_tools/test_w_timings.py
+++ b/tests/test_tools/test_w_timings.py
@@ -4,6 +4,7 @@ import argparse
 import pytest
 from westpa.cli.tools.w_timings import entry_point
 
+
 class Test_W_Timings:
     """Test class for w_timings tool."""
 
@@ -34,11 +35,10 @@ class Test_W_Timings:
         output = captured.out
 
         # Basic checks that output sections are present
-        #TODO: Replace with actual known values from reference
+        # TODO: Replace with actual known values from reference
         assert "===== WALLCLOCK  =====" in output
         assert "Total Wallclock Time:" in output
         assert "===== SIMULATION  =====" in output
         assert "Simulation time:" in output
         assert "===== RECYCLING =====" in output
         assert "Recycled walkers:" in output
-

--- a/tests/test_tools/test_w_timings.py
+++ b/tests/test_tools/test_w_timings.py
@@ -1,44 +1,62 @@
-import os
 from unittest import mock
 import argparse
-import pytest
+
 from westpa.cli.tools.w_timings import entry_point
 
 
 class Test_W_Timings:
     """Test class for w_timings tool."""
 
-    @pytest.fixture
-    def ref_west_file(self):
-        return "tests/refs/west_3iter.h5"
+    def args(self, first_iter=None, last_iter=None, tau=None):
+        return argparse.Namespace(
+            verbosity=None,
+            rcfile=None,
+            we_h5filename=self.h5_filepath,
+            first_iter=first_iter,
+            last_iter=last_iter,
+            tau=tau,
+        )
 
-    def test_run_w_timings(self, ref_west_file, capsys):
-        """
-        Currently only checks if sections headers are printing correctly
-        """
-
+    def test_default(self, ref_50iter, capsys):
         with mock.patch(
             "argparse.ArgumentParser.parse_args",
-            return_value=argparse.Namespace(
-                verbosity="debug",
-                rcfile=None,
-                we_h5filename=ref_west_file,
-                first_iter=None,
-                last_iter=None,
-                tau=100,
-                count_events=True,
-            ),
+            return_value=self.args(),
         ):
             entry_point()
-
         captured = capsys.readouterr()
         output = captured.out
+        assert output == """\
+Iterations: 50
+Total segments: 9985
+Wall-clock time: 0:00:01.452625
+"""
 
-        # Basic checks that output sections are present
-        # TODO: Replace with actual known values from reference
-        assert "===== WALLCLOCK  =====" in output
-        assert "Total Wallclock Time:" in output
-        assert "===== SIMULATION  =====" in output
-        assert "Simulation time:" in output
-        assert "===== RECYCLING =====" in output
-        assert "Recycled walkers:" in output
+    def test_tau(self, ref_50iter, capsys):
+        with mock.patch(
+            "argparse.ArgumentParser.parse_args",
+            return_value=self.args(tau='100_ps'),
+        ):
+            entry_point()
+        captured = capsys.readouterr()
+        output = captured.out
+        assert output == """\
+Iterations: 50
+Total segments: 9985
+Wall-clock time: 0:00:01.452625
+Maximum trajectory length: 5.0 ns
+Aggregate simulation time: 998.5 ns
+"""
+
+    def test_iter_range(self, ref_50iter, capsys):
+        with mock.patch(
+                "argparse.ArgumentParser.parse_args",
+                return_value=self.args(first_iter=11, last_iter=40),
+        ):
+            entry_point()
+        captured = capsys.readouterr()
+        output = captured.out
+        assert output == """\
+Iterations: 30
+Total segments: 6320
+Wall-clock time: 0:00:00.868997
+"""

--- a/tests/test_tools/test_w_timings.py
+++ b/tests/test_tools/test_w_timings.py
@@ -26,9 +26,9 @@ class Test_W_Timings:
         captured = capsys.readouterr()
         output = captured.out
         expected = """\
-Iterations: 50
-Total segments: 9985
-Wall-clock time: 0:00:01.452625
+Iterations:                50
+Total segments:            9985
+Wall-clock time:           0:00:01.452625
 """
         assert output == expected
 
@@ -41,9 +41,9 @@ Wall-clock time: 0:00:01.452625
         captured = capsys.readouterr()
         output = captured.out
         expected = """\
-Iterations: 50
-Total segments: 9985
-Wall-clock time: 0:00:01.452625
+Iterations:                50
+Total segments:            9985
+Wall-clock time:           0:00:01.452625
 Maximum trajectory length: 5.0 ns
 Aggregate simulation time: 998.5 ns
 """
@@ -82,8 +82,8 @@ Aggregate simulation time: 998.5 ns
         captured = capsys.readouterr()
         output = captured.out
         expected = """\
-Iterations: 30
-Total segments: 6320
-Wall-clock time: 0:00:00.868997
+Iterations:                30
+Total segments:            6320
+Wall-clock time:           0:00:00.868997
 """
         assert output == expected

--- a/tests/test_tools/test_w_timings.py
+++ b/tests/test_tools/test_w_timings.py
@@ -25,11 +25,12 @@ class Test_W_Timings:
             entry_point()
         captured = capsys.readouterr()
         output = captured.out
-        assert output == """\
+        expected = """\
 Iterations: 50
 Total segments: 9985
 Wall-clock time: 0:00:01.452625
 """
+        assert output == expected
 
     def test_tau(self, ref_50iter, capsys):
         with mock.patch(
@@ -39,24 +40,50 @@ Wall-clock time: 0:00:01.452625
             entry_point()
         captured = capsys.readouterr()
         output = captured.out
-        assert output == """\
+        expected = """\
 Iterations: 50
 Total segments: 9985
 Wall-clock time: 0:00:01.452625
 Maximum trajectory length: 5.0 ns
 Aggregate simulation time: 998.5 ns
 """
+        assert output == expected
+
+    def test_tau_invalid_unit(self, ref_50iter, capsys):
+        with mock.patch(
+            "argparse.ArgumentParser.parse_args",
+            return_value=self.args(tau='100_u'),
+        ):
+            try:
+                entry_point()
+            except SystemExit as e:
+                assert e.code == 2
+        captured = capsys.readouterr()
+        assert "'u' is not a recognized time unit" in captured.err
+
+    def test_tau_invalid_format(self, ref_50iter, capsys):
+        with mock.patch(
+            "argparse.ArgumentParser.parse_args",
+            return_value=self.args(tau='100'),
+        ):
+            try:
+                entry_point()
+            except SystemExit as e:
+                assert e.code == 2
+        captured = capsys.readouterr()
+        assert 'must be formatted as <value>_<unit>' in captured.err
 
     def test_iter_range(self, ref_50iter, capsys):
         with mock.patch(
-                "argparse.ArgumentParser.parse_args",
-                return_value=self.args(first_iter=11, last_iter=40),
+            "argparse.ArgumentParser.parse_args",
+            return_value=self.args(first_iter=11, last_iter=40),
         ):
             entry_point()
         captured = capsys.readouterr()
         output = captured.out
-        assert output == """\
+        expected = """\
 Iterations: 30
 Total segments: 6320
 Wall-clock time: 0:00:00.868997
 """
+        assert output == expected


### PR DESCRIPTION
## Issue Number

This PR is a revision of #499, itself a revision of #466.

closes #499 
closes #466

## Describe the changes made

Add a new CLI tool that displays timing information for a WESTPA simulation.

The default output includes the wall-clock time and, if per-segment CPU times were recorded by the propagator, the total CPU time:
```console
$ w_timings -W west.h5
Iterations:                100
Total segments:            7775
Wall-clock time:           2 days, 4:35:11.749094
Total CPU time:            17 days, 9:09:00.556985
```
When a resampling interval (`-t/--tau`) is specified, output also includes the maximum trajectory length ("molecular time") and aggregate simulation time:
```console
$ w_timings -W west.h5 -t 50_ps
Iterations:                100
Total segments:            7775
Wall-clock time:           2 days, 4:35:11.749094
Total CPU time:            17 days, 9:09:00.556985
Maximum trajectory length: 5.0 ns
Aggregate simulation time: 388.75 ns
```


## Files changed
- `src/westpa/cli/tools/w_timings.py` (new file)
- `setup.py` (added entry point)
- `tests/test_tools/test_w_timings.py` (new file)
- `doc/documentation/cli.rst` (added toctree item)
- `doc/documentation/cli/w_timings.rst` (new file)

## Status
<!--- Delete bullet points that are not relevant. --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
