### PR TITLE
Fix cibuildwheel for macOS/Python 3.14

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install HDF5 with brew
-        if: ${{ matrix.os == "macos-latest" || matrix.os == "macos-15-intel" }}
+        if: ${{ matrix.os == "macos-latest" }} || ${{ matrix.os == "macos-15-intel" }}
         run: "brew install hdf5"
 
       - name: Build wheels

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install HDF5 with brew
-        if: ${{ matrix.os == "macos-latest" or matrix.os == "macos-15-intel" }}
+        if: ${{ matrix.os == "macos-latest" || matrix.os == "macos-15-intel" }}
         run: "brew install hdf5"
 
       - name: Build wheels
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build wheels (Python 3.14)
         uses: pypa/cibuildwheel@v3.3.1
-        if: ${{ matrix.python-version == '14' and matrix.os == "macos-latest" }}
+        if: ${{ (matrix.python-version == '14') && (matrix.os != "macos-15-intel") }}
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build wheels (Python 3.14-macos-intel)
         uses: pypa/cibuildwheel@v3.3.1
-        if: ${{ matrix.python-version == '14' and matrix.os == "macos-15-intel" }}
+        if: ${{ (matrix.python-version == '14') && (matrix.os == "macos-15-intel") }}
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build wheels (Python 3.14)
         uses: pypa/cibuildwheel@v3.3.1
-        if: ${{ (matrix.python-version == '14') && (matrix.os != "macos-15-intel") }}
+        if: ${{ matrix.python-version == '14' }} && ${{ matrix.os != "macos-15-intel" }}
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build wheels (Python 3.14-macos-intel)
         uses: pypa/cibuildwheel@v3.3.1
-        if: ${{ (matrix.python-version == '14') && (matrix.os == "macos-15-intel") }}
+        if: ${{ matrix.python-version == '14' }} && ${{ matrix.os == "macos-15-intel" }}
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,9 +77,7 @@ jobs:
           CIBW_BEFORE_TEST_LINUX: >
             dnf install -y hdf5 hdf5-devel &&
             python -m pip install git+https://github.com/pytables/pytables
-          CIBW_BEFORE_TEST_MACOS: >
-            brew reinstall hdf5 &&
-            python -m pip install git+https://github.com/pytables/pytables
+          CIBW_BEFORE_TEST_MACOS: "python -m pip install git+https://github.com/pytables/pytables"
           CIBW_TEST_COMMAND: > 
             python -c "import tables" &&
             python -c "import westpa; print(westpa.__version__)" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]  # macos-latest is arm64
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]  # macos-latest is arm64
         python-version: [10, 11, 12, 13, 14] # sub-versions of Python
         exclude:
-          - os: macos-15-intel
-            python-version: [10, 11, 12, 13]
+          - os: macos-15-intel  # Building the macOS x86_64 Python 3.14 wheel separately
+            python-version: 14
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,12 +36,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install HDF5 with brew
-        if: matrix.os == "macos-latest" || matrix.os == "macos-15-intel"
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel'
         run: "brew install hdf5"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
-        if: matrix.python-version != "14"
+        if: matrix.python-version != '14'
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build wheels (Python 3.14)
         uses: pypa/cibuildwheel@v3.3.1
-        if: matrix.python-version == "14" && matrix.os != "macos-15-intel" 
+        if: matrix.python-version == '14' && matrix.os != 'macos-15-intel' 
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build wheels (Python 3.14/macos-15-intel)
         uses: pypa/cibuildwheel@v3.3.1
-        if: matrix.python-version == "14" && matrix.os == "macos-15-intel"
+        if: matrix.python-version == '14' && matrix.os == 'macos-15-intel'
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]  # macos-latest is arm64
         python-version: [10, 11, 12, 13, 14] # sub-versions of Python
-        exclude:
+        include:
           - os: macos-15-intel  # Building the macOS x86_64 Python 3.14 wheel separately
             python-version: 14
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,9 @@ jobs:
           CIBW_BEFORE_TEST_LINUX: >
             dnf install -y hdf5 hdf5-devel &&
             python -m pip install git+https://github.com/pytables/pytables
-          CIBW_BEFORE_TEST_MACOS: "python -m pip install git+https://github.com/pytables/pytables"
+          CIBW_BEFORE_TEST_MACOS: >
+            brew install hdf5 &&
+            python -m pip install git+https://github.com/pytables/pytables
           CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" && 
             python -c "import westpa.core.propagators" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,6 @@ jobs:
           CIBW_BEFORE_TEST_MACOS: >
             python -m pip install git+https://github.com/pytables/pytables
           CIBW_TEST_COMMAND: > 
-            python -c "import tables" &&
             python -c "import westpa; print(westpa.__version__)" &&
             python -c "import westpa.core.propagators" &&
             python -c "import westpa.core.binning" &&
@@ -113,7 +112,6 @@ jobs:
           CIBW_BEFORE_TEST_MACOS: >
             python -m pip install git+https://github.com/pytables/pytables
           CIBW_TEST_COMMAND: > 
-            python -c "import tables" &&
             python -c "import westpa; print(westpa.__version__)" &&
             python -c "import westpa.core.propagators" &&
             python -c "import westpa.core.binning" &&
@@ -130,7 +128,6 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
           config-file: "{package}/pyproject.toml"
-
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,13 +27,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest"]  # macos-latest is arm64
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]  # macos-latest is arm64
         python-version: [10, 11, 12, 13, 14] # sub-versions of Python
+        exclude:
+          - os: macos-15-intel
+            python-version: [10, 11, 12, 13]
     steps:
       - uses: actions/checkout@v6
 
       - name: Install HDF5 with brew
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == "macos-latest" or matrix.os == "macos-15-intel" }}
         run: "brew install hdf5"
 
       - name: Build wheels
@@ -42,7 +45,7 @@ jobs:
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
-          CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
+          CIBW_ARCHS_MACOS: "arm64" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_TEST_COMMAND: >
@@ -65,11 +68,11 @@ jobs:
 
       - name: Build wheels (Python 3.14)
         uses: pypa/cibuildwheel@v3.3.1
-        if: ${{ matrix.python-version == '14' }}
+        if: ${{ matrix.python-version == '14' and matrix.os == "macos-latest" }}
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
-          CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
+          CIBW_ARCHS_MACOS: "arm64" # python 3.14 wheels are separate for now
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_TEST_REQUIRES_LINUX: "blosc2"
@@ -78,9 +81,7 @@ jobs:
             dnf install -y hdf5 hdf5-devel &&
             python -m pip install git+https://github.com/pytables/pytables
           CIBW_BEFORE_TEST_MACOS: >
-            arch -arm64 /bin/sh -c "brew install hdf5" &&
-            python -m pip install git+https://github.com/pytables/pytables &&
-            arch -arm64 /bin/sh -c "brew uninstall hdf5"
+            python -m pip install git+https://github.com/pytables/pytables
           CIBW_TEST_COMMAND: > 
             python -c "import tables" &&
             python -c "import westpa; print(westpa.__version__)" &&
@@ -99,6 +100,37 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
           config-file: "{package}/pyproject.toml"
+
+      - name: Build wheels (Python 3.14-macos-intel)
+        uses: pypa/cibuildwheel@v3.3.1
+        if: ${{ matrix.python-version == '14' and matrix.os == "macos-15-intel" }}
+        env:
+          CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
+          CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
+          CIBW_ARCHS_MACOS: "x86_64" # python 3.14 wheels are separate for now
+          CIBW_DEPENDENCY_VERSIONS: "pinned" # default
+          # Installing pytables from source due to python 3.14 support
+          CIBW_BEFORE_TEST_MACOS: >
+            python -m pip install git+https://github.com/pytables/pytables
+          CIBW_TEST_COMMAND: > 
+            python -c "import tables" &&
+            python -c "import westpa; print(westpa.__version__)" &&
+            python -c "import westpa.core.propagators" &&
+            python -c "import westpa.core.binning" &&
+            python -c "import westpa.core.kinetics" &&
+            python -c "import westpa.core.reweight" &&
+            python -c "import westpa.work_managers" &&
+            python -c "import westpa.tools" &&
+            python -c "import westpa.fasthist" &&
+            python -c "import westpa.mclib" &&
+            echo "All done with the import tests!"
+            # Currently blocked by https://github.com/westpa/westpa/issues/70
+            #python -c "import westpa.trajtree"
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+          config-file: "{package}/pyproject.toml"
+
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,12 +36,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install HDF5 with brew
-        if: ${{ matrix.os == "macos-latest" }} || ${{ matrix.os == "macos-15-intel" }}
+        if: matrix.os == "macos-latest" || matrix.os == "macos-15-intel"
         run: "brew install hdf5"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
-        if: ${{ matrix.python-version != '14' }}
+        if: matrix.python-version != "14"
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build wheels (Python 3.14)
         uses: pypa/cibuildwheel@v3.3.1
-        if: ${{ matrix.python-version == '14' }} && ${{ matrix.os != "macos-15-intel" }}
+        if: matrix.python-version == "14" && matrix.os != "macos-15-intel" 
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
@@ -101,9 +101,9 @@ jobs:
           output-dir: wheelhouse
           config-file: "{package}/pyproject.toml"
 
-      - name: Build wheels (Python 3.14-macos-intel)
+      - name: Build wheels (Python 3.14/macos-15-intel)
         uses: pypa/cibuildwheel@v3.3.1
-        if: ${{ matrix.python-version == '14' }} && ${{ matrix.os == "macos-15-intel" }}
+        if: matrix.python-version == "14" && matrix.os == "macos-15-intel"
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,10 +78,11 @@ jobs:
             dnf install -y hdf5 hdf5-devel &&
             python -m pip install git+https://github.com/pytables/pytables
           CIBW_BEFORE_TEST_MACOS: >
-            brew install hdf5 &&
+            brew reinstall hdf5 &&
             python -m pip install git+https://github.com/pytables/pytables
           CIBW_TEST_COMMAND: > 
-            python -c "import westpa; print(westpa.__version__)" && 
+            python -c "import tables" &&
+            python -c "import westpa; print(westpa.__version__)" &&
             python -c "import westpa.core.propagators" &&
             python -c "import westpa.core.binning" &&
             python -c "import westpa.core.kinetics" &&

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
-          CIBW_ARCHS_MACOS: "arm64" # universal2 wheel for macos
+          CIBW_ARCHS_MACOS: "universal2" # universal2 wheel for macos
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_TEST_COMMAND: >

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,10 @@ jobs:
           CIBW_BEFORE_TEST_LINUX: >
             dnf install -y hdf5 hdf5-devel &&
             python -m pip install git+https://github.com/pytables/pytables
-          CIBW_BEFORE_TEST_MACOS: "python -m pip install git+https://github.com/pytables/pytables"
+          CIBW_BEFORE_TEST_MACOS: >
+            arch -arm64 /bin/sh -c "brew install hdf5" &&
+            python -m pip install git+https://github.com/pytables/pytables &&
+            arch -arm64 /bin/sh -c "brew uninstall hdf5"
           CIBW_TEST_COMMAND: > 
             python -c "import tables" &&
             python -c "import westpa; print(westpa.__version__)" &&


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Brew (the macOS package manager) recently updated their hdf5 bottle to 2.0.0 and that is seemingly broke the macOS Python 3.14 wheel testing.

```
    File "/private/var/folders/yz/zr09txvs5dn18vt4cn21kzl40000gn/T/cibw-run-tklpmp64/cp314-macosx_universal2/venv-test-x86_64/lib/python3.14/site-packages/tables/file.py", line 27, in <module>
      from . import (
      ...<6 lines>...
      )
  ImportError: dlopen(/private/var/folders/yz/zr09txvs5dn18vt4cn21kzl40000gn/T/cibw-run-tklpmp64/cp314-macosx_universal2/venv-test-x86_64/lib/python3.14/site-packages/tables/hdf5extension.abi3.so, 0x0002): symbol not found in flat namespace '_H5Dread_chunk1'
```
It's seemingly related to how a arm64 install of hdf5 doesn't work during testing in a x86_64 `venv`. This PR basically separates out the wheels for arm64 and x86_64 for the macOS/Python 3.14 config.

https://github.com/jeremyleung521/westpa/actions/runs/21606536930

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Fix cibuildwheel for macOS/Python 3.14

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] .github/workflows/build.yaml

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


