### PR TITLE
Simplify py3.14 wheel building workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
-        if: matrix.python-version != '14'
+        if: matrix.python-version != '14' && matrix.os != 'macos-15-intel'
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
@@ -49,40 +49,6 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_TEST_COMMAND: >
-            python -c "import westpa; print(westpa.__version__)" &&
-            python -c "import westpa.core.propagators" &&
-            python -c "import westpa.core.binning" &&
-            python -c "import westpa.core.kinetics" &&
-            python -c "import westpa.core.reweight" &&
-            python -c "import westpa.work_managers" &&
-            python -c "import westpa.tools" &&
-            python -c "import westpa.fasthist" &&
-            python -c "import westpa.mclib" &&
-            echo "All done with the import tests!"
-            # Currently blocked by https://github.com/westpa/westpa/issues/70
-            #python -c "import westpa.trajtree"
-        with:
-          package-dir: .
-          output-dir: wheelhouse
-          config-file: "{package}/pyproject.toml"
-
-      - name: Build wheels (Python 3.14)
-        uses: pypa/cibuildwheel@v3.3.1
-        if: matrix.python-version == '14' && matrix.os != 'macos-15-intel' 
-        env:
-          CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
-          CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
-          CIBW_ARCHS_MACOS: "arm64" # python 3.14 wheels are separate for now
-          CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
-          CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          CIBW_TEST_REQUIRES_LINUX: "blosc2"
-          # Installing pytables from source due to python 3.14 support
-          CIBW_BEFORE_TEST_LINUX: >
-            dnf install -y hdf5 hdf5-devel &&
-            python -m pip install git+https://github.com/pytables/pytables
-          CIBW_BEFORE_TEST_MACOS: >
-            python -m pip install git+https://github.com/pytables/pytables
-          CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" &&
             python -c "import westpa.core.propagators" &&
             python -c "import westpa.core.binning" &&
@@ -143,7 +109,7 @@ jobs:
       
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,9 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]  # macos-latest is arm64
         python-version: [10, 11, 12, 13, 14] # sub-versions of Python
-        include:
-          - os: macos-15-intel  # Building the macOS x86_64 Python 3.14 wheel separately
-            python-version: 14
+    
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.1
-        if: matrix.python-version != '14' && matrix.os != 'macos-15-intel'
         env:
           CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
@@ -49,35 +48,6 @@ jobs:
           CIBW_ARCHS_LINUX: "auto64" # x86_64 and arm64, depending on the os
           CIBW_DEPENDENCY_VERSIONS: "pinned" # default
           CIBW_TEST_COMMAND: >
-            python -c "import westpa; print(westpa.__version__)" &&
-            python -c "import westpa.core.propagators" &&
-            python -c "import westpa.core.binning" &&
-            python -c "import westpa.core.kinetics" &&
-            python -c "import westpa.core.reweight" &&
-            python -c "import westpa.work_managers" &&
-            python -c "import westpa.tools" &&
-            python -c "import westpa.fasthist" &&
-            python -c "import westpa.mclib" &&
-            echo "All done with the import tests!"
-            # Currently blocked by https://github.com/westpa/westpa/issues/70
-            #python -c "import westpa.trajtree"
-        with:
-          package-dir: .
-          output-dir: wheelhouse
-          config-file: "{package}/pyproject.toml"
-
-      - name: Build wheels (Python 3.14/macos-15-intel)
-        uses: pypa/cibuildwheel@v3.3.1
-        if: matrix.python-version == '14' && matrix.os == 'macos-15-intel'
-        env:
-          CIBW_SKIP: "pp* *-musllinux* cp31?t-*"
-          CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
-          CIBW_ARCHS_MACOS: "x86_64" # python 3.14 wheels are separate for now
-          CIBW_DEPENDENCY_VERSIONS: "pinned" # default
-          # Installing pytables from source due to python 3.14 support
-          CIBW_BEFORE_TEST_MACOS: >
-            python -m pip install git+https://github.com/pytables/pytables
-          CIBW_TEST_COMMAND: > 
             python -c "import westpa; print(westpa.__version__)" &&
             python -c "import westpa.core.propagators" &&
             python -c "import westpa.core.binning" &&

--- a/tests/test_work_managers/test_processes.py
+++ b/tests/test_work_managers/test_processes.py
@@ -18,7 +18,7 @@ class TestProcessWorkManager(unittest.TestCase, CommonParallelTests, CommonWorkM
 
 
 class TestProcessWorkManagerAux:
-    @pytest.mark.timeout(5)
+    @pytest.mark.timeout(10)
     def test_shutdown(self):
         work_manager = ProcessWorkManager()
         work_manager.startup()
@@ -29,7 +29,7 @@ class TestProcessWorkManagerAux:
             except ValueError:
                 pass  # probably closed already
 
-    @pytest.mark.timeout(5)
+    @pytest.mark.timeout(10)
     def test_hang_shutdown(self):
         work_manager = ProcessWorkManager()
         work_manager.shutdown_timeout = 0.1
@@ -43,7 +43,7 @@ class TestProcessWorkManagerAux:
             except ValueError:
                 pass  # probably closed already
 
-    @pytest.mark.timeout(5)
+    @pytest.mark.timeout(10)
     def test_hang_shutdown_ignoring_sigint(self):
         work_manager = ProcessWorkManager()
         work_manager.shutdown_timeout = 0.1
@@ -57,7 +57,7 @@ class TestProcessWorkManagerAux:
             except ValueError:
                 pass  # probably closed already
 
-    @pytest.mark.timeout(5)
+    @pytest.mark.timeout(10)
     def test_sigint_shutdown(self):
         work_manager = ProcessWorkManager()
         work_manager.install_sigint_handler()
@@ -77,7 +77,7 @@ class TestProcessWorkManagerAux:
                         pass  # probably closed already
                 raise
 
-    @pytest.mark.timeout(5)
+    @pytest.mark.timeout(10)
     def test_worker_close_fail(self, monkeypatch):
         work_manager = ProcessWorkManager()
         work_manager.install_sigint_handler()
@@ -96,7 +96,7 @@ class TestProcessWorkManagerAux:
         # Clean up
         work_manager.shutdown()
 
-    @pytest.mark.timeout(5)
+    @pytest.mark.timeout(10)
     def test_worker_ids(self):
         work_manager = ProcessWorkManager()
         with work_manager:


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
Reverts/simplify work around from #555 #546

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Now that Pytables 3.11.0 (with wheels for python 3.14) is finally released, we don't have to use our workaround for Python 3.14/macOS wheel building.

https://github.com/jeremyleung521/westpa/actions/runs/22416392701

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] simplify wheel-building matrix 

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] .github/workflows/build.yaml

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have read the AI POLICY document.
- [x] This PR conforms to WESTPA's AI policy.
- [x] I have declared all usage of AI in the PR description.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


