### PR TITLE
Fix Processes work manager silent hang

### DIFF
--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -43,8 +43,7 @@ class BinlessSimManager(WESimManager):
             futures.add(future)
             segment_futures.add(future)
 
-        while futures:
-            # TODO: add capacity for timeout or SIGINT here
+        while futures and self.work_manager.running:
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 
@@ -84,7 +83,7 @@ class BinlessSimManager(WESimManager):
         futures.update(istate_gen_futures)
 
         # Wait for istate_gen_futures and catch untracked futures.
-        while futures:
+        while futures and self.work_manager.running:
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -46,8 +46,7 @@ class MABSimManager(WESimManager):
             futures.add(future)
             segment_futures.add(future)
 
-        while futures:
-            # TODO: add capacity for timeout or SIGINT here
+        while futures and self.work_manager.running:
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 
@@ -87,7 +86,7 @@ class MABSimManager(WESimManager):
         futures.update(istate_gen_futures)
 
         # Wait for istate_gen_futures and catch untracked futures.
-        while futures:
+        while futures and self.work_manager.running:
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -723,8 +723,8 @@ class WESTIterationFile(HDF5TrajectoryFile):
             )
 
         if slog is not None:
-            if self._has_node('/log', str(segment.seg_id)):
-                self._remove_node('/log', name=str(segment.seg_id), recursive=True)
+            if self._has_node('/log', name='%d_%d' % (segment.n_iter, segment.seg_id)):
+                self._remove_node('/log', name='%d_%d' % (segment.n_iter, segment.seg_id), recursive=True)
 
             self._create_array(
                 '/log/%d_%d' % (segment.n_iter, segment.seg_id),

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -117,7 +117,7 @@ def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
         if not is_within_directory(path, member_path):
             raise Exception("Attempted Path Traversal in Tar File")
 
-    tar.extractall(path, members, numeric_owner=numeric_owner, filter='data')
+    tar.extractall(path, members, numeric_owner=numeric_owner, filter='fully_trusted')
 
 
 #

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -117,7 +117,7 @@ def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
         if not is_within_directory(path, member_path):
             raise Exception("Attempted Path Traversal in Tar File")
 
-    tar.extractall(path, members, numeric_owner=numeric_owner)
+    tar.extractall(path, members, numeric_owner=numeric_owner, filter='data')
 
 
 #

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -609,8 +609,7 @@ class WESimManager:
             futures.add(future)
             segment_futures.add(future)
 
-        while futures:
-            # TODO: add capacity for timeout or SIGINT here
+        while futures and self.work_manager.running:
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -162,6 +162,9 @@ class ProcessWorkManager(WorkManager):
         while self.running:
             log.debug('shutting down {!r}'.format(self))
 
+            # Send shutdown signal
+            self.shutdown_received.set()
+
             # Empty queues and sending clean shutdown signals to task_queue
             self._empty_queues()
             for _i in range(self.n_workers):
@@ -195,8 +198,5 @@ class ProcessWorkManager(WorkManager):
             # Empty queues again and finally shutdown result_queue
             self._empty_queues()
             self.result_queue.put(result_shutdown_sentinel, self.shutdown_timeout)
-
-            # Send final shutdown
-            self.shutdown_received.set()
 
             self.running = False

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -162,7 +162,7 @@ class ProcessWorkManager(WorkManager):
         while self.running:
             log.debug('shutting down {!r}'.format(self))
 
-            # Empty queues and sending clean shutdown signal to task queue
+            # Empty queues and sending clean shutdown signals to task_queue
             self._empty_queues()
             for _i in range(self.n_workers):
                 self.task_queue.put_nowait(task_shutdown_sentinel)
@@ -192,7 +192,7 @@ class ProcessWorkManager(WorkManager):
                     except ValueError:
                         pass  # Already closed.
 
-            # Empty Queues again and put result queue to rest
+            # Empty queues again and finally shutdown result_queue
             self._empty_queues()
             self.result_queue.put(result_shutdown_sentinel, self.shutdown_timeout)
 

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -150,16 +150,12 @@ class ProcessWorkManager(WorkManager):
                 self.task_queue.get_nowait()
         except (Empty, ValueError) as e:
             log.debug(f'Emptied task queue, exiting: {e}')
-        except (AttributeError, LookupError) as e:
-            log.debug(f'Read/write errors with Pytables while clearing task queue: {e}')
 
         try:
             while True:
                 self.result_queue.get_nowait()
         except (Empty, ValueError) as e:
             log.debug(f'Emptied result queue, exiting: {e}')
-        except (AttributeError, LookupError) as e:
-            log.debug(f'Read/write errors with Pytables while clearing result queue: {e}')
 
     def shutdown(self):
         while self.running:

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -164,12 +164,13 @@ class ProcessWorkManager(WorkManager):
 
             # Empty queues
             self._empty_queues()
-            for _i in range(len(self.workers)):
+            for _i in range(self.n_workers):
                 self.task_queue.put_nowait(task_shutdown_sentinel)
             self.result_queue.put(result_shutdown_sentinel, timeout=self.shutdown_timeout)
 
             # Signal shutdown Event to stop queue loops
             self.shutdown_received.set()
+            self._empty_queues()
 
             # Terminating all workers
             for worker in self.workers:
@@ -196,11 +197,5 @@ class ProcessWorkManager(WorkManager):
                     except ValueError:
                         pass  # Already closed.
 
-            # Completely closing the queues
-            self.task_queue.close()
-            self.result_queue.close()
-
-            self.task_queue.join_thread()
-            self.result_queue.join_thread()
-
             self.running = False
+            log.debug('Done shutting down the processes work manager')

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -166,7 +166,7 @@ class ProcessWorkManager(WorkManager):
             self._empty_queues()
 
             for _i in range(self.n_workers):
-                self.task_queue.put(task_shutdown_sentinel, self.shutdown_timeout)
+                self.task_queue.put_nowait(task_shutdown_sentinel)
 
             self.result_queue.put(result_shutdown_sentinel, self.shutdown_timeout)
 

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -162,9 +162,6 @@ class ProcessWorkManager(WorkManager):
         while self.running:
             log.debug('shutting down {!r}'.format(self))
 
-            # Send shutdown signal
-            self.shutdown_received.set()
-
             # Empty queues and sending clean shutdown signals to task_queue
             self._empty_queues()
             for _i in range(self.n_workers):
@@ -197,6 +194,9 @@ class ProcessWorkManager(WorkManager):
 
             # Empty queues again and finally shutdown result_queue
             self._empty_queues()
-            self.result_queue.put(result_shutdown_sentinel, self.shutdown_timeout)
+            self.result_queue.put(result_shutdown_sentinel, timeout=self.shutdown_timeout)
+
+            # Send shutdown Event
+            self.shutdown_received.set()
 
             self.running = False

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -166,7 +166,7 @@ class ProcessWorkManager(WorkManager):
             self._empty_queues()
             for _i in range(self.n_workers):
                 self.task_queue.put_nowait(task_shutdown_sentinel)
-            self.result_queue.put(result_shutdown_sentinel, timeout=self.shutdown_timeout)
+            self.result_queue.put_nowait(result_shutdown_sentinel)
 
             # Signal shutdown Event to stop queue loops
             self.shutdown_received.set()

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -150,13 +150,13 @@ class ProcessWorkManager(WorkManager):
             while True:
                 self.task_queue.get_nowait()
         except (Empty, ValueError):
-            log.debug('Emptied task queue.')
+            log.debug('Emptied task_queue')
 
         try:
             while True:
                 self.result_queue.get_nowait()
         except (Empty, ValueError):
-            log.debug('Emptied result queue.')
+            log.debug('Emptied result_queue')
 
     def shutdown(self):
         while self.running:

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -150,25 +150,26 @@ class ProcessWorkManager(WorkManager):
             while True:
                 self.task_queue.get_nowait()
         except (Empty, ValueError):
-            log.debug('Emptied task_queue')
+            log.debug('Empty task_queue')
 
         try:
             while True:
                 self.result_queue.get_nowait()
         except (Empty, ValueError):
-            log.debug('Emptied result_queue')
+            log.debug('Empty result_queue')
 
     def shutdown(self):
         while self.running:
             log.debug('shutting down {!r}'.format(self))
 
-            # Signal shutdown Event
-            self.shutdown_received.set()
-
-            # Empty queues and sending clean shutdown signals to task_queue
+            # Empty queues
             self._empty_queues()
-            for _i in range(self.n_workers):
+            for _i in range(len(self.workers)):
                 self.task_queue.put_nowait(task_shutdown_sentinel)
+            self.result_queue.put(result_shutdown_sentinel, timeout=self.shutdown_timeout)
+
+            # Signal shutdown Event to stop queue loops
+            self.shutdown_received.set()
 
             # Terminating all workers
             for worker in self.workers:
@@ -195,8 +196,11 @@ class ProcessWorkManager(WorkManager):
                     except ValueError:
                         pass  # Already closed.
 
-            # Empty queues again and finally shutdown result_queue
-            self._empty_queues()
-            self.result_queue.put(result_shutdown_sentinel, timeout=self.shutdown_timeout)
+            # Completely closing the queues
+            self.task_queue.close()
+            self.result_queue.close()
+
+            self.task_queue.join_thread()
+            self.result_queue.join_thread()
 
             self.running = False

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -109,6 +109,7 @@ class ProcessWorkManager(WorkManager):
                     raise AssertionError('unknown message {!r}'.format((message, task_id, payload)))
 
         log.debug('exiting results_loop')
+        return
 
     def submit(self, fn, args=None, kwargs=None):
         ft = WMFuture()
@@ -160,13 +161,16 @@ class ProcessWorkManager(WorkManager):
     def shutdown(self):
         while self.running:
             log.debug('shutting down {!r}'.format(self))
-            self.shutdown_received.set()
+
+            # Empty queues and sending clean shutdown signal
             self._empty_queues()
 
-            # Send shutdown signal
             for _i in range(self.n_workers):
-                self.task_queue.put_nowait(task_shutdown_sentinel)
+                self.task_queue.put(task_shutdown_sentinel, self.shutdown_timeout)
 
+            self.result_queue.put(result_shutdown_sentinel, self.shutdown_timeout)
+
+            # Terminating all workers
             for worker in self.workers:
                 worker.join(self.shutdown_timeout)
                 if worker.is_alive():
@@ -191,7 +195,7 @@ class ProcessWorkManager(WorkManager):
                     except ValueError:
                         pass  # Already closed.
 
-            self._empty_queues()
-            self.result_queue.put(result_shutdown_sentinel)
+            # Send final shutdown
+            self.shutdown_received.set()
 
             self.running = False

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -149,26 +149,23 @@ class ProcessWorkManager(WorkManager):
         try:
             while True:
                 self.task_queue.get_nowait()
-        except (Empty, ValueError) as e:
-            log.debug(f'Emptied task queue, exiting: {e}')
+        except (Empty, ValueError):
+            log.debug('Emptied task queue.')
 
         try:
             while True:
                 self.result_queue.get_nowait()
-        except (Empty, ValueError) as e:
-            log.debug(f'Emptied result queue, exiting: {e}')
+        except (Empty, ValueError):
+            log.debug('Emptied result queue.')
 
     def shutdown(self):
         while self.running:
             log.debug('shutting down {!r}'.format(self))
 
-            # Empty queues and sending clean shutdown signal
+            # Empty queues and sending clean shutdown signal to task queue
             self._empty_queues()
-
             for _i in range(self.n_workers):
                 self.task_queue.put_nowait(task_shutdown_sentinel)
-
-            self.result_queue.put(result_shutdown_sentinel, self.shutdown_timeout)
 
             # Terminating all workers
             for worker in self.workers:
@@ -194,6 +191,10 @@ class ProcessWorkManager(WorkManager):
                             log.debug('worker process {:d} could not be closed'.format(worker.pid))
                     except ValueError:
                         pass  # Already closed.
+
+            # Empty Queues again and put result queue to rest
+            self._empty_queues()
+            self.result_queue.put(result_shutdown_sentinel, self.shutdown_timeout)
 
             # Send final shutdown
             self.shutdown_received.set()

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -162,6 +162,9 @@ class ProcessWorkManager(WorkManager):
         while self.running:
             log.debug('shutting down {!r}'.format(self))
 
+            # Signal shutdown Event
+            self.shutdown_received.set()
+
             # Empty queues and sending clean shutdown signals to task_queue
             self._empty_queues()
             for _i in range(self.n_workers):
@@ -195,8 +198,5 @@ class ProcessWorkManager(WorkManager):
             # Empty queues again and finally shutdown result_queue
             self._empty_queues()
             self.result_queue.put(result_shutdown_sentinel, timeout=self.shutdown_timeout)
-
-            # Send shutdown Event
-            self.shutdown_received.set()
 
             self.running = False

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -148,14 +148,18 @@ class ProcessWorkManager(WorkManager):
         try:
             while True:
                 self.task_queue.get_nowait()
-        except Empty:
-            pass
+        except (Empty, ValueError) as e:
+            log.debug(f'Emptied task queue, exiting: {e}')
+        except (AttributeError, LookupError) as e:
+            log.debug(f'Read/write errors with Pytables while clearing task queue: {e}')
 
         try:
             while True:
                 self.result_queue.get_nowait()
-        except Empty:
-            pass
+        except (Empty, ValueError) as e:
+            log.debug(f'Emptied result queue, exiting: {e}')
+        except (AttributeError, LookupError) as e:
+            log.debug(f'Read/write errors with Pytables while clearing result queue: {e}')
 
     def shutdown(self):
         while self.running:

--- a/tests/test_sim_manager.py
+++ b/tests/test_sim_manager.py
@@ -45,6 +45,9 @@ class TestSimManager(TestCase):
         self.sim_manager.completed_segments = self.sim_manager.segments
         self.sim_manager.report_bin_statistics = MagicMock(return_value=True)
 
+        self.work_manager = westpa.rc.get_work_manager()
+        self.work_manager.running = True
+
         data = self.sim_manager.we_driver.rc.get_data_manager()
         data.we_h5filename = self.hdf5
         data.prepare_backing()

--- a/tests/test_work_managers/test_processes.py
+++ b/tests/test_work_managers/test_processes.py
@@ -18,7 +18,7 @@ class TestProcessWorkManager(unittest.TestCase, CommonParallelTests, CommonWorkM
 
 
 class TestProcessWorkManagerAux:
-    @pytest.mark.timeout(2)
+    @pytest.mark.timeout(5)
     def test_shutdown(self):
         work_manager = ProcessWorkManager()
         work_manager.startup()
@@ -29,7 +29,7 @@ class TestProcessWorkManagerAux:
             except ValueError:
                 pass  # probably closed already
 
-    @pytest.mark.timeout(2)
+    @pytest.mark.timeout(5)
     def test_hang_shutdown(self):
         work_manager = ProcessWorkManager()
         work_manager.shutdown_timeout = 0.1
@@ -43,7 +43,7 @@ class TestProcessWorkManagerAux:
             except ValueError:
                 pass  # probably closed already
 
-    @pytest.mark.timeout(2)
+    @pytest.mark.timeout(5)
     def test_hang_shutdown_ignoring_sigint(self):
         work_manager = ProcessWorkManager()
         work_manager.shutdown_timeout = 0.1
@@ -57,7 +57,7 @@ class TestProcessWorkManagerAux:
             except ValueError:
                 pass  # probably closed already
 
-    @pytest.mark.timeout(2)
+    @pytest.mark.timeout(5)
     def test_sigint_shutdown(self):
         work_manager = ProcessWorkManager()
         work_manager.install_sigint_handler()
@@ -77,7 +77,7 @@ class TestProcessWorkManagerAux:
                         pass  # probably closed already
                 raise
 
-    @pytest.mark.timeout(2)
+    @pytest.mark.timeout(5)
     def test_worker_close_fail(self, monkeypatch):
         work_manager = ProcessWorkManager()
         work_manager.install_sigint_handler()
@@ -96,7 +96,7 @@ class TestProcessWorkManagerAux:
         # Clean up
         work_manager.shutdown()
 
-    @pytest.mark.timeout(2)
+    @pytest.mark.timeout(5)
     def test_worker_ids(self):
         work_manager = ProcessWorkManager()
         with work_manager:


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
#533 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->

Effectively I reorganized the processes manager so during shutdown:
1. Clean up the queues
2. Throw `shutdown_sentinels` to shutdown task_queue
3. throw `shutdown_sentinel` to shutdown result_queue (also modified it so it is no longer blocking, with the default timeout)
4. Send shutdown to the queue retrieval loops via the "shutdown_received" Event
5. Clean queues again
6. Shutdown all workers

- Also fixed the bug where logs (for HDF5 Framework) were not deleted properly.
- Also added functionality for sim_manager to detect whether the work_manager is running (and subsequently shutdown the future-related `self.work_manager.wait_any()`
- safe_extract will use the 'fully_trusted' filter when tarring/untarring. This will unify the behavior between python <3.14 and python >3.14
https://docs.python.org/3/library/tarfile.html#extraction-filters

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Fix error where existing log dataset leads to hang processes
- [x] Update processes work manager to be more robust

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/h5io.py
- [x] src/westpa/work_managers/processes.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


