### PR TITLE
Fix Hang in Python 3.14 GH Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - "westpa2"
       - "develop"
+      - "py314-action-fix"
   pull_request:
     branches:
       - "westpa2"
@@ -39,15 +40,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-15-intel", "macos-latest"]  # macos-15-intel is x86-64, macos-latest is arm64
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-        numpy-version: ["1", "2"]
-        exclude:
-          - python-version: "3.13"
-            numpy-version: "1"
-          - python-version: "3.14"
-            numpy-version: "1"
-          - os: "ubuntu-24.04-arm"
-            numpy-version: "1"
+        python-version: ["3.14"]
+        numpy-version: ["2"]
     steps:
       - uses: actions/checkout@v6
         with: 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - "westpa2"
       - "develop"
-      - "py314-action-fix"
   pull_request:
     branches:
       - "westpa2"
@@ -40,8 +39,15 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-15-intel", "macos-latest"]  # macos-15-intel is x86-64, macos-latest is arm64
-        python-version: ["3.14"]
-        numpy-version: ["2"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        numpy-version: ["1", "2"]
+        exclude:
+          - python-version: "3.13"
+            numpy-version: "1"
+          - python-version: "3.14"
+            numpy-version: "1"
+          - os: "ubuntu-24.04-arm"
+            numpy-version: "1"
     steps:
       - uses: actions/checkout@v6
         with: 

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -211,13 +211,10 @@ class PassiveMultiTimer:
 
         new_idx = len(self._identifiers)
 
-        self._durations = np.resize(self._durations, (new_idx + 1,))
-        self._started = np.resize(self._started, (new_idx + 1,))
-        self._identifiers = np.resize(self._identifiers, (new_idx + 1,))
+        self._durations = np.pad(self._durations, (0, 1), mode='constant', constant_values=duration)
+        self._started = np.pad(self._started, (0, 1), mode='constant', constant_values=time.time())
+        self._identifiers = np.pad(self._identifiers, (0, 1), mode='constant', constant_values=identifier)
 
-        self._durations[new_idx] = duration
-        self._started[new_idx] = time.time()
-        self._identifiers[new_idx] = identifier
         self._indices[identifier] = new_idx
 
     def remove_timer(self, identifier):

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -211,17 +211,9 @@ class PassiveMultiTimer:
 
         new_idx = len(self._identifiers)
 
-        # Necessary due to coverage.py's use of a tracer triggering an error on resize
-        refcheck = True if sys.gettrace() is None else False
-
-        if not refcheck:
-            self._durations.resize((new_idx + 1,), refcheck=refcheck)
-            self._started.resize((new_idx + 1,), refcheck=refcheck)
-            self._identifiers.resize((new_idx + 1,), refcheck=refcheck)
-        else:
-            self._durations = np.resize(self._durations, (new_idx + 1,))
-            self._started = np.resize(self._started, (new_idx + 1,))
-            self._identifiers = np.resize(self._identifiers, (new_idx + 1,))
+        self._durations = np.resize(self._durations, (new_idx + 1,))
+        self._started = np.resize(self._started, (new_idx + 1,))
+        self._identifiers = np.resize(self._identifiers, (new_idx + 1,))
 
         self._durations[new_idx] = duration
         self._started[new_idx] = time.time()

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -214,9 +214,14 @@ class PassiveMultiTimer:
         # Necessary due to coverage.py's use of a tracer triggering an error on resize
         refcheck = True if sys.gettrace() is None else False
 
-        self._durations.resize((new_idx + 1,), refcheck=refcheck)
-        self._started.resize((new_idx + 1,), refcheck=refcheck)
-        self._identifiers.resize((new_idx + 1,), refcheck=refcheck)
+        if not refcheck:
+            self._durations.resize((new_idx + 1,), refcheck=refcheck)
+            self._started.resize((new_idx + 1,), refcheck=refcheck)
+            self._identifiers.resize((new_idx + 1,), refcheck=refcheck)
+        else:
+            self._durations = np.resize(self._durations, (new_idx + 1,))
+            self._started = np.resize(self._started, (new_idx + 1,))
+            self._identifiers = np.resize(self._identifiers, (new_idx + 1,))
 
         self._durations[new_idx] = duration
         self._started[new_idx] = time.time()


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
https://github.com/westpa/westpa/actions/runs/20641223356

All Python 3.14 tests began to hang on the `TestInstantiations/test_zeroMQ` test from `test_work_managers/test_environment.py`. This is due to the fact that the zeromq work manager is not properly handling the `ValueError` raised by `numpy 2.4.0` for inplace numpy resizing.

https://github.com/numpy/numpy/pull/30282

Since inplace resizing will (seemingly) be removed in the future anyways, we might as well just forgo that completely. This will increase memory usage, but that's what numpy wants.

I think overall we need to fix zeromq so the futures will handle the errors more elegantly. You can throw in a `raise ValueError`  in the [add_timer() method in src/westpa/work_managers/zeromq/core.py](https://github.com/westpa/westpa/blob/westpa2/src/westpa/work_managers/zeromq/core.py#L208) and it will hang similarly in any python version (tried it on Python 3.13, both numpy 2.3.5, 2.4.0). That'll require some more digging so I'll leave it to a different PR.


Hang can be reproduced via the following on python 3.14/numpy 2.4.0:
```
pytest -v tests/test_work_managers/test_environment.py -k 'testZeroMQ' 
```


## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Make Python 3.14 tests run

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/work_managers/zeromq/core.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


