### PR TITLE
Clean up of setup.py, Moving more to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "Cython >=0.29.16",  # Note: sync with setup.py
     "numpy >=2.0.0, <3",  # Force numpy>=2 during build time so it works on both 1.XX and 2.XX
     "scipy >=0.19.1",
-    "versioneer-518"
+    "versioneer-518",
 ]
 # Uncommenting this requires adding the top level of the repo to sys.path in the setup.py
 # so that it can find the vendorized copy of versioneer. I see that other projects don't
@@ -18,7 +18,7 @@ requires = [
 
 [project]
 name = "westpa"
-dynamic = ["version", "dependencies", "optional-dependencies", "scripts"]
+dynamic = ["version", "scripts"]
 license = "MIT"
 license-files = ["LICEN[CS]E.*"]
 requires-python = ">=3.10"
@@ -34,7 +34,25 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Cython",
 ]
+dependencies = [
+  "numpy >= 1.25.0,<3",
+  "scipy >= 0.19.1",
+  "h5py >= 2.10",
+  "mdtraj >= 1.9.5",
+  "pyyaml",
+  "pyzmq",
+  "matplotlib",
+  "blessings",
+  "ipykernel",
+  "tqdm",
+  "pandas",
+  "tables",
+]
 
+[project.optional-dependencies]
+tests = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"]
+mpi = ["mpi4py"]
+dev = ["westpa[tests]", "pre-commit"]
 
 [project.urls]
 Homepage = "https://westpa.github.io"
@@ -42,8 +60,6 @@ Repository = "https://github.com/westpa/westpa"
 Documentation = "https://github.readthedocs.io"
 Issues = "https://github.com/westpa/westpa/issues"
 
-[tool.setuptools.packages.find]
-where = ["src"]
 
 [tool.black]
 line-length = 132
@@ -73,6 +89,9 @@ exclude = '''
      )
 )
 '''
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,96 @@ requires = [
 # always include this (pandas, numpy, etc), so leaving this off for now
 # build-backend = "setuptools.build_meta"
 
+
+[project]
+name = "westpa"
+dynamic = ["version"]
+license = "MIT"
+license-files = ["LICEN[CS]E.*"]
+readme = {file = "README.rst", content-type = "text/x-rst"}
+keywords = []
+requires-python = ">=3.10"
+description = 'WESTPA is a package for constructing and running stochastic simulations using the "weighted ensemble" approach of Huber and Kim (1996).'
+dependencies = [
+  "numpy >= 1.25.0,<3",
+  "scipy >= 0.19.1",
+  "h5py >= 2.10",
+  "mdtraj >= 1.9.5",
+  "pyyaml",
+  "pyzmq",
+  "matplotlib",
+  "blessings",
+  "ipykernel",
+  "tqdm",
+  "pandas",
+  "tables",
+]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Operating System :: POSIX",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Cython",
+]
+
+
+[project.urls]
+Homepage = "https://westpa.github.io"
+Repository = "https://github.com/westpa/westpa"
+Documentation = "https://github.readthedocs.io"
+Issues = "https://github.com/westpa/westpa/issues"
+
+
+[project.optional-dependencies]
+tests = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"]
+mpi = ["mpi4py"]
+dev = ["westpa[tests]", "pre-commit"]
+
+
+[project.scripts]
+# WESTPA Core
+w_fork = "westpa.cli.core.w_fork:entry_point"
+w_states = "westpa.cli.core.w_states:entry_point"
+w_run = "westpa.cli.core.w_run:entry_point"
+w_truncate = "westpa.cli.core.w_truncate:entry_point"
+w_init = "westpa.cli.core.w_init:entry_point"
+w_succ = "westpa.cli.core.w_succ:entry_point"
+# WESTPA Tools
+w_direct = "westpa.cli.tools.w_direct:entry_point"
+w_dumpsegs = "westpa.cli.tools.w_dumpsegs:entry_point"
+w_postanalysis_matrix = "westpa.cli.tools.w_postanalysis_matrix:entry_point"
+w_select = "westpa.cli.tools.w_select:entry_point"
+w_ntop = "westpa.cli.tools.w_ntop:entry_point"
+w_kinavg = "westpa.cli.tools.w_kinavg:entry_point"
+w_eddist = "westpa.cli.tools.w_eddist:entry_point"
+w_assign = "westpa.cli.tools.w_assign:entry_point"
+w_trace = "westpa.cli.tools.w_trace:entry_point"
+w_crawl = "westpa.cli.tools.w_crawl:entry_point"
+w_kinetics = "westpa.cli.tools.w_kinetics:entry_point"
+w_fluxanl = "westpa.cli.tools.w_fluxanl:entry_point"
+w_reweight = "westpa.cli.tools.w_reweight:entry_point"
+w_pdist = "westpa.cli.tools.w_pdist:entry_point"
+w_ipa = "westpa.cli.tools.w_ipa:entry_point"
+w_bins = "westpa.cli.tools.w_bins:entry_point"
+w_stateprobs = "westpa.cli.tools.w_stateprobs:entry_point"
+w_postanalysis_reweight = "westpa.cli.tools.w_postanalysis_reweight:entry_point"
+ploterr = "westpa.cli.tools.ploterr:entry_point"
+plothist = "westpa.cli.tools.plothist:entry_point"
+w_multi_west = "westpa.cli.tools.w_multi_west:entry_point"
+w_red = "westpa.cli.tools.w_red:entry_point"
+w_timings = "westpa.cli.tools.w_timings:entry_point"
+
+
+[tool.setuptools]
+zip-safe = false
+
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+
 [tool.black]
 line-length = 132
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ name = "westpa"
 dynamic = ["version", "scripts"]
 license = "MIT"
 license-files = ["LICEN[CS]E.*"]
-requires-python = ">=3.10"
 readme = {file = "README.rst", content-type = "text/x-rst"}
 keywords = []
 description = 'WESTPA is a package for constructing and running stochastic simulations using the "weighted ensemble" approach of Huber and Kim (1996).'
@@ -34,6 +33,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Cython",
 ]
+requires-python = ">=3.10"
 dependencies = [
   "numpy >= 1.25.0,<3",
   "scipy >= 0.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,27 +18,13 @@ requires = [
 
 [project]
 name = "westpa"
-dynamic = ["version"]
+dynamic = ["version", "dependencies", "optional-dependencies", "scripts"]
 license = "MIT"
 license-files = ["LICEN[CS]E.*"]
+requires-python = ">=3.10"
 readme = {file = "README.rst", content-type = "text/x-rst"}
 keywords = []
-requires-python = ">=3.10"
 description = 'WESTPA is a package for constructing and running stochastic simulations using the "weighted ensemble" approach of Huber and Kim (1996).'
-dependencies = [
-  "numpy >= 1.25.0,<3",
-  "scipy >= 0.19.1",
-  "h5py >= 2.10",
-  "mdtraj >= 1.9.5",
-  "pyyaml",
-  "pyzmq",
-  "matplotlib",
-  "blessings",
-  "ipykernel",
-  "tqdm",
-  "pandas",
-  "tables",
-]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -56,54 +42,8 @@ Repository = "https://github.com/westpa/westpa"
 Documentation = "https://github.readthedocs.io"
 Issues = "https://github.com/westpa/westpa/issues"
 
-
-[project.optional-dependencies]
-tests = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"]
-mpi = ["mpi4py"]
-dev = ["westpa[tests]", "pre-commit"]
-
-
-[project.scripts]
-# WESTPA Core
-w_fork = "westpa.cli.core.w_fork:entry_point"
-w_states = "westpa.cli.core.w_states:entry_point"
-w_run = "westpa.cli.core.w_run:entry_point"
-w_truncate = "westpa.cli.core.w_truncate:entry_point"
-w_init = "westpa.cli.core.w_init:entry_point"
-w_succ = "westpa.cli.core.w_succ:entry_point"
-# WESTPA Tools
-w_direct = "westpa.cli.tools.w_direct:entry_point"
-w_dumpsegs = "westpa.cli.tools.w_dumpsegs:entry_point"
-w_postanalysis_matrix = "westpa.cli.tools.w_postanalysis_matrix:entry_point"
-w_select = "westpa.cli.tools.w_select:entry_point"
-w_ntop = "westpa.cli.tools.w_ntop:entry_point"
-w_kinavg = "westpa.cli.tools.w_kinavg:entry_point"
-w_eddist = "westpa.cli.tools.w_eddist:entry_point"
-w_assign = "westpa.cli.tools.w_assign:entry_point"
-w_trace = "westpa.cli.tools.w_trace:entry_point"
-w_crawl = "westpa.cli.tools.w_crawl:entry_point"
-w_kinetics = "westpa.cli.tools.w_kinetics:entry_point"
-w_fluxanl = "westpa.cli.tools.w_fluxanl:entry_point"
-w_reweight = "westpa.cli.tools.w_reweight:entry_point"
-w_pdist = "westpa.cli.tools.w_pdist:entry_point"
-w_ipa = "westpa.cli.tools.w_ipa:entry_point"
-w_bins = "westpa.cli.tools.w_bins:entry_point"
-w_stateprobs = "westpa.cli.tools.w_stateprobs:entry_point"
-w_postanalysis_reweight = "westpa.cli.tools.w_postanalysis_reweight:entry_point"
-ploterr = "westpa.cli.tools.ploterr:entry_point"
-plothist = "westpa.cli.tools.plothist:entry_point"
-w_multi_west = "westpa.cli.tools.w_multi_west:entry_point"
-w_red = "westpa.cli.tools.w_red:entry_point"
-w_timings = "westpa.cli.tools.w_timings:entry_point"
-
-
-[tool.setuptools]
-zip-safe = false
-
-
 [tool.setuptools.packages.find]
 where = ["src"]
-
 
 [tool.black]
 line-length = 132

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,73 @@ def extensions():
     return exts
 
 
+console_scripts_core = [
+    'w_fork = westpa.cli.core.w_fork:entry_point',
+    'w_states = westpa.cli.core.w_states:entry_point',
+    'w_run = westpa.cli.core.w_run:entry_point',
+    'w_truncate = westpa.cli.core.w_truncate:entry_point',
+    'w_init = westpa.cli.core.w_init:entry_point',
+    'w_succ = westpa.cli.core.w_succ:entry_point',
+]
+
+console_scripts_tools = [
+    'w_direct = westpa.cli.tools.w_direct:entry_point',
+    'w_dumpsegs = westpa.cli.tools.w_dumpsegs:entry_point',
+    'w_postanalysis_matrix = westpa.cli.tools.w_postanalysis_matrix:entry_point',
+    'w_select = westpa.cli.tools.w_select:entry_point',
+    'w_ntop = westpa.cli.tools.w_ntop:entry_point',
+    'w_kinavg = westpa.cli.tools.w_kinavg:entry_point',
+    'w_eddist = westpa.cli.tools.w_eddist:entry_point',
+    'w_assign = westpa.cli.tools.w_assign:entry_point',
+    'w_trace = westpa.cli.tools.w_trace:entry_point',
+    'w_crawl = westpa.cli.tools.w_crawl:entry_point',
+    'w_kinetics = westpa.cli.tools.w_kinetics:entry_point',
+    'w_fluxanl = westpa.cli.tools.w_fluxanl:entry_point',
+    'w_reweight = westpa.cli.tools.w_reweight:entry_point',
+    'w_pdist = westpa.cli.tools.w_pdist:entry_point',
+    'w_ipa = westpa.cli.tools.w_ipa:entry_point',
+    'w_bins = westpa.cli.tools.w_bins:entry_point',
+    'w_stateprobs = westpa.cli.tools.w_stateprobs:entry_point',
+    'w_postanalysis_reweight = westpa.cli.tools.w_postanalysis_reweight:entry_point',
+    'ploterr = westpa.cli.tools.ploterr:entry_point',
+    'plothist = westpa.cli.tools.plothist:entry_point',
+    'w_multi_west = westpa.cli.tools.w_multi_west:entry_point',
+    'w_red = westpa.cli.tools.w_red:entry_point',
+    'w_timings = westpa.cli.tools.w_timings:entry_point',
+]
+
+console_scripts = console_scripts_core + console_scripts_tools
+
+INSTALL_REQUIRES = [
+    "numpy >= 1.25.0, <3",
+    "scipy >= 0.19.1",
+    "h5py >= 2.10",
+    "mdtraj >= 1.9.5",
+    "pyyaml",
+    "pyzmq",
+    "matplotlib",
+    "blessings",
+    "ipykernel",
+    "tqdm",
+    "pandas",
+    "tables",
+]
+
+EXTRAS_REQUIRE = {
+    "tests": ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"],
+    "mpi": ["mpi4py"],
+}
+
+EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + ["pre-commit"]
+
+
 metadata = dict(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     zip_safe=False,
+    entry_points={'console_scripts': console_scripts},
+    install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRE,
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys
 
-from setuptools import setup, Extension, find_packages
+from setuptools import setup, Extension
 
 import versioneer
 
@@ -61,95 +61,10 @@ def extensions():
     return exts
 
 
-console_scripts_core = [
-    'w_fork = westpa.cli.core.w_fork:entry_point',
-    'w_states = westpa.cli.core.w_states:entry_point',
-    'w_run = westpa.cli.core.w_run:entry_point',
-    'w_truncate = westpa.cli.core.w_truncate:entry_point',
-    'w_init = westpa.cli.core.w_init:entry_point',
-    'w_succ = westpa.cli.core.w_succ:entry_point',
-]
-
-console_scripts_tools = [
-    'w_direct = westpa.cli.tools.w_direct:entry_point',
-    'w_dumpsegs = westpa.cli.tools.w_dumpsegs:entry_point',
-    'w_postanalysis_matrix = westpa.cli.tools.w_postanalysis_matrix:entry_point',
-    'w_select = westpa.cli.tools.w_select:entry_point',
-    'w_ntop = westpa.cli.tools.w_ntop:entry_point',
-    'w_kinavg = westpa.cli.tools.w_kinavg:entry_point',
-    'w_eddist = westpa.cli.tools.w_eddist:entry_point',
-    'w_assign = westpa.cli.tools.w_assign:entry_point',
-    'w_trace = westpa.cli.tools.w_trace:entry_point',
-    'w_crawl = westpa.cli.tools.w_crawl:entry_point',
-    'w_kinetics = westpa.cli.tools.w_kinetics:entry_point',
-    'w_fluxanl = westpa.cli.tools.w_fluxanl:entry_point',
-    'w_reweight = westpa.cli.tools.w_reweight:entry_point',
-    'w_pdist = westpa.cli.tools.w_pdist:entry_point',
-    'w_ipa = westpa.cli.tools.w_ipa:entry_point',
-    'w_bins = westpa.cli.tools.w_bins:entry_point',
-    'w_stateprobs = westpa.cli.tools.w_stateprobs:entry_point',
-    'w_postanalysis_reweight = westpa.cli.tools.w_postanalysis_reweight:entry_point',
-    'ploterr = westpa.cli.tools.ploterr:entry_point',
-    'plothist = westpa.cli.tools.plothist:entry_point',
-    'w_multi_west = westpa.cli.tools.w_multi_west:entry_point',
-    'w_red = westpa.cli.tools.w_red:entry_point',
-    'w_timings = westpa.cli.tools.w_timings:entry_point',
-]
-
-console_scripts = console_scripts_core + console_scripts_tools
-
-CLASSIFIERS = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: POSIX",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Cython",
-]
-
-INSTALL_REQUIRES = [
-    "numpy >= 1.25.0, <3",
-    "scipy >= 0.19.1",
-    "h5py >= 2.10",
-    "mdtraj >= 1.9.5",
-    "pyyaml",
-    "pyzmq",
-    "matplotlib",
-    "blessings",
-    "ipykernel",
-    "tqdm",
-    "pandas",
-    "tables",
-]
-
-EXTRAS_REQUIRE = {
-    "tests": ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"],
-    "mpi": ["mpi4py"],
-}
-
-EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + ["pre-commit"]
-
-
 metadata = dict(
-    name='westpa',
-    url='http://github.com/westpa/westpa',
-    license='MIT',
-    long_description=open('README.rst', encoding='utf8').read(),
     version=versioneer.get_version(),
-    keywords='',
     cmdclass=versioneer.get_cmdclass(),
-    python_requires=">=3.10",
     zip_safe=False,
-    classifiers=CLASSIFIERS,
-    entry_points={'console_scripts': console_scripts},
-    install_requires=INSTALL_REQUIRES,
-    extras_require=EXTRAS_REQUIRE,
-    package_data={},
-    packages=find_packages(where='src'),
-    package_dir={"": "src"},
-    description='WESTPA is a package for constructing and running stochastic simulations using the "weighted ensemble" approach of Huber and Kim (1996).',
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -98,36 +98,12 @@ console_scripts_tools = [
 
 console_scripts = console_scripts_core + console_scripts_tools
 
-INSTALL_REQUIRES = [
-    "numpy >= 1.25.0, <3",
-    "scipy >= 0.19.1",
-    "h5py >= 2.10",
-    "mdtraj >= 1.9.5",
-    "pyyaml",
-    "pyzmq",
-    "matplotlib",
-    "blessings",
-    "ipykernel",
-    "tqdm",
-    "pandas",
-    "tables",
-]
-
-EXTRAS_REQUIRE = {
-    "tests": ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout"],
-    "mpi": ["mpi4py"],
-}
-
-EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + ["pre-commit"]
-
 
 metadata = dict(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     zip_safe=False,
     entry_points={'console_scripts': console_scripts},
-    install_requires=INSTALL_REQUIRES,
-    extras_require=EXTRAS_REQUIRE,
 )
 
 

--- a/src/westpa/cli/tools/w_reweight.py
+++ b/src/westpa/cli/tools/w_reweight.py
@@ -92,7 +92,7 @@ def _pop_eval_block(
     do_correl,
     mcbs_enable,
     estimator_kwargs,
-    **kwargs
+    **kwargs,
 ):
     # As our reweighting estimator is a weird function, we can't use the general mclib block.
     # A little hack to make our estimator play nice, as jstate must be there.
@@ -680,7 +680,7 @@ Command-line options
                     name='Bin Population Evolution',
                     mcbs_enable=self.mcbs_enable,
                     data_input={},
-                    **submit_kwargs
+                    **submit_kwargs,
                 )
                 # print(future_kwargs)
                 futures.append(generate_future(self.work_manager, 'Bin Pop Evolution', _pop_eval_block, future_kwargs))

--- a/src/westpa/mclib/__init__.py
+++ b/src/westpa/mclib/__init__.py
@@ -204,7 +204,7 @@ def _1D_simple_eval_block(
     do_correl,
     mcbs_enable,
     subsample=np.mean,
-    **extra
+    **extra,
 ):
     # This is actually appropriate for anything with a directly measured, 1D dataset, i.e.,
     # Fluxes, color populations, and state populations.
@@ -242,7 +242,7 @@ def _2D_simple_eval_block(
     do_correl,
     mcbs_enable,
     subsample=np.mean,
-    **extra
+    **extra,
 ):
     # This is really just a simple 2D block for less complex datasets, but there it is.
     # It's probably limited in this use case to conditional_fluxes, but anything that's an i to j process that is directly measured

--- a/src/westpa/tools/kinetics_tool.py
+++ b/src/westpa/tools/kinetics_tool.py
@@ -302,7 +302,7 @@ class AverageCommands(WESTKineticsBase):
                     name=name,
                     mcbs_enable=self.mcbs_enable,
                     data_input={},
-                    **extra
+                    **extra,
                 )
 
                 # Slice up the datasets for this iteration slice.

--- a/src/westpa/westext/stringmethod/string_method.py
+++ b/src/westpa/westext/stringmethod/string_method.py
@@ -87,7 +87,7 @@ class DefaultStringMethod(WESTStringMethod):
         fourier_P=2,
         fourier_maxiters=100,
         fourier_tol=1.0e-6,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(centers, **kwargs)
 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Just a general cleanup of `setup.py`, moving most into `pyproject.toml`. Simple refactor and should have no observable effects on the user.

Most project info and dependencies are now in `pyproject.toml`.  The only stuff left in `setup.py` are the cythonize steps, `versioneer` and the entry points. The entry points were too big of a block and it's just cleaner to include/leave in `setup.py`.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Update install scripts to modern standards 

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] setup.py
- [x] pyproject.toml

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.

- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


