### PR TITLE
Add Python 3.14 back into cibuildwheels workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,16 +28,44 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest"]  # macos-latest is arm64
-        python-version: [11, 12, 13, 14] # sub-versions of Python
+        python-version: [10, 11, 12, 13, 14] # sub-versions of Python
     steps:
       - uses: actions/checkout@v6
 
-      - name: "Install HDF5 with brew"
+      - name: Install HDF5 with brew
         if: ${{ matrix.os == 'macos-latest' }}
         run: "brew install hdf5"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.0
+        if: ${{ matrix.python-version != '14' }}
+        env:
+          CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
+          CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
+          CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
+          CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
+          CIBW_DEPENDENCY_VERSIONS: "pinned" # default
+          CIBW_TEST_COMMAND: > 
+            python -c "import westpa; print(westpa.__version__)" && 
+            python -c "import westpa.core.propagators" &&
+            python -c "import westpa.core.binning" &&
+            python -c "import westpa.core.kinetics" &&
+            python -c "import westpa.core.reweight" &&
+            python -c "import westpa.work_managers" &&
+            python -c "import westpa.tools" &&
+            python -c "import westpa.fasthist" &&
+            python -c "import westpa.mclib" &&
+            echo "All done with the import tests!"
+            # Currently blocked by https://github.com/westpa/westpa/issues/70
+            #python -c "import westpa.trajtree"
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+          config-file: "{package}/pyproject.toml"
+
+      - name: Build wheels (Python 3.14)
+        uses: pypa/cibuildwheel@v3.3.0
+        if: ${{ matrix.python-version == '14' }}
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
@@ -45,13 +73,11 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_TEST_REQUIRES_LINUX: "blosc2"
-          # Alma Linux 8 does not have blosc2 available so we're installing it via pip
-          # PyTables doesn't detect python-blosc2 very well...
-          # https://github.com/PyTables/PyTables/issues/998
+          # Installing pytables from source due to python 3.14 support
           CIBW_BEFORE_TEST_LINUX: >
-            dnf install -y hdf5 hdf5-devel && 
-            BLOSC2_DIR=$(python -c "import site; print(site.getsitepackages()[0])") && 
+            dnf install -y hdf5 hdf5-devel &&
             python -m pip install git+https://github.com/pytables/pytables
+          CIBW_BEFORE_TEST_MACOS: "python -m pip install git+https://github.com/pytables/pytables"
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,12 +46,12 @@ jobs:
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_TEST_REQUIRES_LINUX: "blosc2"
           CIBW_BEFORE_TEST_LINUX: >
+            dnf install -y hdf5 hdf5-devel &&
+            export BLOSC2_DIR=$(python -c 'import site; print(site.getsitepackages()[0])') &&
+            python -m pip install git+https://github.com/pytables/pytables
             # Alma Linux 8 does not have blosc2 available so we're installing it via pip
             # PyTables doesn't detect python-blosc2 very well...
             # https://github.com/PyTables/PyTables/issues/998
-            dnf install -y hdf5 hdf5-devel
-            export BLOSC2_DIR=$(python -c 'import site; print(site.getsitepackages()[0])')
-            python -m pip install git+https://github.com/pytables/pytables
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,11 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
+          CIBW_BEFORE_TEST_LINUX: >
+            dnf install -y hdf5 hdf5-devel
+          CIBW_TEST_REQUIRES_LINUX: "blosc2" "git+https://github.com/pytables/pytables"
+          CIBW_TEST_ENVIRONMENT_LINUX: >
+            BLOSC2_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,9 +45,10 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: "dnf install -y hdf5 hdf5-devel"
-          CIBW_TEST_REQUIRES_LINUX: "blosc2 git+https://github.com/pytables/pytables"
-          CIBW_TEST_ENVIRONMENT_LINUX: >
-            BLOSC2_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
+          CIBW_TEST_REQUIRES_LINUX: "blosc2"
+          CIBW_BEFORE_TEST_LINUX: >
+            export BLOSC2_DIR=$(python -c 'import site; print(site.getsitepackages()[0])')
+            python -m pip install git+https://github.com/pytables/pytables
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: "dnf install -y hdf5 hdf5-devel"
-          CIBW_TEST_REQUIRES_LINUX: ["blosc2", "git+https://github.com/pytables/pytables"]
+          CIBW_TEST_REQUIRES_LINUX: "blosc2" "git+https://github.com/pytables/pytables"
           CIBW_TEST_ENVIRONMENT_LINUX: >
             BLOSC2_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
           CIBW_TEST_COMMAND: > 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,13 +45,10 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_TEST_REQUIRES_LINUX: "blosc2"
-          CIBW_BEFORE_TEST_LINUX: >
-            dnf install -y hdf5 hdf5-devel &&
-            export BLOSC2_DIR=$(python -c 'import site; print(site.getsitepackages()[0])') &&
-            python -m pip install git+https://github.com/pytables/pytables
-            # Alma Linux 8 does not have blosc2 available so we're installing it via pip
-            # PyTables doesn't detect python-blosc2 very well...
-            # https://github.com/PyTables/PyTables/issues/998
+          # Alma Linux 8 does not have blosc2 available so we're installing it via pip
+          # PyTables doesn't detect python-blosc2 very well...
+          # https://github.com/PyTables/PyTables/issues/998
+          CIBW_BEFORE_TEST_LINUX: 'dnf install -y hdf5 hdf5-devel && BLOSC2_DIR=$(python -c "import site; print(site.getsitepackages()[0])") && python -m pip install git+https://github.com/pytables/pytables'
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest"]  # macos-latest is arm64
-        python-version: [10, 11, 12, 13] # sub-versions of Python
+        python-version: [10, 11, 12, 13, 14] # sub-versions of Python
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_BEFORE_TEST_LINUX: "dnf install -y hdf5 hdf5-devel"
-          CIBW_TEST_REQUIRES_LINUX: "blosc2" "git+https://github.com/pytables/pytables"
+          CIBW_TEST_REQUIRES_LINUX: "blosc2 git+https://github.com/pytables/pytables"
           CIBW_TEST_ENVIRONMENT_LINUX: >
             BLOSC2_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
           CIBW_TEST_COMMAND: > 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest"]  # macos-latest is arm64
-        python-version: [10, 11, 12, 13, 14] # sub-versions of Python
+        python-version: [11, 12, 13, 14] # sub-versions of Python
     steps:
       - uses: actions/checkout@v6
 
@@ -48,7 +48,10 @@ jobs:
           # Alma Linux 8 does not have blosc2 available so we're installing it via pip
           # PyTables doesn't detect python-blosc2 very well...
           # https://github.com/PyTables/PyTables/issues/998
-          CIBW_BEFORE_TEST_LINUX: 'dnf install -y hdf5 hdf5-devel && BLOSC2_DIR=$(python -c "import site; print(site.getsitepackages()[0])") && python -m pip install git+https://github.com/pytables/pytables'
+          CIBW_BEFORE_TEST_LINUX: >
+            dnf install -y hdf5 hdf5-devel && 
+            BLOSC2_DIR=$(python -c "import site; print(site.getsitepackages()[0])") && 
+            python -m pip install git+https://github.com/pytables/pytables
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,9 +44,12 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_BEFORE_TEST_LINUX: "dnf install -y hdf5 hdf5-devel"
           CIBW_TEST_REQUIRES_LINUX: "blosc2"
           CIBW_BEFORE_TEST_LINUX: >
+            # Alma Linux 8 does not have blosc2 available so we're installing it via pip
+            # PyTables doesn't detect python-blosc2 very well...
+            # https://github.com/PyTables/PyTables/issues/998
+            dnf install -y hdf5 hdf5-devel
             export BLOSC2_DIR=$(python -c 'import site; print(site.getsitepackages()[0])')
             python -m pip install git+https://github.com/pytables/pytables
           CIBW_TEST_COMMAND: > 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,9 +44,8 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_BEFORE_TEST_LINUX: >
-            dnf install -y hdf5 hdf5-devel
-          CIBW_TEST_REQUIRES_LINUX: "blosc2" "git+https://github.com/pytables/pytables"
+          CIBW_BEFORE_TEST_LINUX: "dnf install -y hdf5 hdf5-devel"
+          CIBW_TEST_REQUIRES_LINUX: ["blosc2", "git+https://github.com/pytables/pytables"]
           CIBW_TEST_ENVIRONMENT_LINUX: >
             BLOSC2_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
           CIBW_TEST_COMMAND: > 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
Reverts #530

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Try and build Python 3.14 wheels.

Problems were mostly in testing the wheels: installing `pytables` in the venv is a pain because of the lack of wheels for Python 3.14.
I got around by installing `hdf5/hdf5-devel` and installing `python-blosc2` (because blosc2 isn't available for Alma Linux 8 from regular channels). I also had to install from github source for python 3.14 because of a bug in Pytables 3.10.2 source.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Build python 3.14 wheels

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] .github/workflows/build.yaml

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


