### PR TITLE
Work Manager bug fix/code cleanup (ZMQ-multiprocessing, curbing other wm tests)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,7 +80,7 @@ jobs:
           conda list
   
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 45
         # conda setup requires this special shell
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,7 +80,7 @@ jobs:
           conda list
   
       - name: Run tests
-        timeout-minutes: 45
+        timeout-minutes: 30
         # conda setup requires this special shell
         shell: bash -l {0}
         run: |

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -27,7 +27,7 @@ class ProcessWorkManager(WorkManager):
     -----
 
     On MacOS, as of Python 3.8 the default start method for multiprocessing launching new processes was changed from fork to spawn.
-    On Linux, as of Python 3.14, the default start method for multiprocessing launching new processes was changed from fork to spawn.
+    On Linux, as of Python 3.14, the default start method for multiprocessing launching new processes was changed from fork to forkserver.
     In general, spawn is more robust and efficient, however it requires serializability of everything being passed to the child process.
     In contrast, fork is much less memory efficient, as it makes a full copy of everything in the parent process.
     However, it does not require picklability.

--- a/src/westpa/work_managers/processes.py
+++ b/src/westpa/work_managers/processes.py
@@ -77,7 +77,10 @@ class ProcessWorkManager(WorkManager):
 
         while not self.shutdown_received.is_set():
             if not self.task_queue.empty():
-                message, task_id, fn, args, kwargs = self.task_queue.get()[:5]
+                try:
+                    message, task_id, fn, args, kwargs = self.task_queue.get()[:5]
+                except EOFError:
+                    pass  # Take into account of delays between if and get()
 
                 if message == 'shutdown':
                     break
@@ -95,7 +98,10 @@ class ProcessWorkManager(WorkManager):
     def results_loop(self):
         while not self.shutdown_received.is_set():
             if not self.result_queue.empty():
-                message, task_id, payload = self.result_queue.get()[:3]
+                try:
+                    message, task_id, payload = self.result_queue.get()[:3]
+                except EOFError:
+                    pass  # Take into account of delays between if and get()
 
                 if message == 'shutdown':
                     break

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -566,17 +566,26 @@ def shutdown_process(process, timeout=1.0):
     process.join(timeout)
     if process.is_alive():
         log.debug('sending SIGINT to process {:d}'.format(process.pid))
-        os.kill(process.pid, signal.SIGINT)
+        process.terminate()
         process.join(timeout)
         if process.is_alive():
             log.warning('sending SIGKILL to worker process {:d}'.format(process.pid))
-            os.kill(process.pid, signal.SIGKILL)
+            process.kill()
             process.join()
 
         log.debug('process {:d} terminated with code {:d}'.format(process.pid, process.exitcode))
     else:
         log.debug('worker process {:d} terminated gracefully with code {:d}'.format(process.pid, process.exitcode))
-    assert not process.is_alive()
+
+    try:
+        process.close()
+    except ValueError:
+        try:
+            if process.is_alive():
+                log.debug('process {:d} unable to be closed'.format(process.pid))
+            assert not process.is_alive()
+        except ValueError:
+            pass
 
 
 class IsNode:

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -23,6 +23,7 @@ import uuid
 
 import zmq
 import numpy as np
+from zmq import ContextTerminated
 
 # Every ten seconds the master requests a status report from workers.
 # This also notifies workers that the master is still alive
@@ -454,8 +455,12 @@ class ZMQCore:
                 poll_results = dict(poller.poll(timeout=timeout))
                 if socket in poll_results:
                     message = socket.recv_pyobj(flags)
+                elif socket.closed:
+                    raise ContextTerminated
                 else:
                     raise ZMQWMTimeout('recv timed out')
+            except (KeyboardInterrupt, ContextTerminated):
+                return Message(message=Message.SHUTDOWN)
             finally:
                 poller.unregister(socket)
 
@@ -640,6 +645,9 @@ class IsNode:
             shutdown_timeout = self.shutdown_timeout
         except AttributeError:
             shutdown_timeout = 1.0
+
+        for worker in self.local_workers:
+            worker.shutdown_executor()
 
         for process in self.local_worker_processes:
             shutdown_process(process, shutdown_timeout)

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -641,11 +641,11 @@ class IsNode:
         except AttributeError:
             shutdown_timeout = 1.0
 
-        for worker in self.local_workers:
-            worker.shutdown_executor()
-
         for process in self.local_worker_processes:
             shutdown_process(process, shutdown_timeout)
+
+        for worker in self.local_workers:
+            worker.shutdown_executor()
 
         for host_info_file in self.host_info_files:
             try:

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -578,14 +578,14 @@ def shutdown_process(process, timeout=1.0):
         if process.is_alive():
             log.warning('sending SIGKILL to worker process {:d}'.format(process.pid))
             process.kill()
-            process.join()
+        process.join()
 
         log.debug('process {:d} terminated with code {:d}'.format(process.pid, process.exitcode))
     else:
         log.debug('worker process {:d} terminated gracefully with code {:d}'.format(process.pid, process.exitcode))
 
     try:
-        process.close()
+        process.close()  # Release all resources
     except ValueError:
         try:
             if process.is_alive():
@@ -640,6 +640,9 @@ class IsNode:
             shutdown_timeout = self.shutdown_timeout
         except AttributeError:
             shutdown_timeout = 1.0
+
+        for worker in self.local_workers:
+            worker.shutdown_executor()
 
         for process in self.local_worker_processes:
             shutdown_process(process, shutdown_timeout)

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -584,7 +584,6 @@ def shutdown_process(process, timeout=1.0):
             log.warning('sending SIGKILL to worker process {:d}'.format(process.pid))
             process.kill()
         process.join()
-
         log.debug('process {:d} terminated with code {:d}'.format(process.pid, process.exitcode))
     else:
         log.debug('worker process {:d} terminated gracefully with code {:d}'.format(process.pid, process.exitcode))
@@ -646,9 +645,11 @@ class IsNode:
         except AttributeError:
             shutdown_timeout = 1.0
 
+        # Graceful clean up by signaling shut down
         for worker in self.local_workers:
             worker.shutdown_executor()
 
+        # Messy clean up by shutting down processes
         for process in self.local_worker_processes:
             shutdown_process(process, shutdown_timeout)
 

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -644,9 +644,6 @@ class IsNode:
         for process in self.local_worker_processes:
             shutdown_process(process, shutdown_timeout)
 
-        for worker in self.local_workers:
-            worker.shutdown_executor()
-
         for host_info_file in self.host_info_files:
             try:
                 os.unlink(host_info_file)

--- a/src/westpa/work_managers/zeromq/core.py
+++ b/src/westpa/work_managers/zeromq/core.py
@@ -323,6 +323,13 @@ class ZMQCore:
             return cls.make_tcp_endpoint()
 
     def __init__(self):
+        try:
+            if sys.platform in ['darwin', 'linux']:  # UNIX Platforms
+                multiprocessing.set_start_method('fork')
+                log.debug('setting multiprocessing start method to fork')
+        except RuntimeError:
+            log.debug('failed to set start method to fork')
+
         # Unique identifier of this ZMQ node
         self.node_id = uuid.uuid4()
 

--- a/src/westpa/work_managers/zeromq/node.py
+++ b/src/westpa/work_managers/zeromq/node.py
@@ -26,7 +26,7 @@ class ZMQNode(ZMQCore, IsNode):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_traceback):
-        IsNode.shutdown()
+        IsNode.shutdown(self)
         return False
 
     def run(self):

--- a/src/westpa/work_managers/zeromq/node.py
+++ b/src/westpa/work_managers/zeromq/node.py
@@ -26,6 +26,7 @@ class ZMQNode(ZMQCore, IsNode):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_traceback):
+        IsNode.shutdown()
         return False
 
     def run(self):

--- a/src/westpa/work_managers/zeromq/node.py
+++ b/src/westpa/work_managers/zeromq/node.py
@@ -23,11 +23,9 @@ class ZMQNode(ZMQCore, IsNode):
         self.upstream_ann_endpoint = upstream_ann_endpoint
 
     def __enter__(self):
-        self.startup()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_traceback):
-        IsNode.shutdown(self)
         return False
 
     def run(self):
@@ -126,7 +124,7 @@ class ZMQNode(ZMQCore, IsNode):
             self.log.debug('exiting')
             self.context = None
             self.remove_ipc_endpoints()
-            IsNode.shutdown(self)
+            self.shutdown()
 
     def startup(self):
         IsNode.startup(self)

--- a/src/westpa/work_managers/zeromq/node.py
+++ b/src/westpa/work_managers/zeromq/node.py
@@ -23,6 +23,7 @@ class ZMQNode(ZMQCore, IsNode):
         self.upstream_ann_endpoint = upstream_ann_endpoint
 
     def __enter__(self):
+        self.startup()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_traceback):
@@ -130,3 +131,7 @@ class ZMQNode(ZMQCore, IsNode):
     def startup(self):
         IsNode.startup(self)
         super().startup()
+
+    def shutdown(self):
+        IsNode.shutdown(self)
+        super().shutdown()

--- a/src/westpa/work_managers/zeromq/work_manager.py
+++ b/src/westpa/work_managers/zeromq/work_manager.py
@@ -511,7 +511,7 @@ class ZMQWorkManager(ZMQCore, WorkManager, IsNode):
                     self.send_nak(rr_socket, msg)
 
         finally:
-            self.context.destroy(linger=1)
+            self.context.destroy(linger=5)
             self.context = None
             self.remove_ipc_endpoints()
 

--- a/src/westpa/work_managers/zeromq/worker.py
+++ b/src/westpa/work_managers/zeromq/worker.py
@@ -213,7 +213,6 @@ class ZMQWorker(ZMQCore):
             self.log.error('timeout communicating with peer; shutting down')
         finally:
             self.shutdown_executor()
-            self.executor_process.join()
             self.context.destroy(linger=1)
             self.context = None
             self.remove_ipc_endpoints()

--- a/src/westpa/work_managers/zeromq/worker.py
+++ b/src/westpa/work_managers/zeromq/worker.py
@@ -250,7 +250,7 @@ class ZMQWorker(ZMQCore):
 
                 # Exiting after timeout so we can shutdown forcefully later
                 self.executor_process.join(self.shutdown_timeout)
-                if self.executor_processs.exitcode == 0:
+                if self.executor_process.exitcode == 0:
                     self.log.debug('worker process {:d} terminated'.format(pid))
             else:
                 self.log.debug(

--- a/src/westpa/work_managers/zeromq/worker.py
+++ b/src/westpa/work_managers/zeromq/worker.py
@@ -242,15 +242,6 @@ class ZMQWorker(ZMQCore):
         else:
             self.log.debug('worker process {:d} terminated gracefully with code {:d}'.format(pid, self.executor_process.exitcode))
 
-        try:
-            self.executor_process.close()
-        except ValueError:
-            try:
-                if self.executor_process.is_alive():
-                    self.log.debug('worker process {:d} could not be closed'.format(pid))
-            except ValueError:
-                pass  # Already closed.
-
     def install_signal_handlers(self, signals=None):
         if not signals:
             signals = {signal.SIGINT, signal.SIGQUIT, signal.SIGTERM}

--- a/src/westpa/work_managers/zeromq/worker.py
+++ b/src/westpa/work_managers/zeromq/worker.py
@@ -13,6 +13,7 @@ import threading
 from .core import ZMQCore, Message, ZMQWMTimeout, PassiveMultiTimer, Task, Result, TIMEOUT_MASTER_BEACON
 
 import zmq
+from zmq import ContextTerminated
 
 log = logging.getLogger(__name__)
 
@@ -299,7 +300,7 @@ class ZMQExecutor(ZMQCore):
             while True:
                 try:
                     msg = self.recv_message(task_socket, timeout=100)
-                except KeyboardInterrupt:
+                except (KeyboardInterrupt, ContextTerminated):
                     break
                 except ZMQWMTimeout:
                     continue
@@ -311,8 +312,9 @@ class ZMQExecutor(ZMQCore):
                     elif msg.message == Message.SHUTDOWN:
                         break
         finally:
-            self.context.destroy(linger=0)
-            self.context = None
+            if self.context is not None:
+                self.context.destroy(linger=0)
+                self.context = None
 
     def startup(self, process_index=None):
         if process_index is not None:

--- a/src/westpa/work_managers/zeromq/worker.py
+++ b/src/westpa/work_managers/zeromq/worker.py
@@ -234,23 +234,23 @@ class ZMQWorker(ZMQCore):
         # is_alive() is prone to a race condition so catch the case that the PID is already dead
         if self.executor_process.is_alive():
             self.log.debug('sending SIGTERM to worker process {:d}'.format(pid))
-            self.executor_process.terminate()
-            # try:
-            #     os.kill(self.executor_process.pid, signal.SIGINT)
-            # except ProcessLookupError:
-            #     self.log.debug('worker process {:d} already dead'.format(pid))
             self.executor_process.join(self.shutdown_timeout)
             if self.executor_process.is_alive():
                 self.executor_process.kill()
                 self.log.warning('sending SIGKILL to worker process {:d}'.format(pid))
-                # try:
-                #     os.kill(self.executor_process.pid, signal.SIGKILL)
-                # except ProcessLookupError:
-                #     self.log.debug('worker process {:d} already dead'.format(pid))
             self.executor_process.join()
             self.log.debug('worker process {:d} terminated'.format(pid))
         else:
             self.log.debug('worker process {:d} terminated gracefully with code {:d}'.format(pid, self.executor_process.exitcode))
+
+        try:
+            self.executor_process.close()
+        except ValueError:
+            try:
+                if self.executor_process.is_alive():
+                    self.log.debug('worker process {:d} could not be closed'.format(pid))
+            except ValueError:
+                pass  # Already closed.
 
     def install_signal_handlers(self, signals=None):
         if not signals:

--- a/src/westpa/work_managers/zeromq/worker.py
+++ b/src/westpa/work_managers/zeromq/worker.py
@@ -237,16 +237,17 @@ class ZMQWorker(ZMQCore):
                 self.executor_process.terminate()
                 self.executor_process.join(self.shutdown_timeout)
                 if self.executor_process.is_alive():
-                    self.executor_process.kill()
                     self.log.warning('sending SIGKILL to worker process {:d}'.format(pid))
+                    self.executor_process.kill()
                 self.executor_process.join()
                 self.log.debug('worker process {:d} terminated'.format(pid))
             else:
                 self.log.debug(
                     'worker process {:d} terminated gracefully with code {:d}'.format(pid, self.executor_process.exitcode)
                 )
+
         except (ValueError, AttributeError):
-            pass  # Already Closed
+            pass  # Already closed.
 
         try:
             self.executor_process.close()

--- a/src/westpa/work_managers/zeromq/worker.py
+++ b/src/westpa/work_managers/zeromq/worker.py
@@ -233,6 +233,7 @@ class ZMQWorker(ZMQCore):
         # is_alive() is prone to a race condition so catch the case that the PID is already dead
         if self.executor_process.is_alive():
             self.log.debug('sending SIGTERM to worker process {:d}'.format(pid))
+            self.executor_process.terminate()
             self.executor_process.join(self.shutdown_timeout)
             if self.executor_process.is_alive():
                 self.executor_process.kill()

--- a/src/westpa/work_managers/zeromq/worker.py
+++ b/src/westpa/work_managers/zeromq/worker.py
@@ -50,6 +50,13 @@ class ZMQWorker(ZMQCore):
     def is_master(self):
         return False
 
+    @property
+    def is_closed(self):
+        try:
+            return self.context.closed
+        except AttributeError:
+            return True
+
     def update_master_info(self, msg):
         if self.master_id is None:
             self.master_id = msg.master_id
@@ -214,7 +221,7 @@ class ZMQWorker(ZMQCore):
             self.log.error('timeout communicating with peer; shutting down')
         finally:
             self.shutdown_executor()
-            self.context.destroy(linger=1)
+            self.context.destroy(linger=5)
             self.context = None
             self.remove_ipc_endpoints()
 
@@ -225,7 +232,7 @@ class ZMQWorker(ZMQCore):
                 task_socket = self.context.socket(zmq.PUSH)
                 task_socket.connect(self.task_endpoint)
                 self.send_message(task_socket, Message.SHUTDOWN)
-                task_socket.close(linger=1)
+                task_socket.close(linger=5)
             except Exception:
                 pass
 
@@ -240,13 +247,15 @@ class ZMQWorker(ZMQCore):
                 if self.executor_process.is_alive():
                     self.log.warning('sending SIGKILL to worker process {:d}'.format(pid))
                     self.executor_process.kill()
-                self.executor_process.join()
-                self.log.debug('worker process {:d} terminated'.format(pid))
+
+                # Exiting after timeout so we can shutdown forcefully later
+                self.executor_process.join(self.shutdown_timeout)
+                if self.executor_processs.exitcode == 0:
+                    self.log.debug('worker process {:d} terminated'.format(pid))
             else:
                 self.log.debug(
                     'worker process {:d} terminated gracefully with code {:d}'.format(pid, self.executor_process.exitcode)
                 )
-
         except (ValueError, AttributeError):
             pass  # Already closed.
 
@@ -313,7 +322,7 @@ class ZMQExecutor(ZMQCore):
                         break
         finally:
             if self.context is not None:
-                self.context.destroy(linger=0)
+                self.context.destroy(linger=5)
                 self.context = None
 
     def startup(self, process_index=None):

--- a/src/westpa/work_managers/zeromq/worker.py
+++ b/src/westpa/work_managers/zeromq/worker.py
@@ -228,20 +228,34 @@ class ZMQWorker(ZMQCore):
             except Exception:
                 pass
 
-        pid = self.executor_process.pid
-        self.executor_process.join(self.shutdown_timeout)
-        # is_alive() is prone to a race condition so catch the case that the PID is already dead
-        if self.executor_process.is_alive():
-            self.log.debug('sending SIGTERM to worker process {:d}'.format(pid))
-            self.executor_process.terminate()
+        try:
+            pid = self.executor_process.pid
             self.executor_process.join(self.shutdown_timeout)
+            # is_alive() is prone to a race condition so catch the case that the PID is already dead
             if self.executor_process.is_alive():
-                self.executor_process.kill()
-                self.log.warning('sending SIGKILL to worker process {:d}'.format(pid))
-            self.executor_process.join()
-            self.log.debug('worker process {:d} terminated'.format(pid))
-        else:
-            self.log.debug('worker process {:d} terminated gracefully with code {:d}'.format(pid, self.executor_process.exitcode))
+                self.log.debug('sending SIGTERM to worker process {:d}'.format(pid))
+                self.executor_process.terminate()
+                self.executor_process.join(self.shutdown_timeout)
+                if self.executor_process.is_alive():
+                    self.executor_process.kill()
+                    self.log.warning('sending SIGKILL to worker process {:d}'.format(pid))
+                self.executor_process.join()
+                self.log.debug('worker process {:d} terminated'.format(pid))
+            else:
+                self.log.debug(
+                    'worker process {:d} terminated gracefully with code {:d}'.format(pid, self.executor_process.exitcode)
+                )
+        except (ValueError, AttributeError):
+            pass  # Already Closed
+
+        try:
+            self.executor_process.close()
+        except (ValueError, AttributeError):
+            try:
+                if self.executor_process.is_alive():
+                    self.log.debug('worker process {:d} could not be closed'.format(pid))
+            except (ValueError, AttributeError):
+                pass  # Already closed.
 
     def install_signal_handlers(self, signals=None):
         if not signals:

--- a/tests/test_we_driver.py
+++ b/tests/test_we_driver.py
@@ -245,11 +245,10 @@ class TestWEDriver(TestCase):
         self.we_driver.populate_initial([istate], [prob], system=self.system)
         assert len(self.we_driver.next_iter_binning[0]) == target_counts
 
-    @pytest.mark.skip
     def test_populate_initial(self):
         for prob in [0.1, 1.0 / 3.0, 0.9999999999970001, 1.0]:
             for tcount in range(30, 60):
-                yield self.check_populate_initial, prob, tcount
+                self.check_populate_initial(prob, tcount)
 
     def test_merge_by_threshold(self):
         # Create the segments

--- a/tests/test_work_managers/test_environment.py
+++ b/tests/test_work_managers/test_environment.py
@@ -83,8 +83,9 @@ class TestInstantiations(unittest.TestCase):
         assert isinstance(work_manager, ZMQWorkManager)
         with work_manager:
             # Need to send enough work to start sufficient workers
-            for _ in range(2):
+            for _ in range(3):
                 future = work_manager.submit(will_wait)
-                future.get_result()
+                result = future.get_result()
+                assert result
 
             assert work_manager.n_workers == 3

--- a/tests/test_work_managers/test_mpi.py
+++ b/tests/test_work_managers/test_mpi.py
@@ -1,4 +1,7 @@
+import pytest
 import unittest
+
+pytest.importorskip('mpi4py')
 
 from westpa.work_managers.mpi import MPIWorkManager
 

--- a/tests/test_work_managers/test_processes.py
+++ b/tests/test_work_managers/test_processes.py
@@ -9,12 +9,14 @@ from .tsupport import will_busyhang, will_busyhang_uninterruptible, get_process_
 
 
 class TestProcessWorkManager(unittest.TestCase, CommonParallelTests, CommonWorkManagerTests):
-    def setUp(self):
-        self.work_manager = ProcessWorkManager(n_workers=5)
-        self.work_manager.startup()
+    @classmethod
+    def setUpClass(cls):
+        cls.work_manager = ProcessWorkManager(n_workers=5)
+        cls.work_manager.startup()
 
-    def tearDown(self):
-        self.work_manager.shutdown()
+    @classmethod
+    def tearDownClass(cls):
+        cls.work_manager.shutdown()
 
 
 class TestProcessWorkManagerAux:

--- a/tests/test_work_managers/test_processes.py
+++ b/tests/test_work_managers/test_processes.py
@@ -79,6 +79,8 @@ class TestProcessWorkManagerAux:
                         pass  # probably closed already
                 raise
 
+        work_manager.shutdown()
+
     @pytest.mark.timeout(10)
     def test_worker_close_fail(self, monkeypatch):
         work_manager = ProcessWorkManager(n_workers=5)

--- a/tests/test_work_managers/test_processes.py
+++ b/tests/test_work_managers/test_processes.py
@@ -10,7 +10,7 @@ from .tsupport import will_busyhang, will_busyhang_uninterruptible, get_process_
 
 class TestProcessWorkManager(unittest.TestCase, CommonParallelTests, CommonWorkManagerTests):
     def setUp(self):
-        self.work_manager = ProcessWorkManager()
+        self.work_manager = ProcessWorkManager(n_workers=5)
         self.work_manager.startup()
 
     def tearDown(self):
@@ -20,7 +20,7 @@ class TestProcessWorkManager(unittest.TestCase, CommonParallelTests, CommonWorkM
 class TestProcessWorkManagerAux:
     @pytest.mark.timeout(10)
     def test_shutdown(self):
-        work_manager = ProcessWorkManager()
+        work_manager = ProcessWorkManager(n_workers=5)
         work_manager.startup()
         work_manager.shutdown()
         for worker in work_manager.workers:
@@ -31,7 +31,7 @@ class TestProcessWorkManagerAux:
 
     @pytest.mark.timeout(10)
     def test_hang_shutdown(self):
-        work_manager = ProcessWorkManager()
+        work_manager = ProcessWorkManager(n_workers=5)
         work_manager.shutdown_timeout = 0.1
         work_manager.startup()
         for _ in range(5):
@@ -45,7 +45,7 @@ class TestProcessWorkManagerAux:
 
     @pytest.mark.timeout(10)
     def test_hang_shutdown_ignoring_sigint(self):
-        work_manager = ProcessWorkManager()
+        work_manager = ProcessWorkManager(n_workers=5)
         work_manager.shutdown_timeout = 0.1
         work_manager.startup()
         for _ in range(5):
@@ -59,7 +59,7 @@ class TestProcessWorkManagerAux:
 
     @pytest.mark.timeout(10)
     def test_sigint_shutdown(self):
-        work_manager = ProcessWorkManager()
+        work_manager = ProcessWorkManager(n_workers=5)
         work_manager.install_sigint_handler()
         work_manager.shutdown_timeout = 0.1
         work_manager.startup()
@@ -79,7 +79,7 @@ class TestProcessWorkManagerAux:
 
     @pytest.mark.timeout(10)
     def test_worker_close_fail(self, monkeypatch):
-        work_manager = ProcessWorkManager()
+        work_manager = ProcessWorkManager(n_workers=5)
         work_manager.install_sigint_handler()
         work_manager.shutdown_timeout = 0.1
         work_manager.startup()
@@ -98,7 +98,7 @@ class TestProcessWorkManagerAux:
 
     @pytest.mark.timeout(10)
     def test_worker_ids(self):
-        work_manager = ProcessWorkManager()
+        work_manager = ProcessWorkManager(n_workers=5)
         with work_manager:
             futures = work_manager.submit_many([(get_process_index, (), {})] * work_manager.n_workers)
             work_manager.wait_all(futures)

--- a/tests/test_work_managers/test_threads.py
+++ b/tests/test_work_managers/test_threads.py
@@ -6,7 +6,7 @@ from .tsupport import CommonWorkManagerTests, CommonParallelTests
 
 class TestThreadsWorkManager(unittest.TestCase, CommonWorkManagerTests, CommonParallelTests):
     def setUp(self):
-        self.work_manager = ThreadsWorkManager()
+        self.work_manager = ThreadsWorkManager(n_workers=5)
         self.work_manager.startup()
 
     def tearDown(self):

--- a/tests/test_work_managers/test_threads.py
+++ b/tests/test_work_managers/test_threads.py
@@ -5,12 +5,14 @@ from .tsupport import CommonWorkManagerTests, CommonParallelTests
 
 
 class TestThreadsWorkManager(unittest.TestCase, CommonWorkManagerTests, CommonParallelTests):
-    def setUp(self):
-        self.work_manager = ThreadsWorkManager(n_workers=5)
-        self.work_manager.startup()
+    @classmethod
+    def setUpClass(cls):
+        cls.work_manager = ThreadsWorkManager(n_workers=5)
+        cls.work_manager.startup()
 
-    def tearDown(self):
-        self.work_manager.shutdown()
+    @classmethod
+    def tearDownClass(cls):
+        cls.work_manager.shutdown()
 
 
 class TestThreadsWorkManagerAux:

--- a/tests/test_work_managers/test_threads.py
+++ b/tests/test_work_managers/test_threads.py
@@ -17,7 +17,7 @@ class TestThreadsWorkManager(unittest.TestCase, CommonWorkManagerTests, CommonPa
 
 class TestThreadsWorkManagerAux:
     def test_shutdown(self):
-        work_manager = ThreadsWorkManager()
+        work_manager = ThreadsWorkManager(n_workers=5)
         work_manager.startup()
         work_manager.shutdown()
         for worker in work_manager.workers:

--- a/tests/test_work_managers/test_zeromq/test_work_manager.py
+++ b/tests/test_work_managers/test_zeromq/test_work_manager.py
@@ -124,12 +124,10 @@ class TestZMQWorkManagerBasic(ZMQTestBase, unittest.TestCase):
         with self.expect_announcement(Message.SHUTDOWN):
             self.test_wm.signal_shutdown()
 
-    # This won't work, because initial beacon is discarded if no clients are connected
-    #     def test_immediate_master_beacon(self):
-    #         with self.expect_announcement(Message.MASTER_BEACON):
-    #             time.sleep(BEACON_WAIT)
+    def test_immediate_master_beacon(self):
+        with self.expect_announcement(Message.MASTER_BEACON):
+            time.sleep(BEACON_WAIT)
 
-    @pytest.mark.skip(reason='skipping')
     def test_delayed_master_beacon(self):
         self.discard_announcements()
         with self.expect_announcement(Message.MASTER_BEACON):

--- a/tests/test_work_managers/test_zeromq/test_work_manager.py
+++ b/tests/test_work_managers/test_zeromq/test_work_manager.py
@@ -17,6 +17,12 @@ from .zmq_tsupport import ZMQTestBase
 pytestmark = pytest.mark.flaky(reruns=5, reason='ZeroMQ tests are flaky')
 
 
+@pytest.fixture(scope="class")
+def monkeypatch_for_class(request):
+    request.cls.monkeypatch = pytest.MonkeyPatch()
+
+
+@pytest.mark.usefixtures('monkeypatch_for_class')
 class TestZMQWorkManagerBasic(ZMQTestBase, unittest.TestCase):
     '''Tests for the core task dispersal/retrieval and shutdown operations
     (the parts of the WM that do not require ZMQWorker).'''
@@ -164,6 +170,16 @@ class TestZMQWorkManagerBasic(ZMQTestBase, unittest.TestCase):
             result = task.execute()
             self.test_core.send_message(s, Message.RESULT, result)
         assert future.result == r
+
+    def test_worker_close_fail(self):
+        with self.monkeypatch.context() as m:
+            for process in self.test_wm.local_worker_processes:
+                m.setattr(process, 'close', lambda: exec('raise(ValueError)'))
+
+            self.test_wm.signal_shutdown()
+            self.test_wm.join()
+
+            assert not self.test_wm.comm_thread.is_alive()
 
 
 class BaseInternal:

--- a/tests/test_work_managers/test_zeromq/test_worker.py
+++ b/tests/test_work_managers/test_zeromq/test_worker.py
@@ -83,12 +83,20 @@ class TestZMQWorkerBasic(ZMQTestBase, unittest.TestCase):
 
     def test_executor_shuts_down_immediately(self):
         self.test_worker.shutdown_executor()
-        assert not self.test_worker.executor_process.is_alive()
+        try:
+            assert not self.test_worker.executor_process.is_alive()
+        except ValueError:
+            # Closed processes will return ValueError instead
+            pass
 
     def test_shutdown_on_announcement(self):
         self.test_core.send_message(self.ann_socket, Message.SHUTDOWN)
         self.test_worker.join()
-        assert not self.test_worker.executor_process.is_alive()
+        try:
+            assert not self.test_worker.executor_process.is_alive()
+        except ValueError:
+            # Closed processes will return ValueError instead
+            pass
 
     def test_responds_to_task_avail(self):
         self.test_core.send_message(self.ann_socket, Message.TASKS_AVAILABLE)
@@ -100,7 +108,11 @@ class TestZMQWorkerBasic(ZMQTestBase, unittest.TestCase):
         self.test_core.send_message(self.ann_socket, Message.RECONFIGURE_TIMEOUT, (TIMEOUT_MASTER_BEACON, 0.01))
         time.sleep(0.02)
         self.test_worker.join()
-        assert not self.test_worker.executor_process.is_alive()
+        try:
+            assert not self.test_worker.executor_process.is_alive()
+        except ValueError:
+            # Closed processes will return ValueError instead
+            pass
 
     def test_worker_processes_task(self):
         r = random_int()

--- a/tests/test_work_managers/test_zeromq/test_worker.py
+++ b/tests/test_work_managers/test_zeromq/test_worker.py
@@ -53,6 +53,8 @@ class TestZMQWorkerBasic(ZMQTestBase, unittest.TestCase):
     def tearDown(self):
         time.sleep(TEARDOWN_WAIT)
 
+        self.test_core.shutdown()
+
         self.test_worker.signal_shutdown()
         self.test_worker.comm_thread.join()
 
@@ -132,9 +134,13 @@ class TestZMQWorkerBasic(ZMQTestBase, unittest.TestCase):
         self.test_core.send_message(self.ann_socket, Message.SHUTDOWN)
         self.test_worker.join()
 
+        assert self.test_worker.is_closed
+
     def test_hung_worker_uninterruptible(self):
         task = Task(will_busyhang_uninterruptible, (), {})
         self.send_task(task)
         time.sleep(1.0)
         self.test_core.send_message(self.ann_socket, Message.SHUTDOWN)
         self.test_worker.join()
+
+        assert self.test_worker.is_closed

--- a/tests/test_work_managers/test_zeromq/zmq_tsupport.py
+++ b/tests/test_work_managers/test_zeromq/zmq_tsupport.py
@@ -91,5 +91,5 @@ class ZMQTestBase:
 
     def tearDown(self):
         self.cleanup_endpoints()
-        self.test_context.destroy(linger=1)
+        self.test_context.destroy(linger=5)
         del self.test_context

--- a/tests/test_work_managers/tsupport.py
+++ b/tests/test_work_managers/tsupport.py
@@ -20,7 +20,7 @@ def fn_interrupted():
 def will_wait():
     import time
 
-    time.sleep(0.5)
+    time.sleep(0.1)
     return True
 
 


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
A copy of the shutdown logic for processes work manager for zmq work manager. This will prevent orphaned processes and unexplained hangs after a run (pytest or simulation). Also defaults to "fork" on UNIX/POSIX on Python 3.14+ to speed things up. Forkserver is slow.

Also refactored the tests for processes and threads so we don't over request the number of workers and that minimize it so the setup only runs once per run.

Also unblocked a few tests that were previously skipped. New test added as well.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Better shutdown logic in zeromq to prevent hangs and 
- [x] Run setup for processes and threads tests only once each. 
- [x] Some test clean up

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] src/westpa/work_managers/zeromq
- [x] tests/test_work_managers/

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have read the AI POLICY document.
- [x] This PR conforms to WESTPA's AI policy.
- [x] I have declared all usage of AI in the PR description.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


