### PR TITLE
Remove pytest filter warning + test.yaml deprecated key "auto_activate_base" removal

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,6 @@ jobs:
           miniforge-version: latest
           channel-priority: true
           auto-update-conda: true
-          auto-activate-base: false
           show-channel-urls: true
           conda-remove-defaults: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,9 +108,3 @@ parentdir_prefix = "westpa-"
 [tool.pytest]
 testpaths = ['tests']
 addopts = ['-v', '-ra']
-filterwarnings = [
-    # The following is to filter warnings from unpickling `west_ref.h5`'s binmapper pickles. Numpy changed their internals
-    # so it'll throw a DeprecationWarning (load 1.X pickle in 2.X) or throw a ModuleNotFoundError (load 2.X pickle in 1.X).
-    # Once we drop support for numpy 1.X, remake the binmapper pickles in numpy 2.0 and remove this filter.
-    'ignore:numpy\.core\.numeric is deprecated and has been renamed to numpy\.\_core\.numeric:DeprecationWarning',
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,9 +106,11 @@ tag_prefix = "v"
 parentdir_prefix = "westpa-"
 
 [tool.pytest]
+testpaths = ['tests']
+addopts = ['-v', '-ra']
 filterwarnings = [
     # The following is to filter warnings from unpickling `west_ref.h5`'s binmapper pickles. Numpy changed their internals
     # so it'll throw a DeprecationWarning (load 1.X pickle in 2.X) or throw a ModuleNotFoundError (load 2.X pickle in 1.X).
     # Once we drop support for numpy 1.X, remake the binmapper pickles in numpy 2.0 and remove this filter.
-    'ignore:numpy.core.numeric is deprecated and has been renamed to numpy._core.numeric.:DeprecationWarning',
+    'ignore:numpy\.core\.numeric is deprecated and has been renamed to numpy\.\_core\.numeric:DeprecationWarning',
 ]


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
After countless tests, it's impossible to remove those DeprecationWarnings from numpy (I assume the fault is on numpy or pytest).

https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html#deprecationwarning-and-pendingdeprecationwarning

Dropping it completely

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] removing the deprecationwarning filter from pyproject.toml
- [x] drop the auto_activate_base deprecated key from test.yaml

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] pyproject.toml
- [x] .github/workflows/test.yaml

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


