### PR TITLE
Hotfix for PropagatorExecutable where aux_data_loader is mistakenly chosen for 'pcoord'

### DIFF
--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -1708,7 +1708,7 @@ def create_dataset_from_dsopts(group, dsopts, shape=None, dtype=None, data=None,
         opts['scaleoffset'] = scaleoffset
 
     if log.isEnabledFor(logging.DEBUG):
-        log.debug('requiring aux dataset {!r}, shape={!r}, opts={!r}'.format(h5_dsname, shape, opts))
+        log.debug('requiring dataset {!r}, shape={!r}, opts={!r}'.format(h5_dsname, shape, opts))
 
     dset = containing_group.require_dataset(h5_dsname, **opts)
 

--- a/src/westpa/core/logging.py
+++ b/src/westpa/core/logging.py
@@ -1,0 +1,12 @@
+"""Logging utilities"""
+
+import logging
+
+
+class DuplicateFilter(logging.Filter):
+    def filter(self, record):
+        current_log = (record.module, record.levelno, record.getMessage())
+        if current_log != getattr(self, "last_log", None):
+            self.last_log = current_log
+            return True
+        return False

--- a/src/westpa/core/logging.py
+++ b/src/westpa/core/logging.py
@@ -3,7 +3,7 @@
 import logging
 
 
-class DuplicateFilter(logging.Filter):
+class ConsecutiveDuplicateFilter(logging.Filter):
     def filter(self, record):
         current_log = (record.module, record.levelno, record.getMessage())
         if current_log != getattr(self, "last_log", None):

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -132,13 +132,7 @@ class ExecutablePropagator(WESTPropagator):
         log.debug('exe_info: {!r}'.format(self.exe_info))
 
         # Load configuration items relating to dataset input
-        self.data_info['pcoord'] = {
-            'name': 'pcoord',
-            'loader': pcoord_loader,
-            'enabled': True,
-            'filename': None,
-            'dir': False
-        }
+        self.data_info['pcoord'] = {'name': 'pcoord', 'loader': pcoord_loader, 'enabled': True, 'filename': None, 'dir': False}
         self.data_info['trajectory'] = {
             'name': 'trajectory',
             'loader': mdtraj_trajectory_loader,
@@ -153,13 +147,7 @@ class ExecutablePropagator(WESTPropagator):
             'filename': None,
             'dir': True,
         }
-        self.data_info['log'] = {
-            'name': 'seglog',
-            'loader': seglog_loader,
-            'enabled': store_h5,
-            'filename': None,
-            'dir': False
-        }
+        self.data_info['log'] = {'name': 'seglog', 'loader': seglog_loader, 'enabled': store_h5, 'filename': None, 'dir': False}
 
         # Grab config from west.executable.datasets, else fallback to west.data.datasets.
         dataset_configs = config.get(["west", "executable", "datasets"]) or config.get(['west', 'data', 'datasets'], {})

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -30,7 +30,8 @@ from westpa.core.segment import Segment
 from westpa.core.yamlcfg import check_bool
 
 log = logging.getLogger(__name__)
-log.addFilter(DuplicateFilter())
+if log.root.level >= logging.WARNING:
+    log.addFilter(DuplicateFilter())
 
 # Get a list of user-friendly signal names
 SIGNAL_NAMES = {getattr(signal, name): name for name in dir(signal) if name.startswith('SIG') and not name.startswith('SIG_')}

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -132,8 +132,13 @@ class ExecutablePropagator(WESTPropagator):
         log.debug('exe_info: {!r}'.format(self.exe_info))
 
         # Load configuration items relating to dataset input
-        self.data_info['pcoord'] = {'name': 'pcoord', 'loader': pcoord_loader, 'enabled': True, 'filename': None, 'dir': False}
-
+        self.data_info['pcoord'] = {
+            'name': 'pcoord',
+            'loader': pcoord_loader,
+            'enabled': True,
+            'filename': None,
+            'dir': False
+        }
         self.data_info['trajectory'] = {
             'name': 'trajectory',
             'loader': mdtraj_trajectory_loader,
@@ -148,10 +153,17 @@ class ExecutablePropagator(WESTPropagator):
             'filename': None,
             'dir': True,
         }
-        self.data_info['log'] = {'name': 'seglog', 'loader': seglog_loader, 'enabled': store_h5, 'filename': None, 'dir': False}
+        self.data_info['log'] = {
+            'name': 'seglog',
+            'loader': seglog_loader,
+            'enabled': store_h5,
+            'filename': None,
+            'dir': False
+        }
 
         # Grab config from west.executable.datasets, else fallback to west.data.datasets.
         dataset_configs = config.get(["west", "executable", "datasets"]) or config.get(['west', 'data', 'datasets'], {})
+
         for dsinfo in dataset_configs:
             try:
                 dsname = dsinfo['name']
@@ -170,31 +182,29 @@ class ExecutablePropagator(WESTPropagator):
             else:
                 dspath = None
 
-            match loader_directive:
-                case loader_directive if callable(loader_directive):
-                    # If directly callable, then use it
-                    loader = loader_directive
-                case 'pcoord' | 'seglog' | 'restart':
-                    # These are "protected" dataset names
-                    if loader_directive in data_loaders:
-                        loader = data_loaders[loader_directive]
-                    else:
-                        loader = get_object(loader_directive)
-                case 'trajectory':
-                    # Special dataset for saving trajectory coordinates in HDF5 Framework
-                    if loader_directive in trajectory_loaders:
-                        loader = trajectory_loaders[loader_directive]
-                    else:
-                        loader = get_object(loader_directive, path=dspath)
-                case _:
-                    # All other dataset names
-                    if loader_directive in data_loaders:
-                        loader = data_loaders[loader_directive]
-                    elif isinstance(loader_directive, str):
-                        loader = get_object(loader_directive, path=dspath)
-                    else:
-                        # Assumed aux dataset, defaulting to aux_data_loader
-                        loader = aux_data_loader
+            if callable(loader_directive):
+                # If directly callable, then use it
+                loader = loader_directive
+            else:
+                match dsname:
+                    case 'pcoord' | 'seglog' | 'restart':
+                        # These are proteced dataset names, so set them directly.
+                        loader = loader_directive
+                    case 'trajectory':
+                        # Special dataset for saving trajectory coordinates in HDF5 Framework
+                        if loader_directive in trajectory_loaders:
+                            loader = trajectory_loaders[loader_directive]
+                        else:
+                            loader = get_object(loader_directive, path=dspath)
+                    case _:
+                        # All other dataset names
+                        if loader_directive in data_loaders:
+                            loader = data_loaders[loader_directive]
+                        elif isinstance(loader_directive, str):
+                            loader = get_object(loader_directive, path=dspath)
+                        else:
+                            # Assumed aux dataset, defaulting to aux_data_loader
+                            loader = aux_data_loader
 
             if loader:
                 dsinfo['loader'] = loader

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -12,6 +12,7 @@ from numpy.random import MT19937, Generator
 
 from westpa.core.data_manager import makepath
 from westpa.core.extloader import get_object
+from westpa.core.logging import DuplicateFilter
 from westpa.core.propagators import WESTPropagator
 from westpa.core.propagators.loaders import (
     data_loaders,
@@ -29,6 +30,7 @@ from westpa.core.segment import Segment
 from westpa.core.yamlcfg import check_bool
 
 log = logging.getLogger(__name__)
+log.addFilter(DuplicateFilter())
 
 # Get a list of user-friendly signal names
 SIGNAL_NAMES = {getattr(signal, name): name for name in dir(signal) if name.startswith('SIG') and not name.startswith('SIG_')}

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -176,8 +176,16 @@ class ExecutablePropagator(WESTPropagator):
             else:
                 match dsname:
                     case 'pcoord' | 'seglog' | 'restart':
-                        # These are proteced dataset names, so set the defaults.
-                        loader = None
+                        # These are proteced dataset names.
+                        if loader_directive:
+                            try:
+                                # trust the user
+                                loader = get_object(loader_directive, path=dspath)
+                            except (AttributeError, ValueError, IndexError, ImportError):
+                                # Failed. Use defaults.
+                                loader = None
+                        else:
+                            loader = None
                     case 'trajectory':
                         # Special dataset for saving trajectory coordinates in HDF5 Framework
                         if loader_directive in trajectory_loaders:

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -12,7 +12,7 @@ from numpy.random import MT19937, Generator
 
 from westpa.core.data_manager import makepath
 from westpa.core.extloader import get_object
-from westpa.core.logging import DuplicateFilter
+from westpa.core.logging import ConsecutiveDuplicateFilter
 from westpa.core.propagators import WESTPropagator
 from westpa.core.propagators.loaders import (
     data_loaders,
@@ -31,7 +31,7 @@ from westpa.core.yamlcfg import check_bool
 
 log = logging.getLogger(__name__)
 if log.root.level >= logging.WARNING:
-    log.addFilter(DuplicateFilter())
+    log.addFilter(ConsecutiveDuplicateFilter())
 
 # Get a list of user-friendly signal names
 SIGNAL_NAMES = {getattr(signal, name): name for name in dir(signal) if name.startswith('SIG') and not name.startswith('SIG_')}

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -176,14 +176,16 @@ class ExecutablePropagator(WESTPropagator):
             else:
                 match dsname:
                     case 'pcoord' | 'seglog' | 'restart':
-                        # These are proteced dataset names, so set them directly.
-                        loader = loader_directive
+                        # These are proteced dataset names, so set the defaults.
+                        loader = None
                     case 'trajectory':
                         # Special dataset for saving trajectory coordinates in HDF5 Framework
                         if loader_directive in trajectory_loaders:
                             loader = trajectory_loaders[loader_directive]
-                        else:
+                        elif isinstance(loader_directive, str):
                             loader = get_object(loader_directive, path=dspath)
+                        else:
+                            loader = mdtraj_trajectory_loader
                     case _:
                         # All other dataset names
                         if loader_directive in data_loaders:

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -177,15 +177,16 @@ class ExecutablePropagator(WESTPropagator):
                 match dsname:
                     case 'pcoord' | 'seglog' | 'restart':
                         # These are proteced dataset names.
-                        if loader_directive:
-                            try:
-                                # trust the user
-                                loader = get_object(loader_directive, path=dspath)
-                            except (AttributeError, ValueError, IndexError, ImportError):
-                                # Failed. Use defaults.
-                                loader = None
-                        else:
-                            loader = None
+                        try:
+                            # trust the user
+                            loader = get_object(loader_directive, path=dspath)
+                        except (AttributeError, ValueError, IndexError, ImportError):
+                            # Failed. Using defaults.
+                            loader = self.data_info[dsname]['loader']
+                            if loader_directive:
+                                log.warning(
+                                    f'Unable to use specified loader `{loader_directive}` for dataset `{dsname}`. Revering to default `{loader.__name__}`.'
+                                )
                     case 'trajectory':
                         # Special dataset for saving trajectory coordinates in HDF5 Framework
                         if loader_directive in trajectory_loaders:
@@ -194,6 +195,7 @@ class ExecutablePropagator(WESTPropagator):
                             loader = get_object(loader_directive, path=dspath)
                         else:
                             loader = mdtraj_trajectory_loader
+                            log.debug(f'Using default `{loader.__name__}` for dataset `{dsname}`')
                     case _:
                         # All other dataset names
                         if loader_directive in data_loaders:
@@ -203,6 +205,7 @@ class ExecutablePropagator(WESTPropagator):
                         else:
                             # Assumed aux dataset, defaulting to aux_data_loader
                             loader = aux_data_loader
+                            log.debug(f'Using default `{loader.__name__}` for dataset `{dsname}`')
 
             if loader:
                 dsinfo['loader'] = loader

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,7 +219,7 @@ def ref_executable(request, tmp_path):
 
     # Create a "temp" file
     with open(CFG_FILENAME, 'r') as f, open('west_implicit.cfg', 'w') as g:
-        for line in f.readlines()[:24]:
+        for line in f.readlines()[:25]:
             g.write(line)
 
     request.cls.cfg_filepath = CFG_FILENAME

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,7 +219,7 @@ def ref_executable(request, tmp_path):
 
     # Create a "temp" file
     with open(CFG_FILENAME, 'r') as f, open('west_implicit.cfg', 'w') as g:
-        for line in f.readlines()[:22]:
+        for line in f.readlines()[:24]:
             g.write(line)
 
     request.cls.cfg_filepath = CFG_FILENAME

--- a/tests/refs/west_executable.cfg
+++ b/tests/refs/west_executable.cfg
@@ -11,6 +11,7 @@ west:
         enabled: false
       - name: pcoord                  
         scaleoffset: 4
+        loader: blah                  # This should be correctly ignored
       - name: trajectory
         loader: mdanalysis_trajectory_loader
     data_refs:

--- a/tests/refs/west_executable.cfg
+++ b/tests/refs/west_executable.cfg
@@ -11,6 +11,8 @@ west:
         enabled: false
       - name: pcoord                  
         scaleoffset: 4
+      - name: trajectory
+        loader: mdanalysis_trajectory_loader
     data_refs:
       segment:       $WEST_SIM_ROOT/traj_segs/{segment.n_iter:06d}/{segment.seg_id:06d}
       basis_state:   $WEST_SIM_ROOT/bstates/{basis_state.auxref}

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -18,7 +18,7 @@ from westpa.core.propagators.loaders import (
     seglog_writer,
     pcoord_loader,
     mdanalysis_trajectory_loader,
-    mdtraj_trajectory_loader
+    mdtraj_trajectory_loader,
 )
 from westpa.core.segment import Segment
 
@@ -33,10 +33,11 @@ class Test_Executable:
         westpa.rc.read_config(filename='west_implicit.cfg')
         executable = ExecutablePropagator(rc=westpa.rc)
 
-        check = {'pcoord': pcoord_loader,
-                 'displacement': numpy_data_loader,
-                 'trajectory' : mdanalysis_trajectory_loader,
-                }
+        check = {
+            'pcoord': pcoord_loader,
+            'displacement': numpy_data_loader,
+            'trajectory': mdanalysis_trajectory_loader,
+        }
 
         for dsname, loader in check.items():
             assert dsname in executable.data_info
@@ -49,10 +50,11 @@ class Test_Executable:
         westpa.rc.read_config(filename='west.cfg')
         executable = ExecutablePropagator(rc=westpa.rc)
 
-        check = {'pcoord': pcoord_loader,
-                 'displacement': aux_data_loader,
-                 'trajectory' : mdtraj_trajectory_loader,
-                }
+        check = {
+            'pcoord': pcoord_loader,
+            'displacement': aux_data_loader,
+            'trajectory': mdtraj_trajectory_loader,
+        }
 
         for dsname, loader in check.items():
             assert dsname in executable.data_info

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -35,7 +35,7 @@ class Test_Executable:
         with caplog.at_level(logging.WARNING):
             executable = ExecutablePropagator(rc=westpa.rc)
 
-        assert 'WARNING  westpa.core.propagators.executable:executable.py:187' in caplog.text
+        assert 'Unable to use specified loader' in caplog.text
 
         check = {
             'pcoord': pcoord_loader,

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -17,6 +17,8 @@ from westpa.core.propagators.loaders import (
     seglog_loader,
     seglog_writer,
     pcoord_loader,
+    mdanalysis_trajectory_loader,
+    mdtraj_trajectory_loader
 )
 from westpa.core.segment import Segment
 
@@ -31,8 +33,14 @@ class Test_Executable:
         westpa.rc.read_config(filename='west_implicit.cfg')
         executable = ExecutablePropagator(rc=westpa.rc)
 
-        assert 'displacement' in executable.data_info
-        assert executable.data_info['displacement']['loader'] == numpy_data_loader
+        check = {'pcoord': pcoord_loader,
+                 'displacement': numpy_data_loader,
+                 'trajectory' : mdanalysis_trajectory_loader,
+                }
+
+        for dsname, loader in check.items():
+            assert dsname in executable.data_info
+            assert executable.data_info[dsname]['loader'] == loader
 
     def test_legacy_data_config(self, ref_executable):
         """Test if the dataset config is initialized correctly using the legacy part, where propagator datasets have to be specified twice."""
@@ -41,8 +49,14 @@ class Test_Executable:
         westpa.rc.read_config(filename='west.cfg')
         executable = ExecutablePropagator(rc=westpa.rc)
 
-        assert 'displacement' in executable.data_info
-        assert executable.data_info['displacement']['loader'] == aux_data_loader
+        check = {'pcoord': pcoord_loader,
+                 'displacement': aux_data_loader,
+                 'trajectory' : mdtraj_trajectory_loader,
+                }
+
+        for dsname, loader in check.items():
+            assert dsname in executable.data_info
+            assert executable.data_info[dsname]['loader'] == loader
 
 
 class Test_Loaders:

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,4 +1,3 @@
-import logging
 import pytest
 from filecmp import cmpfiles
 from io import StringIO
@@ -32,10 +31,7 @@ class Test_Executable:
 
         # Make the rc and executable read the config file.
         westpa.rc.read_config(filename='west_implicit.cfg')
-        with caplog.at_level(logging.WARNING):
-            executable = ExecutablePropagator(rc=westpa.rc)
-
-        assert 'Unable to use specified loader' in caplog.text
+        executable = ExecutablePropagator(rc=westpa.rc)
 
         check = {
             'pcoord': pcoord_loader,

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from filecmp import cmpfiles
 from io import StringIO
@@ -31,7 +32,10 @@ class Test_Executable:
 
         # Make the rc and executable read the config file.
         westpa.rc.read_config(filename='west_implicit.cfg')
-        executable = ExecutablePropagator(rc=westpa.rc)
+        with caplog.at_level(logging.INFO, logger="westpa.core.propagators.executable"):
+            executable = ExecutablePropagator(rc=westpa.rc)
+
+            assert "Unable to use specified loader" in caplog.text
 
         check = {
             'pcoord': pcoord_loader,

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,4 +1,3 @@
-import logging
 import pytest
 from filecmp import cmpfiles
 from io import StringIO
@@ -27,15 +26,13 @@ from westpa.core.segment import Segment
 class Test_Executable:
     """Class to test the propagator executable."""
 
-    def test_data_config(self, ref_executable, caplog):
+    def test_data_config(self, ref_executable):
         """Test if the config is initialized correctly, where the executable propagator dataset options are set with the data manager options."""
 
         # Make the rc and executable read the config file.
         westpa.rc.read_config(filename='west_implicit.cfg')
-        with caplog.at_level(logging.INFO, logger="westpa.core.propagators.executable"):
-            executable = ExecutablePropagator(rc=westpa.rc)
 
-            assert "Unable to use specified loader" in caplog.text
+        executable = ExecutablePropagator(rc=westpa.rc)
 
         check = {
             'pcoord': pcoord_loader,

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from filecmp import cmpfiles
 from io import StringIO
@@ -26,12 +27,15 @@ from westpa.core.segment import Segment
 class Test_Executable:
     """Class to test the propagator executable."""
 
-    def test_data_config(self, ref_executable):
+    def test_data_config(self, ref_executable, caplog):
         """Test if the config is initialized correctly, where the executable propagator dataset options are set with the data manager options."""
 
         # Make the rc and executable read the config file.
         westpa.rc.read_config(filename='west_implicit.cfg')
-        executable = ExecutablePropagator(rc=westpa.rc)
+        with caplog.at_level(logging.WARNING):
+            executable = ExecutablePropagator(rc=westpa.rc)
+
+        assert 'WARNING  westpa.core.propagators.executable:executable.py:187' in caplog.text
 
         check = {
             'pcoord': pcoord_loader,
@@ -48,6 +52,7 @@ class Test_Executable:
 
         # Make the rc and executable read the config file.
         westpa.rc.read_config(filename='west.cfg')
+
         executable = ExecutablePropagator(rc=westpa.rc)
 
         check = {


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
#484 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Rewrote the config parsing sections because #484 has introduced a bug where the loader for 'pcoord' is mistakenly set to aux_data_loader.


To test, initialize a simulation with `--debug` and look at the `data_info` log.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Fix propagator executable so loaders are selected correctly

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/propagators/executable.py
- [x] tests/

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


