### PR TITLE
Initialize RNG a little later in the propagator

### DIFF
--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -221,6 +221,8 @@ class ExecutablePropagator(WESTPropagator):
         as a dictionary, suitable for use in ``os.environ.update()`` or as the ``env`` argument to
         ``subprocess.Popen()``. Every child process executed by ``exec_child()`` gets these.'''
 
+        # Initialize rng here when we need our first number. This will prevent
+        # certain work managers (e.g., `processes`) from reusing an initialized RNG.
         if self.rng is None:
             self.rng = Generator(MT19937())
 

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -100,8 +100,8 @@ class ExecutablePropagator(WESTPropagator):
         self.initial_state_ref_template = config['west', 'data', 'data_refs', 'initial_state']
         store_h5 = config.get(['west', 'data', 'data_refs', 'iteration']) is not None
 
-        # Create a persistent RNG for each worker
-        self.rng = Generator(MT19937())
+        # Create a persistent variable for RNG, to be initialized later when we need our first random number
+        self.rng = None
 
         # Load additional environment variables for all child processes
         self.addtl_child_environ.update({k: str(v) for k, v in (config['west', 'executable', 'environ'] or {}).items()})
@@ -220,6 +220,9 @@ class ExecutablePropagator(WESTPropagator):
         '''Return a set of environment variables containing random seeds. These are returned
         as a dictionary, suitable for use in ``os.environ.update()`` or as the ``env`` argument to
         ``subprocess.Popen()``. Every child process executed by ``exec_child()`` gets these.'''
+
+        if self.rng is None:
+            self.rng = Generator(MT19937())
 
         return {
             self.ENV_RAND16: str(self.rng.integers(2**16, dtype=np.uint16)),

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -221,8 +221,8 @@ class ExecutablePropagator(WESTPropagator):
         as a dictionary, suitable for use in ``os.environ.update()`` or as the ``env`` argument to
         ``subprocess.Popen()``. Every child process executed by ``exec_child()`` gets these.'''
 
-        # Initialize rng here when we need our first number. This will prevent
-        # certain work managers (e.g., `processes`) from reusing an initialized RNG.
+        # Initialize rng here when we need our first number. This will prevent certain work managers
+        # (e.g., `processes`) from reusing an RNG that might be initialized too early (i.e. before forking).
         if self.rng is None:
             self.rng = Generator(MT19937())
 

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,4 +1,5 @@
 import pytest
+from copy import copy
 from filecmp import cmpfiles
 from io import StringIO
 
@@ -61,6 +62,24 @@ class Test_Executable:
         for dsname, loader in check.items():
             assert dsname in executable.data_info
             assert executable.data_info[dsname]['loader'] == loader
+
+    def test_rng(self, ref_executable):
+        """Test if the RNG is initialized properly at first call of random numbers."""
+
+        westpa.rc.read_config(filename='west.cfg')
+        executable = ExecutablePropagator(rc=westpa.rc)
+
+        assert executable.rng is None  # RNG should not be initialized
+        cp_executable = copy(executable)  # Mock copying via os.fork()
+
+        # Create the RNGs
+        executable.random_val_env_vars()
+        cp_executable.random_val_env_vars()
+
+        # Assert
+        assert executable.rng is not None
+        assert cp_executable.rng is not None
+        assert executable.rng != cp_executable.rng
 
 
 class Test_Loaders:


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
#460 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
An initialized RNG might be copied verbatim within the PropagatorExecutable if using the `processes` work manager. This is a result of the `os.fork()` on UNIX.

The bug can be reproduced when running tutorial 7.2 as is. All the trajectories will have the same seed. I can reproduce this starting from 2022.12. Seemingly works fine on 2022.10 (but I'm having trouble with holding all the variables constant--dependency version, python version etc--due to how old it is) so I'm semi-sure it's due to #460.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Fix the RNG problem with certain work managers (`processes`)

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/propagators/executable.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have read the AI POLICY document.
- [x] This PR conforms to WESTPA's AI policy.
- [x] I have declared all usage of AI in the PR description.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


