### PR TITLE
Fix ExternalLink for hdf5 framework which might be wonky when mixing relative + absolute paths

### DIFF
--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -605,7 +605,7 @@ class WESTDataManager:
         west_h5_file = makepath(self.we_h5filename)
         west_h5_file_dir = dirname(west_h5_file)
         iter_ref_h5_file = makepath(self.iter_h5_path_template, {'n_iter': n_iter})
-        iter_ref_rel_path = relpath(iter_ref_h5_file, makepath('$WEST_SIM_ROOT') if west_h5_file_dir == '' else west_h5_file_dir)
+        iter_ref_rel_path = relpath(iter_ref_h5_file, west_h5_file_dir if west_h5_file_dir != '' else makepath('$WEST_SIM_ROOT'))
 
         if self.iter_h5_template_file_path:
             # Make path to per-iter H5 File

--- a/src/westpa/core/data_manager.py
+++ b/src/westpa/core/data_manager.py
@@ -603,8 +603,10 @@ class WESTDataManager:
             return
 
         west_h5_file = makepath(self.we_h5filename)
+        west_h5_file_dir = dirname(west_h5_file)
         iter_ref_h5_file = makepath(self.iter_h5_path_template, {'n_iter': n_iter})
-        iter_ref_rel_path = relpath(iter_ref_h5_file, dirname(west_h5_file))
+        iter_ref_rel_path = relpath(iter_ref_h5_file, makepath('$WEST_SIM_ROOT') if west_h5_file_dir == '' else west_h5_file_dir)
+
         if self.iter_h5_template_file_path:
             # Make path to per-iter H5 File
             iter_h5_template_file_path_expanded = makepath(self.iter_h5_template_file_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,8 +267,9 @@ def traj_setup(request, tmp_path):
 
     with netcdf_file(traj_file_path) as rootgrp:
         request.cls.ref_coords = rootgrp.variables['coordinates'][()].copy() / 10
-        #        request.cls.ref_lengths = rootgrp.variables['cell_lengths'][()]
-        #        request.cls.ref_angles = rootgrp.variables['cell_angles'][()]
+        # Not all simulations have periodic boundaries
+        # request.cls.ref_lengths = rootgrp.variables['cell_lengths'][()]
+        # request.cls.ref_angles = rootgrp.variables['cell_angles'][()]
         request.cls.ref_time = rootgrp.variables['time'][()].copy()
 
 

--- a/tests/test_hdf5_framework.py
+++ b/tests/test_hdf5_framework.py
@@ -1,9 +1,14 @@
+import argparse
+import os
 import sys
 
+import h5py
+import pytest
 from mdtraj import Trajectory
 from numpy.testing import assert_allclose
-import pytest
 
+from westpa.core._rc import WESTRC
+from westpa.core.data_manager import WESTDataManager
 from westpa.core.segment import Segment
 from westpa.core.trajectory import WESTTrajectory, load_mdanalysis, load_mdtraj, load_netcdf
 from westpa.core.propagators.loaders import mdtraj_trajectory_loader, mdanalysis_trajectory_loader, netcdf_trajectory_loader
@@ -76,3 +81,57 @@ class TestHDF5Framework:
 
         assert_allclose(dummy_segment.data['iterh5/trajectory'].xyz, self.ref_coords)
         assert_allclose(dummy_segment.data['iterh5/trajectory'].time, self.ref_time)
+
+    def test_update_iterh5_file(self, ref_initialized, monkeypatch, tmp_path):
+        """
+        Test for checking if update_iter_h5file actually finds the correct relative paths
+        relative to `west.h5` and not your current working directory.
+        The external link previously would to be something like `../abc/iter_000000.h5`
+        instead of `iter_000000.h5`, even if your `west.h5` file is right next to it.
+
+        Conditions necessary for this to happen:
+        a) $WEST_SIM_ROOT is an absolute path.
+        b) $WEST_SIM_ROOT must exist.
+        c) You are working in a location other than $WEST_SIM_ROOT.
+        d) `WESTDataManager.we_h5filename` (usually read from `west.cfg`
+           under `west/data/west_data/file`) either doesn't exist (so the `west.h5`
+           default is used) or is a relative path.
+
+        EXAMPLE TREE
+        |
+        |
+        |---abc  => $WEST_SIM_ROOT
+        |   |--- west.h5
+        |   |--- iter_000000.h5
+        |
+        |---def  => CWD
+
+        """
+        os.makedirs('abc', exist_ok=True)
+        os.makedirs('def', exist_ok=True)
+        os.chdir('abc')
+        rc = WESTRC()
+
+        args = argparse.Namespace(
+            verbosity='debug',
+            rcfile='../' + self.cfg_filepath,
+            we_h5filename=self.h5_filepath,
+        )
+
+        rc.process_args(args)
+        dm = WESTDataManager(rc=rc)
+        dm.iter_h5_path_template = '$WEST_SIM_ROOT/iter_{n_iter:06d}.h5'
+        dm.we_h5filename = 'west.h5'
+        dm.store_h5 = True
+        dm.prepare_backing()
+
+        with monkeypatch.context() as m:
+            m.setenv('WEST_SIM_ROOT', f'{tmp_path}/abc')
+            os.chdir('../def')
+            dm.require_iter_group(0)
+            dm.update_iter_h5file(0, [])
+            assert os.path.exists(f'{tmp_path}/abc/iter_000000.h5')
+            assert not os.path.exists(f'{tmp_path}/def/iter_000000.h5')
+            with h5py.File('../abc/west.h5', 'r') as h5_iterfile:
+                link_path = h5_iterfile.get('iterations/iter_00000000/trajectories', getlink=True).filename
+                assert link_path == 'iter_000000.h5'  # Before v2022.16 it would be '../abc/iter_000000.h5'

--- a/tests/test_hdf5_framework.py
+++ b/tests/test_hdf5_framework.py
@@ -99,26 +99,28 @@ class TestHDF5Framework:
 
         EXAMPLE TREE
         |
-        |
         |---abc  => $WEST_SIM_ROOT
         |   |--- west.h5
         |   |--- iter_000000.h5
         |
-        |---def  => CWD
+        |---def  => $PWD
 
         """
+        # Setup folder structure and move to abc/
         os.makedirs('abc', exist_ok=True)
         os.makedirs('def', exist_ok=True)
         os.chdir('abc')
-        rc = WESTRC()
 
+        # Setup rc
+        rc = WESTRC()
         args = argparse.Namespace(
             verbosity='debug',
             rcfile='../' + self.cfg_filepath,
             we_h5filename=self.h5_filepath,
         )
-
         rc.process_args(args)
+
+        # Setup data manager and create west.h5 file
         dm = WESTDataManager(rc=rc)
         dm.iter_h5_path_template = '$WEST_SIM_ROOT/iter_{n_iter:06d}.h5'
         dm.we_h5filename = 'west.h5'
@@ -126,10 +128,15 @@ class TestHDF5Framework:
         dm.prepare_backing()
 
         with monkeypatch.context() as m:
+            # map $WEST_SIM_ROOT to abc, move to def/
             m.setenv('WEST_SIM_ROOT', f'{tmp_path}/abc')
             os.chdir('../def')
+
+            # Write to iter_000000.h5
             dm.require_iter_group(0)
             dm.update_iter_h5file(0, [])
+
+            # Check files existence (should be in $WEST_SIM_ROOT!) and link location
             assert os.path.exists(f'{tmp_path}/abc/iter_000000.h5')
             assert not os.path.exists(f'{tmp_path}/def/iter_000000.h5')
             with h5py.File('../abc/west.h5', 'r') as h5_iterfile:

--- a/tests/test_hdf5_framework.py
+++ b/tests/test_hdf5_framework.py
@@ -86,7 +86,7 @@ class TestHDF5Framework:
         """
         Test for checking if update_iter_h5file actually finds the correct relative paths
         relative to `west.h5` and not your current working directory.
-        The external link previously would to be something like `../abc/iter_000000.h5`
+        The external link would previously be something like `../abc/iter_000000.h5`
         instead of `iter_000000.h5`, even if your `west.h5` file is right next to it.
 
         Conditions necessary for this to happen:
@@ -94,7 +94,7 @@ class TestHDF5Framework:
         b) $WEST_SIM_ROOT must exist.
         c) You are working in a location other than $WEST_SIM_ROOT.
         d) `WESTDataManager.we_h5filename` (usually read from `west.cfg`
-           under `west/data/west_data/file`) either doesn't exist (so the `west.h5`
+           under `west/data/west_data_file`) either doesn't exist (so the `west.h5`
            default is used) or is a relative path.
 
         EXAMPLE TREE

--- a/tests/test_hdf5_framework.py
+++ b/tests/test_hdf5_framework.py
@@ -132,7 +132,7 @@ class TestHDF5Framework:
             m.setenv('WEST_SIM_ROOT', f'{tmp_path}/abc')
             os.chdir('../def')
 
-            # Write to iter_000000.h5
+            # Write to west.h5, create iter_000000.h5
             dm.require_iter_group(0)
             dm.update_iter_h5file(0, [])
 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->
#573 

## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Added a guard so we don't get outrages hdf5 framework external links when your `current working directory != $WEST_SIM_ROOT` pointing to where west.h5 is located. This happens because we feed in `start=''` to `os.path.relpath()` https://docs.python.org/3/library/os.path.html#os.path.relpath), (`dirname('west.h5') = ''`) making relpaths relative to your `cwd` instead of `west.h5`.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Make sure external links are always the minimal relative path to `west.h5` not cwd

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] data_manager.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have read the AI POLICY document.
- [x] This PR conforms to WESTPA's AI policy.
- [x] I have declared all usage of AI in the PR description.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


