### PR TITLE
Remove numpy data type from MAB stats output

### DIFF
--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -332,13 +332,14 @@ def detect_bottlenecks(unmasked_coords, unmasked_weights, n_coords, n):
 
 
 def log_mab_stats(minlist, maxlist, direction, skip):
-    westpa.rc.pstatus("################ MAB stats ################")
-    westpa.rc.pstatus(f"minima in each dimension:      {minlist}")
-    westpa.rc.pstatus(f"maxima in each dimension:      {maxlist}")
-    westpa.rc.pstatus(f"direction in each dimension:   {direction}")
-    westpa.rc.pstatus(f"skip in each dimension:        {skip}")
-    westpa.rc.pstatus("###########################################")
-    westpa.rc.pflush()
+    with np.printoptions(legacy='1.25'):
+        westpa.rc.pstatus("################ MAB stats ################")
+        westpa.rc.pstatus(f"minima in each dimension:      {minlist}")
+        westpa.rc.pstatus(f"maxima in each dimension:      {maxlist}")
+        westpa.rc.pstatus(f"direction in each dimension:   {direction}")
+        westpa.rc.pstatus(f"skip in each dimension:        {skip}")
+        westpa.rc.pstatus("###########################################")
+        westpa.rc.pflush()
 
 
 def bin_assignment(

--- a/tests/test_binningfe.py
+++ b/tests/test_binningfe.py
@@ -79,4 +79,5 @@ skip in each dimension:        [0, 1]
             log_mab_stats(minlist, maxlist, direction, skip)
 
             captured = capsys.readouterr()
-            assert captured.out == desired_output
+            for out_line, desired_line in zip(captured.out.splitlines(), desired_output.splitlines()):
+                assert out_line == desired_line

--- a/tests/test_binningfe.py
+++ b/tests/test_binningfe.py
@@ -3,7 +3,10 @@ from io import StringIO
 
 import numpy as np
 
+import westpa
 from westpa.core.binning.assign import RecursiveBinMapper
+from westpa.core.binning.mab import log_mab_stats
+from westpa.core._rc import WESTRC
 from westpa.tools.binning import mapper_from_expr, mapper_from_system, write_bin_info
 
 
@@ -52,3 +55,28 @@ Norm = 1, error in norm = 0 (0 epsilon)
 
         write_bin_info(mapper=mapper, assignments=assignments, weights=weights, n_target_states=1, outfile=out_io, detailed=True)
         assert out_io.getvalue() == reference_output
+
+
+class TestMABStats:
+    def test_log_mab_stats(self, monkeypatch, capsys):
+        rc = WESTRC()
+
+        minlist = [np.float64(-0.47485543251358475), np.float64(-0.4430687890306835)]
+        maxlist = [np.float64(1.1889518895689877), np.float64(1.266509184762224)]
+        direction = [0, 0]
+        skip = [0, 1]
+
+        desired_output = '''################ MAB stats ################
+minima in each dimension:      [-0.47485543251358475, -0.4430687890306835]
+maxima in each dimension:      [1.1889518895689877, 1.266509184762224]
+direction in each dimension:   [0, 0]
+skip in each dimension:        [0, 1]
+###########################################
+'''
+        with monkeypatch.context() as m:
+            m.setattr(westpa, 'rc', rc)
+
+            log_mab_stats(minlist, maxlist, direction, skip)
+
+            captured = capsys.readouterr()
+            assert captured.out == desired_output


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Output for MAB stats in the `west.log` file will now be a little cleaner.

Due to changes in numpy 2 string outputs, the current "MAB stats" look like:
```
################ MAB stats ################
minima in each dimension:      [np.float32(0.16191083)]
maxima in each dimension:      [np.float32(0.20319091)]
direction in each dimension:   [1]
skip in each dimension:        [0]
###########################################
```
instead of what's in numpy 1.XX:
```
################ MAB stats ################
minima in each dimension:      [0.16191083]
maxima in each dimension:      [0.20319091]
direction in each dimension:   [1]
skip in each dimension:        [0]
###########################################
```

This PR reverts printing behavior to `numpy 1.XX` format just for these lines in the `west.log`.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Cleaner output for MAB stats

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/core/binning/mab.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have read the AI POLICY document.
- [x] This PR conforms to WESTPA's AI policy.
- [x] I have declared all usage of AI in the PR description.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


