### PR TITLE
Revert work_manager.running check

### DIFF
--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -43,7 +43,7 @@ class BinlessSimManager(WESimManager):
             futures.add(future)
             segment_futures.add(future)
 
-        while futures and self.work_manager.running:
+        while futures:
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 

--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -44,6 +44,7 @@ class BinlessSimManager(WESimManager):
             segment_futures.add(future)
 
         while futures:
+            # TODO: add capacity to timeout or SIGINT here
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -46,7 +46,7 @@ class MABSimManager(WESimManager):
             futures.add(future)
             segment_futures.add(future)
 
-        while futures and self.work_manager.running:
+        while futures:
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -47,6 +47,7 @@ class MABSimManager(WESimManager):
             segment_futures.add(future)
 
         while futures:
+            # TODO: add capacity to timeout or SIGINT here
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -607,6 +607,7 @@ class WESimManager:
             segment_futures.add(future)
 
         while futures:
+            # TODO: add capacity to timeout or SIGINT here
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -606,7 +606,7 @@ class WESimManager:
             futures.add(future)
             segment_futures.add(future)
 
-        while futures and self.work_manager.running:
+        while futures:
             future = self.work_manager.wait_any(futures)
             futures.remove(future)
 

--- a/tests/test_sim_manager.py
+++ b/tests/test_sim_manager.py
@@ -9,6 +9,8 @@ import numpy as np
 
 import westpa
 from westpa.core.binning.assign import RectilinearBinMapper
+from westpa.core.binning.binless_manager import BinlessSimManager
+from westpa.core.binning.mab_manager import MABSimManager
 from westpa.core.segment import Segment
 from westpa.core.states import BasisState
 from westpa.core.sim_manager import PropagationError
@@ -208,7 +210,7 @@ class TestMABSimManager(TestSimManager):
         config_file_name = os.path.join(here, 'refs', 'odld', 'west_mab.cfg')
         args = parser.parse_args(['-r={}'.format(config_file_name)])
         westpa.rc.process_args(args)
-        self.sim_manager = westpa.rc.get_sim_manager()
+        self.sim_manager = MABSimManager()
         self.test_dir = tempfile.mkdtemp()
         self.hdf5 = os.path.join(self.test_dir, "west.h5")
         self.basis_states = [BasisState(label="label", probability=1.0)]
@@ -253,7 +255,7 @@ class TestBinlessSimManager(TestSimManager):
         config_file_name = os.path.join(here, 'refs', 'odld', 'west_binless.cfg')
         args = parser.parse_args(['-r={}'.format(config_file_name)])
         westpa.rc.process_args(args)
-        self.sim_manager = westpa.rc.get_sim_manager()
+        self.sim_manager = BinlessSimManager()
         self.test_dir = tempfile.mkdtemp()
         self.hdf5 = os.path.join(self.test_dir, "west.h5")
         self.basis_states = [BasisState(label="label", probability=1.0)]


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
https://github.com/westpa/westpa/pull/537

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
The new `work_manager.running` check in sim manager is causing the simulation to prematurely end when using the zmq work manager. Reverting it for the time being.

The first batch of segments will complete, but it would shutdown throwing PropagationError.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Make sure work manager works.

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] all sim_managers

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


