### PR TITLE
drop macos testing on python 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,9 +45,13 @@ jobs:
           - python-version: "3.13"
             numpy-version: "1"
           - os: "ubuntu-24.04-arm"
-            python-version: "3.10"
-          - os: "ubuntu-24.04-arm"
             numpy-version: "1"
+          - os: "ubuntu-24.04-arm"
+            python-version: "3.10"
+          - os: "macos-13"
+            python-version: "3.10"
+          - os: 'macos-latest'
+            python-version: "3.10"
     steps:
       - uses: actions/checkout@v4
         with: 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
The environment-solving for macos/python 3.10 are take an hour+ (sometimes times out after 6 hours). This completely drops testing for those builds. There is no way to speed them up, despite best efforts.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Drop MacOS/Python 3.10 tests

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] .github/workflows/test.yaml

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


