### PR TITLE
Move pytables into an optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,15 +121,15 @@ INSTALL_REQUIRES = [
     "ipykernel",
     "tqdm",
     "pandas",
-    "tables",
 ]
 
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"],
-    "mpi": ["mpi4py"],
+        "optional": ["tables"],
+        "tests": ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"],
+        "mpi": ["mpi4py"],
 }
 
-EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + ["pre-commit"]
+EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["optional"] + EXTRAS_REQUIRE["tests"] + ["pre-commit"]
 
 
 metadata = dict(

--- a/setup.py
+++ b/setup.py
@@ -124,9 +124,9 @@ INSTALL_REQUIRES = [
 ]
 
 EXTRAS_REQUIRE = {
-        "optional": ["tables"],
-        "tests": ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"],
-        "mpi": ["mpi4py"],
+    "optional": ["tables"],
+    "tests": ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"],
+    "mpi": ["mpi4py"],
 }
 
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["optional"] + EXTRAS_REQUIRE["tests"] + ["pre-commit"]

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -29,6 +29,7 @@ except ImportError:
 
 try:
     from tables import NaturalNameWarning
+
     warnings.filterwarnings('ignore', category=NaturalNameWarning)
 except ImportError:
     pass

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -14,7 +14,6 @@ import warnings
 import h5py
 import numpy as np
 from numpy import index_exp
-from tables import NaturalNameWarning
 
 from mdtraj import Trajectory, join as join_traj
 from mdtraj.utils import in_units_of, import_, ensure_type
@@ -28,8 +27,13 @@ try:
 except ImportError:
     psutil = None
 
+try:
+    from tables import NaturalNameWarning
+    warnings.filterwarnings('ignore', category=NaturalNameWarning)
+except ImportError:
+    pass
+
 log = logging.getLogger(__name__)
-warnings.filterwarnings('ignore', category=NaturalNameWarning)
 
 #
 # Constants and globals


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
#516 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Moving `pytables`/`tables` into an optional dependency, similar to `mpi4py` . This will streamline westpa's installation.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Make Pytables an optional dependency

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] setup.py
- [x] src/westpa/core/h5io.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


