### PR TITLE
Fix to Python 3.14 build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc2"
+          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc-devel"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,15 @@ jobs:
 
       - name: "Install HDF5 with brew"
         if: ${{ matrix.os == 'macos-latest' }}
-        run: "brew install hdf5"
+        run: |
+          brew update
+          brew install hdf5
+
+      - name: "Install HDF5 with apt"
+        if: ${{ matrix.os != 'macos-latest' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install hdf5
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc-devel"
+          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc2-devel"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ matrix.os != 'macos-latest' }}
         run: |
           sudo apt-get update
-          sudo apt-get install hdf5
+          sudo apt-get install libhdf5-dev
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           brew install hdf5
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.0
+        uses: pypa/cibuildwheel@v3.2.1
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,9 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: >
-            yum -y install libhdf5-dev
+            yum install -u epel-release
+            yum-config-manager --enable epel
+            yum -y install hdf5-devel
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
           brew update
-          brew install hdf5
+          brew install hdf5 c-blosc2
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.0
@@ -47,7 +47,6 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel"
-          CIBW_BEFORE_TEST_MACOS: "brew install c-blosc2"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel"
+          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc-devel"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,8 +47,6 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: >
-            yum install -u epel-release &&
-            yum-config-manager --enable epel &&
             yum -y install hdf5-devel
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest"]  # macos-latest is arm64
-        python-version: [10, 11, 12, 13, 14] # sub-versions of Python
+        python-version: [10, 11, 12, 13] # sub-versions of Python
     steps:
       - uses: actions/checkout@v5
 
@@ -36,7 +36,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
           brew update
-          brew install hdf5 c-blosc2
+          brew install hdf5
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
@@ -46,7 +46,6 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc blosc-devel"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
           brew update
-          brew install hdf5
+          brew install hdf5 c-blosc2
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
           brew update
-          brew install hdf5 c-blosc2
+          brew install hdf5
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,8 +46,8 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_BEFORE_TEST_LINUX: >
-            yum -y install hdf5-devel
+          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel"
+          CIBW_BEFORE_TEST_MACOS: "brew install c-blosc2"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,8 +47,8 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: >
-            yum install -u epel-release
-            yum-config-manager --enable epel
+            yum install -u epel-release &&
+            yum-config-manager --enable epel &&
             yum -y install hdf5-devel
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,8 +47,8 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: >
-            apt-get update &&
-            apt-get install libhdf5-dev
+            apt update &&
+            apt install libhdf5-dev
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,12 +38,6 @@ jobs:
           brew update
           brew install hdf5
 
-      - name: "Install HDF5 with apt"
-        if: ${{ matrix.os != 'macos-latest' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install libhdf5-dev
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.0
         env:
@@ -52,6 +46,9 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
+          CIBW_BEFORE_TEST_LINUX: >
+            sudo apt-get update &&
+            sudo apt-get install libhdf5-dev
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,8 +47,8 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: >
-            sudo apt-get update &&
-            sudo apt-get install libhdf5-dev
+            apt-get update &&
+            apt-get install libhdf5-dev
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,8 +47,7 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: >
-            apt update &&
-            apt install libhdf5-dev
+            yum -y install libhdf5-dev
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc-devel"
+          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc blosc-devel"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc2-devel"
+          CIBW_BEFORE_TEST_LINUX: "yum -y install hdf5-devel blosc2"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ INSTALL_REQUIRES = [
     "ipykernel",
     "tqdm",
     "pandas",
-    "tables",
+    "tables==3.10.1",
 ]
 
 EXTRAS_REQUIRE = {

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ INSTALL_REQUIRES = [
     "ipykernel",
     "tqdm",
     "pandas",
-    "tables==3.10.1",
+    "tables",
 ]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
A small change in python 3.14 wheels-building procedure to allow for python 3.14 wheels to be tested.

hdf5 will now be install on non-macos (i.e. linux) `cibuildwheel` workflows to allow for testing when h5py/tables wheels are not available.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Added extra step in build.yaml to install hdf5 on ubuntu (not macos-latest)

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] .github/workflows/build.yaml

## Status
<!--- Delete bullet points that are not relevant. --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the CONTRIBUTING document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


