### PR TITLE
Add a progress tracking and ETA CLI tool for WESTPA simulations

### DIFF
--- a/doc/documentation/cli.rst
+++ b/doc/documentation/cli.rst
@@ -8,6 +8,7 @@ westpa.cli package
     w_init       <cli/w_init>
     w_bins       <cli/w_bins>
     w_run        <cli/w_run>
+    w_progress   <cli/w_progress>
     w_truncate   <cli/w_truncate>
     w_fork       <cli/w_fork>
 

--- a/doc/documentation/cli/w_progress.rst
+++ b/doc/documentation/cli/w_progress.rst
@@ -1,0 +1,74 @@
+w_progress
+==========
+
+``w_progress`` shows a live terminal dashboard for a WESTPA simulation.
+
+Overview
+--------
+
+Usage:
+
+.. code-block:: text
+
+  w_progress [-h] [-r RCFILE] [--quiet | --verbose | --debug] [--version]
+             [-W WEST_H5FILE] [--refresh SECONDS]
+
+Tool-specific arguments:
+
+.. code-block:: text
+
+  -W WEST_H5FILE, --west-data WEST_H5FILE
+                        Take WEST data from WEST_H5FILE.
+  --refresh SECONDS     Refresh the dashboard every SECONDS seconds.
+
+Examples
+--------
+
+Monitor the default ``west.h5`` file, refreshing once per second:
+
+.. code-block:: console
+
+  $ w_progress
+
+Monitor a specific WEST HDF5 file:
+
+.. code-block:: console
+
+  $ w_progress -W /path/to/west.h5
+
+Refresh every 10 seconds:
+
+.. code-block:: console
+
+  $ w_progress --refresh 10
+
+Notes
+-----
+
+``w_progress`` reads data in this order:
+
+#. If the sidecar file written by ``w_run`` exists and reports an active run
+   state, render that live status without opening ``west.h5``.
+#. Otherwise, read ``west.h5`` directly for the most complete stopped-run or
+   completed-run summary.
+#. If ``west.h5`` cannot be read and the sidecar reports a completed run, render
+   the completed sidecar status as a fallback.
+
+The sidecar is written next to the WEST HDF5 file, for example
+``west.h5.progress.json``. This avoids opening ``west.h5`` while the running
+simulation owns the HDF5 file lock.
+
+The top ``Updated`` timestamp is the time when ``w_progress`` refreshed the
+dashboard. For active runs, the ``Live status updated`` row shows when ``w_run``
+last wrote the sidecar data.
+
+``w_progress`` is intended to be run in a separate terminal while a simulation
+is running. By default, it clears and redraws the terminal on each refresh.
+
+When the live status file is unavailable, or when the run has completed,
+``w_progress`` falls back to reading the latest available state from
+``west.h5``.
+
+The ETA is a simple estimate based on the requested total iterations from
+``west.cfg`` and the average wall-clock time of recent completed iterations. If
+either value is unavailable, the ETA is shown as ``unknown``.

--- a/doc/documentation/core/westpa.core.rst
+++ b/doc/documentation/core/westpa.core.rst
@@ -46,6 +46,15 @@ westpa.core.progress module
    :show-inheritance:
    :imported-members:
 
+westpa.core.run\_status module
+------------------------------
+
+.. automodule:: westpa.core.run_status
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :imported-members:
+
 westpa.core.segment module
 --------------------------
 

--- a/doc/documentation/tools/westpa.tools.rst
+++ b/doc/documentation/tools/westpa.tools.rst
@@ -82,6 +82,15 @@ westpa.tools.progress module
    :show-inheritance:
    :imported-members:
 
+westpa.tools.progress\_status module
+------------------------------------
+
+.. automodule:: westpa.tools.progress_status
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :imported-members:
+
 westpa.tools.selected\_segs module
 ----------------------------------
 

--- a/doc/users_guide/command_line_tools.rst
+++ b/doc/users_guide/command_line_tools.rst
@@ -10,6 +10,7 @@ Command Line Tool Index
     w_init       <command_line_tools/w_init>
     w_bins       <command_line_tools/w_bins>
     w_run        <command_line_tools/w_run>
+    w_progress   <command_line_tools/w_progress>
     w_truncate   <command_line_tools/w_truncate>
     w_fork       <command_line_tools/w_fork>
 

--- a/doc/users_guide/command_line_tools/w_progress.rst
+++ b/doc/users_guide/command_line_tools/w_progress.rst
@@ -1,0 +1,58 @@
+.. _w_progress:
+
+w_progress
+==========
+
+``w_progress`` shows a live terminal dashboard for a running or recently updated
+WESTPA simulation.
+
+Usage:
+
+.. code-block:: text
+
+  w_progress [-h] [-r RCFILE] [--quiet | --verbose | --debug] [--version]
+             [-W WEST_H5FILE] [--refresh SECONDS]
+
+Examples
+--------
+
+Refresh the dashboard once per second using the default WEST data file:
+
+.. code-block:: console
+
+  $ w_progress
+
+Read a specific WEST HDF5 file:
+
+.. code-block:: console
+
+  $ w_progress -W west.h5
+
+Refresh every 10 seconds:
+
+.. code-block:: console
+
+  $ w_progress --refresh 10
+
+Output
+------
+
+The dashboard reports the current iteration, latest completed iteration,
+requested total iterations when available, prepared and failed segment counts
+for the current iteration with the current segment total, recent iteration
+wall-clock times, completed wall-clock time when available, completed segment
+count when available, and a simple ETA based on the last five completed
+iterations.
+
+``w_progress`` is read-only. It does not control or modify a WESTPA simulation.
+The command is intended to be run in a separate terminal while a simulation is
+running. By default, it clears and redraws the terminal on each refresh.
+
+During active runs started with the current ``w_run``, live values come from a
+small sidecar status file named ``west.h5.progress.json``. When that file is not
+available, or when the run has completed, ``w_progress`` falls back to reading
+``west.h5`` directly.
+
+The top ``Updated`` timestamp shows when ``w_progress`` refreshed the dashboard.
+During active runs, ``Live status updated`` shows when ``w_run`` last wrote new
+live status data.

--- a/doc/users_guide/west/running.rst
+++ b/doc/users_guide/west/running.rst
@@ -36,8 +36,9 @@ engine); any errors will be logged here.
 
 The :ref:`w_progress` command can also be used to monitor a running or recently
 updated simulation. It reports the current iteration, segment
-completion counts, recent iteration timings, and an estimated time to
-completion when available.
+prepared and failed counts, recent iteration timings, and an estimated time to
+completion when available. During active runs, ``w_progress`` reads the
+``west.h5.progress.json`` status file written by ``w_run``
 
 - The error "could not read pcoord from 'tempfile': progress coordinate has
   incorrect shape" may come about from multiple causes; it is possible that the

--- a/doc/users_guide/west/running.rst
+++ b/doc/users_guide/west/running.rst
@@ -34,6 +34,11 @@ By default, information about simulation progress is stored in
 **west-JOBID.log** (where JOBID refers to the job ID given by the submission
 engine); any errors will be logged here.
 
+The :ref:`w_progress` command can also be used to monitor a running or recently
+updated simulation. It reports the current iteration, segment
+completion counts, recent iteration timings, and an estimated time to
+completion when available.
+
 - The error "could not read pcoord from 'tempfile': progress coordinate has
   incorrect shape" may come about from multiple causes; it is possible that the
   progress coordinate length is incorrectly specified in system.py

--- a/doc/users_guide/west_tools.rst
+++ b/doc/users_guide/west_tools.rst
@@ -49,6 +49,8 @@ Command             Function
 :ref:`w_run`        Launches a simulation. Command arguments/environmental
                     variables can be included to specify the work managers and
                     simulation parameters
+:ref:`w_progress`   Monitors simulation progress from ``west.h5`` and reports
+                    iteration progress, segment completion, timing, and ETA.
 :ref:`w_truncate`   Truncates the weighted ensemble simulation from a given
                     iteration. 
 =================== ===========================================================

--- a/doc/users_guide/west_tools.rst
+++ b/doc/users_guide/west_tools.rst
@@ -49,8 +49,9 @@ Command             Function
 :ref:`w_run`        Launches a simulation. Command arguments/environmental
                     variables can be included to specify the work managers and
                     simulation parameters
-:ref:`w_progress`   Monitors simulation progress from ``west.h5`` and reports
-                    iteration progress, segment completion, timing, and ETA.
+:ref:`w_progress`   Monitors simulation progress from the live status sidecar
+                    or ``west.h5`` and reports iteration progress, segment
+                    completion, timing, and ETA.
 :ref:`w_truncate`   Truncates the weighted ensemble simulation from a given
                     iteration. 
 =================== ===========================================================

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ console_scripts_tools = [
     'w_multi_west = westpa.cli.tools.w_multi_west:entry_point',
     'w_red = westpa.cli.tools.w_red:entry_point',
     'w_timings = westpa.cli.tools.w_timings:entry_point',
+    'w_progress = westpa.cli.tools.w_progress:entry_point',
 ]
 
 

--- a/src/westpa/cli/core/w_run.py
+++ b/src/westpa/cli/core/w_run.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 
 import westpa
+from westpa.core.run_status import RUN_STATE_ERROR, RUN_STATE_INTERRUPTED
 import westpa.work_managers as work_managers
 from westpa.work_managers import make_work_manager
 
@@ -62,8 +63,20 @@ def run_simulation():
                 log.debug('finalizing run')
                 sim_manager.finalize_run()
             except KeyboardInterrupt:
+                sim_manager.write_run_status(
+                    'interrupted',
+                    run_state=RUN_STATE_INTERRUPTED,
+                    force=True,
+                    message='interrupted; shutting down',
+                )
                 westpa.rc.pstatus('interrupted; shutting down')
             except Exception as e:
+                sim_manager.write_run_status(
+                    'error',
+                    run_state=RUN_STATE_ERROR,
+                    force=True,
+                    message=str(e) or e.__class__.__name__,
+                )
                 westpa.rc.pstatus('exception caught; shutting down')
                 if str(e) != '':
                     log.error(f'error message: {e}')

--- a/src/westpa/cli/tools/w_progress.py
+++ b/src/westpa/cli/tools/w_progress.py
@@ -76,3 +76,30 @@ class WProgress(WESTTool):
             status_result,
         )
 
+    def render_once(self, include_hint=True):
+        sidecar_snapshot, sidecar_status = self.sidecar_snapshot()
+        if sidecar_snapshot is not None and sidecar_snapshot.run_state in ACTIVE_RUN_STATES:
+            return render_progress(sidecar_snapshot, refresh_interval=self.refresh_interval, include_hint=include_hint)
+
+        snapshot = self.snapshot()
+        if snapshot.error is None:
+            return render_progress(snapshot, refresh_interval=self.refresh_interval, include_hint=include_hint)
+
+        if sidecar_snapshot is not None and sidecar_snapshot.run_state == RUN_STATE_COMPLETE:
+            return render_progress(
+                sidecar_snapshot,
+                refresh_interval=self.refresh_interval,
+                include_hint=include_hint,
+                status_message=f'Could not read west.h5 ({snapshot.error}); showing the last live status snapshot instead.',
+            )
+
+        if sidecar_status.error:
+            return render_progress(
+                snapshot,
+                refresh_interval=self.refresh_interval,
+                include_hint=include_hint,
+                status_message=sidecar_status.error,
+            )
+
+        return render_progress(snapshot, refresh_interval=self.refresh_interval, include_hint=include_hint)
+

--- a/src/westpa/cli/tools/w_progress.py
+++ b/src/westpa/cli/tools/w_progress.py
@@ -21,3 +21,21 @@ class WProgress(WESTTool):
         self.refresh_interval = 1.0
         self.requested_total_iterations = None
 
+    def add_args(self, parser):
+        group = parser.add_argument_group('WEST input data options')
+        group.add_argument(
+            '-W',
+            '--west-data',
+            dest='we_h5filename',
+            metavar='WEST_H5FILE',
+            help='Take WEST data from WEST_H5FILE (default: read from the HDF5 file specified in west.cfg).',
+        )
+        group.add_argument(
+            '--refresh',
+            dest='refresh_interval',
+            type=float,
+            default=1.0,
+            metavar='SECONDS',
+            help='Refresh the dashboard every SECONDS seconds (default: 1.0).',
+        )
+

--- a/src/westpa/cli/tools/w_progress.py
+++ b/src/westpa/cli/tools/w_progress.py
@@ -1,0 +1,12 @@
+import sys
+import time
+
+import westpa
+from westpa.core.run_status import ACTIVE_RUN_STATES, RUN_STATE_COMPLETE, read_run_status
+from westpa.tools import WESTTool
+from westpa.tools.progress_status import (
+    progress_snapshot_from_run_status,
+    read_progress_snapshot,
+    render_progress,
+)
+

--- a/src/westpa/cli/tools/w_progress.py
+++ b/src/westpa/cli/tools/w_progress.py
@@ -39,3 +39,17 @@ class WProgress(WESTTool):
             help='Refresh the dashboard every SECONDS seconds (default: 1.0).',
         )
 
+    def process_args(self, args):
+        if args.refresh_interval <= 0:
+            self.parser.error('--refresh must be greater than 0')
+
+        data_manager = westpa.rc.get_data_manager()
+        if args.we_h5filename:
+            data_manager.we_h5filename = args.we_h5filename
+
+        self.we_h5filename = data_manager.we_h5filename
+        self.refresh_interval = args.refresh_interval
+
+        requested_total = westpa.rc.config.get(['west', 'propagation', 'max_total_iterations'], None)
+        self.requested_total_iterations = int(requested_total) if requested_total is not None else None
+

--- a/src/westpa/cli/tools/w_progress.py
+++ b/src/westpa/cli/tools/w_progress.py
@@ -103,3 +103,23 @@ class WProgress(WESTTool):
 
         return render_progress(snapshot, refresh_interval=self.refresh_interval, include_hint=include_hint)
 
+    def go(self):
+        try:
+            while True:
+                if self.should_clear:
+                    sys.stdout.write('\033[H\033[J')
+                sys.stdout.write(self.render_once())
+                sys.stdout.flush()
+                time.sleep(self.refresh_interval)
+        except KeyboardInterrupt:
+            if self.should_clear:
+                sys.stdout.write('\n')
+                sys.stdout.flush()
+
+
+def entry_point():
+    WProgress().main()
+
+
+if __name__ == '__main__':
+    entry_point()

--- a/src/westpa/cli/tools/w_progress.py
+++ b/src/westpa/cli/tools/w_progress.py
@@ -53,3 +53,26 @@ class WProgress(WESTTool):
         requested_total = westpa.rc.config.get(['west', 'propagation', 'max_total_iterations'], None)
         self.requested_total_iterations = int(requested_total) if requested_total is not None else None
 
+    @property
+    def should_clear(self):
+        return sys.stdout.isatty()
+
+    def snapshot(self):
+        return read_progress_snapshot(
+            self.we_h5filename,
+            requested_total_iterations=self.requested_total_iterations,
+            recent=5,
+        )
+
+    def sidecar_snapshot(self):
+        status_result = read_run_status(self.we_h5filename)
+        if status_result.status is None:
+            return None, status_result
+        return (
+            progress_snapshot_from_run_status(
+                status_result.status,
+                requested_total_iterations=self.requested_total_iterations,
+            ),
+            status_result,
+        )
+

--- a/src/westpa/cli/tools/w_progress.py
+++ b/src/westpa/cli/tools/w_progress.py
@@ -10,3 +10,14 @@ from westpa.tools.progress_status import (
     render_progress,
 )
 
+
+class WProgress(WESTTool):
+    prog = 'w_progress'
+    description = 'Show a live progress dashboard for a WESTPA simulation.'
+
+    def __init__(self):
+        super().__init__()
+        self.we_h5filename = None
+        self.refresh_interval = 1.0
+        self.requested_total_iterations = None
+

--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -24,6 +24,7 @@ class BinlessSimManager(WESimManager):
         log.debug("BinlessManager in use")
         segments = list(self.incomplete_segments.values())
         log.debug('iteration {:d}: propagating {:d} segments'.format(self.n_iter, len(segments)))
+        self.write_run_status('propagating', force=True)
 
         # all futures dispatched for this iteration
         futures = set()
@@ -62,6 +63,7 @@ class BinlessSimManager(WESimManager):
 
                 with self.data_manager.expiring_flushing_lock():
                     self.data_manager.update_segments(self.n_iter, incoming)
+                self.write_run_status('propagating')
 
             elif future in istate_gen_futures:
                 istate_gen_futures.remove(future)

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -27,6 +27,7 @@ class MABSimManager(WESimManager):
         log.debug("MABSimManager in use")
         segments = list(self.incomplete_segments.values())
         log.debug('iteration {:d}: propagating {:d} segments'.format(self.n_iter, len(segments)))
+        self.write_run_status('propagating', force=True)
 
         # all futures dispatched for this iteration
         futures = set()
@@ -65,6 +66,7 @@ class MABSimManager(WESimManager):
 
                 with self.data_manager.expiring_flushing_lock():
                     self.data_manager.update_segments(self.n_iter, incoming)
+                self.write_run_status('propagating')
 
             elif future in istate_gen_futures:
                 istate_gen_futures.remove(future)

--- a/src/westpa/core/run_status.py
+++ b/src/westpa/core/run_status.py
@@ -32,3 +32,26 @@ def status_path_for_h5(we_h5filename):
     return os.path.abspath(we_h5filename) + '.progress.json'
 
 
+def read_run_status(we_h5filename):
+    path = status_path_for_h5(we_h5filename)
+    try:
+        with open(path, 'r', encoding='utf-8') as status_file:
+            status = json.load(status_file)
+    except FileNotFoundError:
+        return RunStatusReadResult(path=path, missing=True)
+    except Exception as exc:
+        return RunStatusReadResult(path=path, error=f'Could not read live status file {path}: {exc}')
+
+    if not isinstance(status, dict):
+        return RunStatusReadResult(path=path, error=f'Live status file {path} does not contain a JSON object')
+
+    schema_version = status.get('schema_version')
+    if schema_version != SCHEMA_VERSION:
+        return RunStatusReadResult(
+            path=path,
+            error=f'Live status file {path} has unsupported schema version {schema_version!r}',
+        )
+
+    return RunStatusReadResult(path=path, status=status)
+
+

--- a/src/westpa/core/run_status.py
+++ b/src/westpa/core/run_status.py
@@ -61,3 +61,35 @@ def _json_default(value):
     raise TypeError(f'Object of type {value.__class__.__name__} is not JSON serializable')
 
 
+def write_run_status(we_h5filename, status):
+    path = status_path_for_h5(we_h5filename)
+    directory = os.path.dirname(path) or '.'
+    os.makedirs(directory, exist_ok=True)
+
+    payload = dict(status)
+    payload['schema_version'] = SCHEMA_VERSION
+    payload['west_h5file'] = os.path.abspath(we_h5filename)
+    payload.setdefault('updated_at', time.time())
+
+    tmp_name = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            'w',
+            encoding='utf-8',
+            dir=directory,
+            prefix=os.path.basename(path) + '.',
+            suffix='.tmp',
+            delete=False,
+        ) as tmp_file:
+            tmp_name = tmp_file.name
+            json.dump(payload, tmp_file, default=_json_default, sort_keys=True)
+            tmp_file.write('\n')
+        os.replace(tmp_name, path)
+    finally:
+        if tmp_name and os.path.exists(tmp_name):
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+
+

--- a/src/westpa/core/run_status.py
+++ b/src/westpa/core/run_status.py
@@ -20,3 +20,15 @@ RUN_STATE_ERROR = 'error'
 ACTIVE_RUN_STATES = {RUN_STATE_RUNNING, RUN_STATE_INTERRUPTED, RUN_STATE_ERROR}
 
 
+@dataclass
+class RunStatusReadResult:
+    path: str
+    status: dict | None = None
+    error: str | None = None
+    missing: bool = False
+
+
+def status_path_for_h5(we_h5filename):
+    return os.path.abspath(we_h5filename) + '.progress.json'
+
+

--- a/src/westpa/core/run_status.py
+++ b/src/westpa/core/run_status.py
@@ -11,7 +11,6 @@ import tempfile
 import time
 from dataclasses import dataclass
 
-
 SCHEMA_VERSION = 1
 RUN_STATE_RUNNING = 'running'
 RUN_STATE_COMPLETE = 'complete'

--- a/src/westpa/core/run_status.py
+++ b/src/westpa/core/run_status.py
@@ -55,3 +55,9 @@ def read_run_status(we_h5filename):
     return RunStatusReadResult(path=path, status=status)
 
 
+def _json_default(value):
+    if hasattr(value, 'item'):
+        return value.item()
+    raise TypeError(f'Object of type {value.__class__.__name__} is not JSON serializable')
+
+

--- a/src/westpa/core/run_status.py
+++ b/src/westpa/core/run_status.py
@@ -93,3 +93,18 @@ def write_run_status(we_h5filename, status):
                 pass
 
 
+class RunStatusWriter:
+    def __init__(self, we_h5filename, min_interval=1.0):
+        self.we_h5filename = we_h5filename
+        self.min_interval = float(min_interval)
+        self.last_write = 0.0
+
+    def write(self, status, force=False):
+        now = time.time()
+        if not force and now - self.last_write < self.min_interval:
+            return False
+        payload = dict(status)
+        payload['updated_at'] = now
+        write_run_status(self.we_h5filename, payload)
+        self.last_write = now
+        return True

--- a/src/westpa/core/run_status.py
+++ b/src/westpa/core/run_status.py
@@ -1,0 +1,22 @@
+"""Live run status sidecar support for ``w_progress``.
+
+The running ``w_run`` process owns ``west.h5`` while it is writing simulation
+data, so ``w_progress`` uses this lightweight JSON file for active-run
+monitoring and falls back to HDF5 for completed-run details.
+"""
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+
+
+SCHEMA_VERSION = 1
+RUN_STATE_RUNNING = 'running'
+RUN_STATE_COMPLETE = 'complete'
+RUN_STATE_INTERRUPTED = 'interrupted'
+RUN_STATE_ERROR = 'error'
+ACTIVE_RUN_STATES = {RUN_STATE_RUNNING, RUN_STATE_INTERRUPTED, RUN_STATE_ERROR}
+
+

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -668,6 +668,7 @@ class WESimManager:
     def propagate(self):
         segments = list(self.incomplete_segments.values())
         log.debug('iteration {:d}: propagating {:d} segments'.format(self.n_iter, len(segments)))
+        self.write_run_status('propagating', force=True)
 
         # all futures dispatched for this iteration
         futures = set()
@@ -707,6 +708,7 @@ class WESimManager:
 
                 with self.data_manager.expiring_flushing_lock():
                     self.data_manager.update_segments(self.n_iter, incoming)
+                self.write_run_status('propagating')
 
             elif future in istate_gen_futures:
                 istate_gen_futures.remove(future)
@@ -832,6 +834,12 @@ class WESimManager:
 
         self.n_iter = self.data_manager.current_iteration
         max_iter = self.max_total_iterations or self.n_iter + 1
+        (
+            self.run_status_recent_walltimes,
+            self.run_status_completed_walltime,
+            self.run_status_completed_segments,
+        ) = self._summary_progress()
+        self.write_run_status('starting', force=True)
 
         iter_elapsed = 0
         while self.n_iter <= max_iter:

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -137,6 +137,48 @@ class WESimManager:
                 failed += 1
         return total, prepared, failed
 
+    def write_run_status(self, phase, run_state=RUN_STATE_RUNNING, force=False, message=None):
+        if self.run_status_writer is None:
+            try:
+                self.run_status_writer = RunStatusWriter(self.data_manager.we_h5filename)
+            except Exception:
+                return False
+
+        current_iteration = self.n_iter
+        if current_iteration is None:
+            try:
+                current_iteration = self.data_manager.current_iteration
+            except Exception:
+                current_iteration = None
+
+        latest_completed_iteration = None
+        if current_iteration is not None:
+            latest_completed_iteration = max(int(current_iteration) - 1, 0)
+
+        segment_total, segment_prepared, segment_failed = self._status_segment_counts()
+        try:
+            return self.run_status_writer.write(
+                {
+                    'run_state': run_state,
+                    'phase': phase,
+                    'current_iteration': current_iteration,
+                    'latest_completed_iteration': latest_completed_iteration,
+                    'requested_total_iterations': self.max_total_iterations,
+                    'segment_total': segment_total,
+                    'segment_prepared': segment_prepared,
+                    'segment_failed': segment_failed,
+                    'iteration_started_at': self.iteration_started_at,
+                    'recent_walltimes': self.run_status_recent_walltimes[-5:],
+                    'completed_walltime': self.run_status_completed_walltime,
+                    'completed_segments': self.run_status_completed_segments,
+                    'message': message,
+                },
+                force=force,
+            )
+        except Exception:
+            log.debug('could not write live run status', exc_info=True)
+            return False
+
     def register_callback(self, hook, function, priority=0):
         '''Registers a callback to execute during the given ``hook`` into the simulation loop. The optional
         priority is used to order when the function is called relative to other registered callbacks.'''

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -101,6 +101,7 @@ class WESimManager:
         self.run_status_recent_walltimes = []
         self.run_status_completed_walltime = 0.0
         self.run_status_completed_segments = 0
+        self.iteration_started_at = None
         # Pseudo Random Number Generator
         self.rng = Generator(MT19937())
 

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -106,6 +106,25 @@ class WESimManager:
         # Pseudo Random Number Generator
         self.rng = Generator(MT19937())
 
+    def _summary_progress(self, recent=5):
+        try:
+            current_iteration = self.data_manager.current_iteration
+            if current_iteration <= 1:
+                return [], 0.0, 0
+            rows = self.data_manager.we_h5file['summary'][: current_iteration - 1]
+        except Exception:
+            return [], 0.0, 0
+
+        walltimes = []
+        for value in rows['walltime']:
+            value = float(value)
+            if math.isfinite(value) and value > 0:
+                walltimes.append(value)
+
+        completed_walltime = sum(float(value) for value in rows['walltime'] if math.isfinite(float(value)))
+        completed_segments = int(rows['n_particles'].sum()) if 'n_particles' in rows.dtype.names else 0
+        return walltimes[-recent:], completed_walltime, completed_segments
+
     def register_callback(self, hook, function, priority=0):
         '''Registers a callback to execute during the given ``hook`` into the simulation loop. The optional
         priority is used to order when the function is called relative to other registered callbacks.'''

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -12,6 +12,7 @@ from numpy.random import Generator, MT19937
 
 import westpa
 from .data_manager import weight_dtype
+from .run_status import RUN_STATE_COMPLETE, RUN_STATE_INTERRUPTED, RUN_STATE_RUNNING, RunStatusWriter
 from .segment import Segment
 from .states import InitialState
 from . import extloader

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -100,6 +100,7 @@ class WESimManager:
         self.run_status_writer = None
         self.run_status_recent_walltimes = []
         self.run_status_completed_walltime = 0.0
+        self.run_status_completed_segments = 0
         # Pseudo Random Number Generator
         self.rng = Generator(MT19937())
 

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -846,6 +846,11 @@ class WESimManager:
             if max_walltime and time.time() + 1.1 * iter_elapsed >= run_killtime:
                 self.rc.pstatus('Iteration {:d} would require more than the allotted time. Ending run.'.format(self.n_iter))
                 self.write_run_status(
+                    'stopping',
+                    run_state=RUN_STATE_INTERRUPTED,
+                    force=True,
+                    message='Iteration would require more than the allotted time.',
+                )
                 return
 
             try:

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -96,6 +96,7 @@ class WESimManager:
         # Tracking of binning
         self.bin_mapper_hash = None  # Hash of bin mapper from most recently-run WE, for use by post-WE analysis plugins
 
+        # Live status sidecar used by w_progress while west.h5 is locked by w_run.
         # Pseudo Random Number Generator
         self.rng = Generator(MT19937())
 

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -97,6 +97,7 @@ class WESimManager:
         self.bin_mapper_hash = None  # Hash of bin mapper from most recently-run WE, for use by post-WE analysis plugins
 
         # Live status sidecar used by w_progress while west.h5 is locked by w_run.
+        self.run_status_writer = None
         # Pseudo Random Number Generator
         self.rng = Generator(MT19937())
 

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -102,6 +102,7 @@ class WESimManager:
         self.run_status_completed_walltime = 0.0
         self.run_status_completed_segments = 0
         self.iteration_started_at = None
+
         # Pseudo Random Number Generator
         self.rng = Generator(MT19937())
 

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -99,6 +99,7 @@ class WESimManager:
         # Live status sidecar used by w_progress while west.h5 is locked by w_run.
         self.run_status_writer = None
         self.run_status_recent_walltimes = []
+        self.run_status_completed_walltime = 0.0
         # Pseudo Random Number Generator
         self.rng = Generator(MT19937())
 

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -855,16 +855,20 @@ class WESimManager:
 
             try:
                 iter_start_time = time.time()
+                self.iteration_started_at = iter_start_time
 
                 self.rc.pstatus('\n%s' % time.asctime())
                 self.rc.pstatus('Iteration %d (%d requested)' % (self.n_iter, max_iter))
 
+                self.write_run_status('preparing iteration', force=True)
                 self.prepare_iteration()
                 self.rc.pflush()
 
+                self.write_run_status('propagating', force=True)
                 self.pre_propagation()
                 self.propagate()
                 self.rc.pflush()
+                self.write_run_status('checking propagation', force=True)
                 self.check_propagation()
                 self.rc.pflush()
                 self.post_propagation()
@@ -872,13 +876,16 @@ class WESimManager:
                 cputime = sum(segment.cputime for segment in self.segments.values())
 
                 self.rc.pflush()
+                self.write_run_status('weighted ensemble', force=True)
                 self.pre_we()
                 self.run_we()
                 self.post_we()
                 self.rc.pflush()
 
+                self.write_run_status('preparing next iteration', force=True)
                 self.prepare_new_iteration()
 
+                self.write_run_status('finalizing iteration', force=True)
                 self.finalize_iteration()
 
                 iter_elapsed = time.time() - iter_start_time

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -893,9 +893,14 @@ class WESimManager:
                 iter_summary['walltime'] += iter_elapsed
                 iter_summary['cputime'] = cputime
                 self.data_manager.update_iter_summary(iter_summary)
+                self.run_status_recent_walltimes.append(float(iter_elapsed))
+                self.run_status_recent_walltimes = self.run_status_recent_walltimes[-5:]
+                self.run_status_completed_walltime += float(iter_elapsed)
+                self.run_status_completed_segments += int(iter_summary['n_particles'])
 
                 self.n_iter += 1
                 self.data_manager.current_iteration += 1
+                self.write_run_status('iteration complete', force=True)
 
                 try:
                     # This may give NaN if starting a truncated simulation
@@ -915,6 +920,7 @@ class WESimManager:
 
         self.rc.pstatus('\n%s' % time.asctime())
         self.rc.pstatus('WEST run complete.')
+        self.write_run_status('complete', run_state=RUN_STATE_COMPLETE, force=True)
 
     def prepare_run(self):
         '''Prepare a new run.'''

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -837,6 +837,7 @@ class WESimManager:
         while self.n_iter <= max_iter:
             if max_walltime and time.time() + 1.1 * iter_elapsed >= run_killtime:
                 self.rc.pstatus('Iteration {:d} would require more than the allotted time. Ending run.'.format(self.n_iter))
+                self.write_run_status(
                 return
 
             try:

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -98,6 +98,7 @@ class WESimManager:
 
         # Live status sidecar used by w_progress while west.h5 is locked by w_run.
         self.run_status_writer = None
+        self.run_status_recent_walltimes = []
         # Pseudo Random Number Generator
         self.rng = Generator(MT19937())
 

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -125,6 +125,18 @@ class WESimManager:
         completed_segments = int(rows['n_particles'].sum()) if 'n_particles' in rows.dtype.names else 0
         return walltimes[-recent:], completed_walltime, completed_segments
 
+    def _status_segment_counts(self):
+        segments = self.segments or {}
+        total = len(segments)
+        prepared = 0
+        failed = 0
+        for segment in segments.values():
+            if segment.status == Segment.SEG_STATUS_PREPARED:
+                prepared += 1
+            elif segment.status == Segment.SEG_STATUS_FAILED:
+                failed += 1
+        return total, prepared, failed
+
     def register_callback(self, hook, function, priority=0):
         '''Registers a callback to execute during the given ``hook`` into the simulation loop. The optional
         priority is used to order when the function is called relative to other registered callbacks.'''

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -20,3 +20,59 @@ class SegmentStatusCounts:
     other: int = 0
 
 
+@dataclass
+class ProgressSnapshot:
+    we_h5filename: str
+    updated_at: float
+    h5_mtime: float | None = None
+    current_iteration: int | None = None
+    latest_completed_iteration: int | None = None
+    requested_total_iterations: int | None = None
+    current_status_counts: SegmentStatusCounts = field(default_factory=SegmentStatusCounts)
+    recent_walltimes: list[float] = field(default_factory=list)
+    average_recent_walltime: float | None = None
+    eta_seconds: float | None = None
+    completed_walltime: float | None = None
+    completed_segments: int | None = None
+    error: str | None = None
+    run_state: str | None = None
+    phase: str | None = None
+    status_updated_at: float | None = None
+    current_iteration_elapsed: float | None = None
+    message: str | None = None
+
+
+
+
+def _current_iteration(h5file):
+    attrs = h5file.attrs
+    if 'west_current_iteration' in attrs:
+        return int(attrs['west_current_iteration'])
+    if 'wemd_current_iteration' in attrs:
+        return int(attrs['wemd_current_iteration'])
+    return None
+
+
+def _segment_status_counts(iter_group):
+    try:
+        statuses = iter_group['seg_index']['status'][:]
+    except KeyError:
+        return SegmentStatusCounts()
+
+    total = len(statuses)
+    unset = int(np.count_nonzero(statuses == Segment.SEG_STATUS_UNSET))
+    prepared = int(np.count_nonzero(statuses == Segment.SEG_STATUS_PREPARED))
+    complete = int(np.count_nonzero(statuses == Segment.SEG_STATUS_COMPLETE))
+    failed = int(np.count_nonzero(statuses == Segment.SEG_STATUS_FAILED))
+    other = total - unset - prepared - complete - failed
+
+    return SegmentStatusCounts(
+        total=total,
+        unset=unset,
+        prepared=prepared,
+        complete=complete,
+        failed=failed,
+        other=other,
+    )
+
+

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -177,3 +177,75 @@ def read_progress_snapshot(we_h5filename, requested_total_iterations=None, recen
     return snapshot
 
 
+def progress_snapshot_from_run_status(status, requested_total_iterations=None, now=None):
+    now = time.time() if now is None else now
+    west_h5file = status.get('west_h5file', 'unknown')
+    status_updated_at = status.get('updated_at')
+    h5_mtime = None
+    if west_h5file != 'unknown':
+        try:
+            h5_mtime = os.path.getmtime(west_h5file)
+        except OSError:
+            h5_mtime = None
+
+    segment_total = int(status.get('segment_total') or 0)
+    segment_prepared = int(status.get('segment_prepared') or 0)
+    segment_failed = int(status.get('segment_failed') or 0)
+    recent_walltimes = []
+    for value in status.get('recent_walltimes', []):
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            continue
+        if _finite_positive(value):
+            recent_walltimes.append(value)
+    average_recent_walltime = None
+    if recent_walltimes:
+        average_recent_walltime = float(sum(recent_walltimes) / len(recent_walltimes))
+
+    requested_total = status.get('requested_total_iterations', requested_total_iterations)
+    if requested_total is not None:
+        requested_total = int(requested_total)
+
+    latest_completed = status.get('latest_completed_iteration')
+    if latest_completed is not None:
+        latest_completed = int(latest_completed)
+
+    current_iteration = status.get('current_iteration')
+    if current_iteration is not None:
+        current_iteration = int(current_iteration)
+
+    iteration_started_at = status.get('iteration_started_at')
+    current_iteration_elapsed = None
+    if iteration_started_at is not None:
+        current_iteration_elapsed = max(now - float(iteration_started_at), 0.0)
+
+    eta_seconds = _eta_seconds(requested_total, latest_completed, average_recent_walltime)
+    if status.get('run_state') == RUN_STATE_COMPLETE:
+        eta_seconds = 0
+
+    return ProgressSnapshot(
+        we_h5filename=west_h5file,
+        updated_at=now,
+        h5_mtime=h5_mtime,
+        current_iteration=current_iteration,
+        latest_completed_iteration=latest_completed,
+        requested_total_iterations=requested_total,
+        current_status_counts=SegmentStatusCounts(
+            total=segment_total,
+            prepared=segment_prepared,
+            failed=segment_failed,
+        ),
+        recent_walltimes=recent_walltimes,
+        average_recent_walltime=average_recent_walltime,
+        eta_seconds=eta_seconds,
+        completed_walltime=status.get('completed_walltime'),
+        completed_segments=status.get('completed_segments'),
+        run_state=status.get('run_state'),
+        phase=status.get('phase'),
+        status_updated_at=float(status_updated_at) if status_updated_at is not None else None,
+        current_iteration_elapsed=current_iteration_elapsed,
+        message=status.get('message'),
+    )
+
+

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -287,3 +287,12 @@ def _line(label, value, width=28):
     return f'{label:<{width}}{value}'
 
 
+def _progress_text(latest_completed_iteration, requested_total_iterations):
+    if latest_completed_iteration is None:
+        return 'unknown'
+    if requested_total_iterations is None or requested_total_iterations <= 0:
+        return f'{latest_completed_iteration} completed'
+    percent = 100.0 * latest_completed_iteration / requested_total_iterations
+    return f'{latest_completed_iteration} / {requested_total_iterations} iterations ({percent:.1f}%)'
+
+

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -106,3 +106,23 @@ def _summary_rows(h5file, latest_completed_iteration):
     return summary[:stop]
 
 
+def _walltimes(rows, recent):
+    if rows is None or 'walltime' not in rows.dtype.names:
+        return []
+    values = [float(value) for value in rows['walltime'] if _finite_positive(float(value))]
+    return values[-recent:]
+
+
+def _completed_walltime(rows):
+    if rows is None or 'walltime' not in rows.dtype.names:
+        return None
+    values = [float(value) for value in rows['walltime'] if np.isfinite(float(value))]
+    return float(sum(values))
+
+
+def _completed_segments(rows):
+    if rows is None or 'n_particles' not in rows.dtype.names:
+        return None
+    return int(rows['n_particles'].sum())
+
+

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -1,0 +1,22 @@
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import numpy as np
+
+from westpa.core.h5io import WESTPAH5File
+from westpa.core.run_status import RUN_STATE_COMPLETE
+from westpa.core.segment import Segment
+
+
+@dataclass
+class SegmentStatusCounts:
+    total: int = 0
+    unset: int = 0
+    prepared: int = 0
+    complete: int = 0
+    failed: int = 0
+    other: int = 0
+
+

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -296,3 +296,81 @@ def _progress_text(latest_completed_iteration, requested_total_iterations):
     return f'{latest_completed_iteration} / {requested_total_iterations} iterations ({percent:.1f}%)'
 
 
+def render_progress(snapshot, refresh_interval=None, include_hint=True, status_message=None):
+    lines = [
+        'WESTPA Progress',
+        f'Data file: {snapshot.we_h5filename}',
+        f'Updated: {_format_timestamp(snapshot.updated_at)}    west.h5 modified: {_format_timestamp(snapshot.h5_mtime)}',
+        '',
+    ]
+
+    if status_message:
+        lines.extend(
+            [
+                'Status',
+                status_message,
+                '',
+            ]
+        )
+
+    if snapshot.run_state or snapshot.phase or snapshot.message:
+        lines.append('Run Status')
+        if snapshot.run_state:
+            lines.append(_line('Run state:', _format_status_value(snapshot.run_state)))
+        if snapshot.phase:
+            lines.append(_line('Phase:', _format_status_value(snapshot.phase)))
+        if snapshot.status_updated_at is not None:
+            lines.append(_line('Live status updated:', _format_timestamp(snapshot.status_updated_at)))
+        if snapshot.message:
+            lines.append(_line('Message:', snapshot.message))
+        lines.append('')
+
+    if snapshot.error:
+        lines.extend(
+            [
+                'Status',
+                _line('Error:', snapshot.error),
+                '',
+            ]
+        )
+    else:
+        counts = snapshot.current_status_counts
+        lines.extend(
+            [
+                'Iterations',
+                _line('Current iteration:', _format_value(snapshot.current_iteration)),
+                _line('Latest completed:', _format_value(snapshot.latest_completed_iteration)),
+                _line('Requested total:', _format_value(snapshot.requested_total_iterations)),
+                _line('Progress:', _progress_text(snapshot.latest_completed_iteration, snapshot.requested_total_iterations)),
+                '',
+                'Current Iteration Segments',
+                _line('Prepared:', f'{counts.prepared} / {counts.total}'),
+                _line('Failed:', f'{counts.failed} / {counts.total}'),
+            ]
+        )
+
+        if snapshot.recent_walltimes:
+            recent_walltimes = ', '.join(format_duration(value) for value in snapshot.recent_walltimes)
+        else:
+            recent_walltimes = 'unknown'
+
+        lines.extend(
+            [
+                '',
+                'Timing',
+                _line('Recent walltimes:', recent_walltimes),
+                _line('Current iter elapsed:', format_duration(snapshot.current_iteration_elapsed)),
+                _line('Avg iteration time:', format_duration(snapshot.average_recent_walltime)),
+                _line('Completed walltime:', format_duration(snapshot.completed_walltime)),
+                _line('ETA:', format_duration(snapshot.eta_seconds)),
+                '',
+                _line('Completed segments:', _format_value(snapshot.completed_segments)),
+            ]
+        )
+
+    if refresh_interval is not None:
+        lines.append(_line('Refresh Rate:', format_duration(refresh_interval)))
+    if include_hint:
+        lines.append('Press Ctrl-C to close')
+
+    return '\n'.join(lines) + '\n'

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -85,3 +85,24 @@ def _segment_status_counts(iter_group):
     )
 
 
+def _latest_completed_iteration(current_iteration, status_counts):
+    if current_iteration is None:
+        return None
+    if status_counts.total and status_counts.complete == status_counts.total:
+        return current_iteration
+    return max(current_iteration - 1, 0)
+
+
+def _summary_rows(h5file, latest_completed_iteration):
+    if latest_completed_iteration is None or latest_completed_iteration <= 0:
+        return None
+    try:
+        summary = h5file['summary']
+    except KeyError:
+        return None
+    stop = min(latest_completed_iteration, len(summary))
+    if stop <= 0:
+        return None
+    return summary[:stop]
+
+

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -42,6 +42,15 @@ class ProgressSnapshot:
     message: str | None = None
 
 
+def _finite_positive(value):
+    return value is not None and np.isfinite(value) and value > 0
+
+
+def _h5_iter_group(h5file, n_iter):
+    try:
+        return h5file.get_iter_group(n_iter)
+    except KeyError:
+        return h5file[f'/iter_{int(n_iter):0{h5file.iter_prec}d}']
 
 
 def _current_iteration(h5file):

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -135,3 +135,45 @@ def _eta_seconds(requested_total_iterations, latest_completed_iteration, average
     return remaining_iterations * average_recent_walltime
 
 
+def read_progress_snapshot(we_h5filename, requested_total_iterations=None, recent=5, now=None):
+    now = time.time() if now is None else now
+    snapshot = ProgressSnapshot(
+        we_h5filename=we_h5filename,
+        requested_total_iterations=requested_total_iterations,
+        updated_at=now,
+    )
+
+    try:
+        snapshot.h5_mtime = os.path.getmtime(we_h5filename)
+        with WESTPAH5File(we_h5filename, 'r') as h5file:
+            current_iteration = _current_iteration(h5file)
+            snapshot.current_iteration = current_iteration
+
+            status_counts = SegmentStatusCounts()
+            if current_iteration is not None and current_iteration > 0:
+                try:
+                    status_counts = _segment_status_counts(_h5_iter_group(h5file, current_iteration))
+                except KeyError:
+                    status_counts = SegmentStatusCounts()
+            snapshot.current_status_counts = status_counts
+
+            latest_completed = _latest_completed_iteration(current_iteration, status_counts)
+            snapshot.latest_completed_iteration = latest_completed
+
+            rows = _summary_rows(h5file, latest_completed)
+            snapshot.recent_walltimes = _walltimes(rows, recent)
+            if snapshot.recent_walltimes:
+                snapshot.average_recent_walltime = float(sum(snapshot.recent_walltimes) / len(snapshot.recent_walltimes))
+            snapshot.completed_walltime = _completed_walltime(rows)
+            snapshot.completed_segments = _completed_segments(rows)
+            snapshot.eta_seconds = _eta_seconds(
+                requested_total_iterations,
+                latest_completed,
+                snapshot.average_recent_walltime,
+            )
+    except Exception as exc:
+        snapshot.error = str(exc)
+
+    return snapshot
+
+

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -249,3 +249,23 @@ def progress_snapshot_from_run_status(status, requested_total_iterations=None, n
     )
 
 
+def format_duration(seconds):
+    if seconds is None or not np.isfinite(seconds):
+        return 'unknown'
+    seconds = float(seconds)
+    if seconds < 60:
+        return f'{seconds:.1f}s'
+
+    seconds = int(round(seconds))
+    minutes, seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f'{minutes}m {seconds:02d}s'
+
+    hours, minutes = divmod(minutes, 60)
+    if hours < 24:
+        return f'{hours}h {minutes:02d}m {seconds:02d}s'
+
+    days, hours = divmod(hours, 24)
+    return f'{days}d {hours:02d}h {minutes:02d}m'
+
+

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -126,3 +126,12 @@ def _completed_segments(rows):
     return int(rows['n_particles'].sum())
 
 
+def _eta_seconds(requested_total_iterations, latest_completed_iteration, average_recent_walltime):
+    if requested_total_iterations is None or latest_completed_iteration is None:
+        return None
+    if not _finite_positive(average_recent_walltime):
+        return None
+    remaining_iterations = max(requested_total_iterations - latest_completed_iteration, 0)
+    return remaining_iterations * average_recent_walltime
+
+

--- a/src/westpa/tools/progress_status.py
+++ b/src/westpa/tools/progress_status.py
@@ -269,3 +269,21 @@ def format_duration(seconds):
     return f'{days}d {hours:02d}h {minutes:02d}m'
 
 
+def _format_timestamp(timestamp):
+    if timestamp is None:
+        return 'unknown'
+    return datetime.fromtimestamp(timestamp).strftime('%H:%M:%S')
+
+
+def _format_value(value):
+    return 'unknown' if value is None else str(value)
+
+
+def _format_status_value(value):
+    return 'unknown' if value is None else str(value).replace('_', ' ').title()
+
+
+def _line(label, value, width=28):
+    return f'{label:<{width}}{value}'
+
+

--- a/tests/test_core/test_run_status.py
+++ b/tests/test_core/test_run_status.py
@@ -30,3 +30,22 @@ class Test_Run_Status:
         assert result.status['phase'] == 'propagating'
         assert result.status['current_iteration'] == 3
 
+    def test_missing_status(self, tmp_path):
+        result = read_run_status(str(tmp_path / 'west.h5'))
+
+        assert result.status is None
+        assert result.error is None
+        assert result.missing is True
+
+    def test_invalid_json_status(self, tmp_path):
+        h5file = tmp_path / 'west.h5'
+        status_path = status_path_for_h5(str(h5file))
+        with open(status_path, 'w', encoding='utf-8') as status_file:
+            status_file.write('{not json')
+
+        result = read_run_status(str(h5file))
+
+        assert result.status is None
+        assert result.error is not None
+        assert 'Could not read live status file' in result.error
+

--- a/tests/test_core/test_run_status.py
+++ b/tests/test_core/test_run_status.py
@@ -1,0 +1,5 @@
+import json
+
+from westpa.core.run_status import SCHEMA_VERSION, read_run_status, status_path_for_h5, write_run_status
+
+

--- a/tests/test_core/test_run_status.py
+++ b/tests/test_core/test_run_status.py
@@ -49,3 +49,14 @@ class Test_Run_Status:
         assert result.error is not None
         assert 'Could not read live status file' in result.error
 
+    def test_unsupported_schema_status(self, tmp_path):
+        h5file = tmp_path / 'west.h5'
+        status_path = status_path_for_h5(str(h5file))
+        with open(status_path, 'w', encoding='utf-8') as status_file:
+            json.dump({'schema_version': 999}, status_file)
+
+        result = read_run_status(str(h5file))
+
+        assert result.status is None
+        assert result.error is not None
+        assert 'unsupported schema version' in result.error

--- a/tests/test_core/test_run_status.py
+++ b/tests/test_core/test_run_status.py
@@ -3,3 +3,30 @@ import json
 from westpa.core.run_status import SCHEMA_VERSION, read_run_status, status_path_for_h5, write_run_status
 
 
+class Test_Run_Status:
+    def test_status_path_for_h5(self, tmp_path):
+        h5file = tmp_path / 'west.h5'
+
+        assert status_path_for_h5(str(h5file)) == str(h5file) + '.progress.json'
+
+    def test_write_and_read_status(self, tmp_path):
+        h5file = tmp_path / 'west.h5'
+
+        write_run_status(
+            str(h5file),
+            {
+                'run_state': 'running',
+                'phase': 'propagating',
+                'current_iteration': 3,
+            },
+        )
+        result = read_run_status(str(h5file))
+
+        assert result.error is None
+        assert result.missing is False
+        assert result.status['schema_version'] == SCHEMA_VERSION
+        assert result.status['west_h5file'] == str(h5file)
+        assert result.status['run_state'] == 'running'
+        assert result.status['phase'] == 'propagating'
+        assert result.status['current_iteration'] == 3
+

--- a/tests/test_sim_manager.py
+++ b/tests/test_sim_manager.py
@@ -94,6 +94,35 @@ class TestSimManager(TestCase):
         self.assertEqual(self.sim_manager.n_propagated, 0)
         self.assertEqual(len(self.sim_manager._callback_table), 0)
 
+    def test_write_run_status_counts_segments(self):
+        self.sim_manager.run_status_writer = MagicMock()
+        self.sim_manager.max_total_iterations = 10
+        self.sim_manager.n_iter = 3
+        self.sim_manager.iteration_started_at = 123.0
+        self.sim_manager.run_status_completed_walltime = 12.5
+        self.sim_manager.run_status_completed_segments = 8
+        self.segments[0].status = Segment.SEG_STATUS_COMPLETE
+        self.segments[1].status = Segment.SEG_STATUS_FAILED
+        for segment in self.segments[2:]:
+            segment.status = Segment.SEG_STATUS_PREPARED
+        self.sim_manager.segments = {seg_id: segment for seg_id, segment in enumerate(self.segments)}
+
+        self.sim_manager.write_run_status('propagating', force=True)
+
+        status = self.sim_manager.run_status_writer.write.call_args.args[0]
+        assert status['phase'] == 'propagating'
+        assert status['run_state'] == 'running'
+        assert status['current_iteration'] == 3
+        assert status['latest_completed_iteration'] == 2
+        assert status['requested_total_iterations'] == 10
+        assert status['segment_total'] == len(self.segments)
+        assert status['segment_prepared'] == len(self.segments) - 2
+        assert status['segment_failed'] == 1
+        assert status['iteration_started_at'] == 123.0
+        assert status['completed_walltime'] == 12.5
+        assert status['completed_segments'] == 8
+        assert self.sim_manager.run_status_writer.write.call_args.kwargs['force'] is True
+
     def test_register_callback(self):
         hook = self.sim_manager.prepare_new_iteration
 

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -148,9 +148,7 @@ class Test_W_Progress:
     def test_render_once_running_sidecar_does_not_open_hdf5(self, ref_50iter):
         tool = WProgress()
         tool.we_h5filename = self.h5_filepath
-        live_snapshot = progress_snapshot_from_run_status(
-            live_status(west_h5file=self.h5_filepath)
-        )
+        live_snapshot = progress_snapshot_from_run_status(live_status(west_h5file=self.h5_filepath))
 
         with mock.patch.object(tool, 'sidecar_snapshot', return_value=(live_snapshot, RunStatusReadResult(path='status'))):
             with mock.patch.object(tool, 'snapshot', side_effect=AssertionError('west.h5 should not be opened')):

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -97,3 +97,23 @@ class Test_W_Progress:
         assert 'ETA:' in output
         assert '2m 54s' in output
 
+    def test_format_duration(self):
+        assert format_duration(None) == 'unknown'
+        assert format_duration(12.4) == '12.4s'
+        assert format_duration(174.0) == '2m 54s'
+        assert format_duration(3723.0) == '1h 02m 03s'
+
+    def test_render_status_message(self):
+        snapshot = ProgressSnapshot(
+            we_h5filename='west.h5',
+            updated_at=0,
+            h5_mtime=0,
+            current_iteration=1,
+            latest_completed_iteration=0,
+        )
+
+        output = render_progress(snapshot, status_message='Using live status data.')
+
+        assert 'Status' in output
+        assert 'Using live status data.' in output
+

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -68,3 +68,32 @@ class Test_W_Progress:
         assert 'Error:' in output
         assert 'missing-west.h5' in output
 
+    def test_render_progress(self):
+        snapshot = ProgressSnapshot(
+            we_h5filename='west.h5',
+            updated_at=0,
+            h5_mtime=0,
+            current_iteration=37,
+            latest_completed_iteration=36,
+            requested_total_iterations=50,
+            current_status_counts=SegmentStatusCounts(total=100, prepared=18, failed=2),
+            recent_walltimes=[12.4, 11.8, 13.1],
+            average_recent_walltime=12.433333333333334,
+            eta_seconds=174.06666666666666,
+            completed_walltime=642,
+            completed_segments=9985,
+        )
+
+        output = render_progress(snapshot, refresh_interval=1.0)
+
+        assert 'WESTPA Progress' in output
+        assert 'Current iteration:' in output
+        assert '37' in output
+        assert '36 / 50 iterations (72.0%)' in output
+        assert '18 / 100' in output
+        assert '2 / 100' in output
+        assert 'Recent walltimes:' in output
+        assert '12.4s, 11.8s, 13.1s' in output
+        assert 'ETA:' in output
+        assert '2m 54s' in output
+

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -48,3 +48,23 @@ class Test_W_Progress:
         assert snapshot.average_recent_walltime > 0
         assert snapshot.eta_seconds == 0
 
+    def test_snapshot_initialized_run(self, ref_initialized):
+        snapshot = read_progress_snapshot(self.h5_filepath, requested_total_iterations=2, recent=5)
+
+        assert snapshot.error is None
+        assert snapshot.current_iteration == 1
+        assert snapshot.latest_completed_iteration == 0
+        assert snapshot.current_status_counts.total > 0
+        assert snapshot.current_status_counts.complete == 0
+        assert snapshot.current_status_counts.prepared == snapshot.current_status_counts.total
+        assert snapshot.completed_segments is None
+        assert snapshot.eta_seconds is None
+
+    def test_missing_file_is_error_snapshot(self, ref_50iter):
+        snapshot = read_progress_snapshot('missing-west.h5', requested_total_iterations=50, recent=5)
+        output = render_progress(snapshot, refresh_interval=1.0)
+
+        assert snapshot.error is not None
+        assert 'Error:' in output
+        assert 'missing-west.h5' in output
+

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -1,0 +1,15 @@
+import argparse
+from unittest import mock
+
+from westpa.cli.tools.w_progress import WProgress, entry_point
+from westpa.core.run_status import RUN_STATE_COMPLETE, RUN_STATE_RUNNING, RunStatusReadResult
+from westpa.tools.progress_status import (
+    ProgressSnapshot,
+    SegmentStatusCounts,
+    format_duration,
+    progress_snapshot_from_run_status,
+    read_progress_snapshot,
+    render_progress,
+)
+
+

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -159,3 +159,24 @@ class Test_W_Progress:
         assert 'Run state:                  Running' in output
         assert 'Current iteration:          37' in output
 
+    def test_render_once_complete_sidecar_prefers_readable_hdf5(self, ref_50iter):
+        tool = WProgress()
+        tool.we_h5filename = self.h5_filepath
+        sidecar_snapshot = progress_snapshot_from_run_status(
+            live_status(west_h5file=self.h5_filepath, run_state=RUN_STATE_COMPLETE, phase='complete', segment_prepared=0)
+        )
+        hdf5_snapshot = ProgressSnapshot(
+            we_h5filename=self.h5_filepath,
+            updated_at=1,
+            current_iteration=51,
+            latest_completed_iteration=50,
+            requested_total_iterations=50,
+        )
+
+        with mock.patch.object(tool, 'sidecar_snapshot', return_value=(sidecar_snapshot, RunStatusReadResult(path='status'))):
+            with mock.patch.object(tool, 'snapshot', return_value=hdf5_snapshot):
+                output = tool.render_once(include_hint=False)
+
+        assert 'Current iteration:          51' in output
+        assert 'Run state:' not in output
+

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -208,3 +208,29 @@ class Test_W_Progress:
         assert 'Run state:                  Complete' in output
         assert 'Error:' not in output
 
+    def test_render_once_hdf5_error_renders_error(self, ref_50iter):
+        tool = WProgress()
+        tool.we_h5filename = self.h5_filepath
+        error_snapshot = ProgressSnapshot(we_h5filename='missing-west.h5', updated_at=1, error='No such file or directory')
+
+        with mock.patch.object(tool, 'snapshot', return_value=error_snapshot):
+            output = tool.render_once(include_hint=False)
+
+        assert 'No such file or directory' in output
+        assert 'Current iteration:          37' not in output
+
+    def test_entry_point_renders_once(self, ref_50iter, capsys):
+        args = argparse.Namespace(
+            verbosity='quiet',
+            rcfile=self.cfg_filepath,
+            we_h5filename=self.h5_filepath,
+            refresh_interval=1.0,
+        )
+
+        with mock.patch('argparse.ArgumentParser.parse_args', return_value=args):
+            with mock.patch('time.sleep', side_effect=KeyboardInterrupt):
+                entry_point()
+
+        captured = capsys.readouterr()
+        assert 'WESTPA Progress' in captured.out
+        assert self.h5_filepath in captured.out

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -180,3 +180,31 @@ class Test_W_Progress:
         assert 'Current iteration:          51' in output
         assert 'Run state:' not in output
 
+    def test_render_once_complete_sidecar_fallback_when_hdf5_unreadable(self, ref_50iter):
+        tool = WProgress()
+        tool.we_h5filename = self.h5_filepath
+        sidecar_snapshot = progress_snapshot_from_run_status(
+            live_status(
+                west_h5file=self.h5_filepath,
+                run_state=RUN_STATE_COMPLETE,
+                phase='complete',
+                current_iteration=51,
+                latest_completed_iteration=50,
+                segment_prepared=0,
+                recent_walltimes=[12.0],
+            )
+        )
+        unreadable_hdf5_snapshot = ProgressSnapshot(
+            we_h5filename=self.h5_filepath,
+            updated_at=1,
+            error='Unable to open west.h5',
+        )
+
+        with mock.patch.object(tool, 'sidecar_snapshot', return_value=(sidecar_snapshot, RunStatusReadResult(path='status'))):
+            with mock.patch.object(tool, 'snapshot', return_value=unreadable_hdf5_snapshot):
+                output = tool.render_once(include_hint=False)
+
+        assert 'Could not read west.h5' in output
+        assert 'Run state:                  Complete' in output
+        assert 'Error:' not in output
+

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -117,3 +117,23 @@ class Test_W_Progress:
         assert 'Status' in output
         assert 'Using live status data.' in output
 
+    def test_render_live_status_snapshot(self):
+        snapshot = progress_snapshot_from_run_status(
+            live_status(iteration_started_at=0, recent_walltimes=[12.4, 11.8, 13.1]),
+            now=20,
+        )
+
+        assert snapshot.updated_at == 20
+        assert snapshot.status_updated_at == 0
+        output = render_progress(snapshot, refresh_interval=1.0)
+
+        assert 'Run state:                  Running' in output
+        assert 'Phase:                      Propagating' in output
+        assert 'Live status updated:' in output
+        assert 'Current iteration:          37' in output
+        assert 'Prepared:                   18 / 100' in output
+        assert 'Failed:                     0 / 100' in output
+        assert 'Current iter elapsed:       20.0s' in output
+        assert 'Completed walltime:         10m 42s' in output
+        assert 'Completed segments:         9985' in output
+

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -13,3 +13,25 @@ from westpa.tools.progress_status import (
 )
 
 
+def live_status(**overrides):
+    status = {
+        'west_h5file': 'west.h5',
+        'updated_at': 0,
+        'run_state': RUN_STATE_RUNNING,
+        'phase': 'propagating',
+        'current_iteration': 37,
+        'latest_completed_iteration': 36,
+        'requested_total_iterations': 50,
+        'segment_total': 100,
+        'segment_prepared': 18,
+        'segment_failed': 0,
+        'iteration_started_at': None,
+        'recent_walltimes': [],
+        'completed_walltime': 642,
+        'completed_segments': 9985,
+        'message': None,
+    }
+    status.update(overrides)
+    return status
+
+

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -137,3 +137,25 @@ class Test_W_Progress:
         assert 'Completed walltime:         10m 42s' in output
         assert 'Completed segments:         9985' in output
 
+    def test_parser(self, ref_50iter):
+        tool = WProgress()
+        tool.make_parser_and_process(args=['-W', self.h5_filepath, '--refresh', '2.5'])
+
+        assert tool.we_h5filename == self.h5_filepath
+        assert tool.refresh_interval == 2.5
+        assert tool.requested_total_iterations == 50
+
+    def test_render_once_running_sidecar_does_not_open_hdf5(self, ref_50iter):
+        tool = WProgress()
+        tool.we_h5filename = self.h5_filepath
+        live_snapshot = progress_snapshot_from_run_status(
+            live_status(west_h5file=self.h5_filepath)
+        )
+
+        with mock.patch.object(tool, 'sidecar_snapshot', return_value=(live_snapshot, RunStatusReadResult(path='status'))):
+            with mock.patch.object(tool, 'snapshot', side_effect=AssertionError('west.h5 should not be opened')):
+                output = tool.render_once(include_hint=False)
+
+        assert 'Run state:                  Running' in output
+        assert 'Current iteration:          37' in output
+

--- a/tests/test_tools/test_w_progress.py
+++ b/tests/test_tools/test_w_progress.py
@@ -35,3 +35,16 @@ def live_status(**overrides):
     return status
 
 
+class Test_W_Progress:
+    def test_snapshot_completed_run(self, ref_50iter):
+        snapshot = read_progress_snapshot(self.h5_filepath, requested_total_iterations=50, recent=5)
+
+        assert snapshot.error is None
+        assert snapshot.current_iteration == 51
+        assert snapshot.latest_completed_iteration == 50
+        assert snapshot.requested_total_iterations == 50
+        assert snapshot.completed_segments == 9985
+        assert snapshot.completed_walltime > 0
+        assert snapshot.average_recent_walltime > 0
+        assert snapshot.eta_seconds == 0
+


### PR DESCRIPTION
## Issue Number
Issue https://github.com/westpa/westpa/issues/588

## Describe the changes made
This PR adds a new `w_progress` command for monitoring WESTPA simulation progress from a separate terminal.

The command displays a live terminal dashboard with the current iteration, latest completed iteration, total requested iterations when available, prepared and failed segment counts, recent iteration timings, completed walltime, completed segment count, and ETA when available.

This PR adds a lightweight live status sidecar file, `west.h5.progress.json`, written during simulation execution. `w_progress` reads this sidecar during active runs and falls back to reading `west.h5` directly when the sidecar is unavailable, or the run has completed.

## Goals and Outstanding Issues

**Features:**
- [x] Current / latest completed iteration
- [x] Total requested iterations if available
- [x] Elapsed time for recent iterations
- [x] ETA
- [x] Run summary information
- [x] Iteration data such as segment counts
- [x] Read-only `west.h5` monitoring
- [x] Tests for CLI behavior and progress calculations
- [x] Documentation for usage and limitations

## Major files changed
- [x] `setup.py` - Add `w_progress` as a console script
- [x] `src/westpa/tools/progress_status.py` - Add the `west.h5` progress and ETA logic
- [x] `src/westpa/cli/tools/w_progress.py` - Add the CLI and command options
- [x] `src/westpa/core/run_status.py` - Add sidecar status file read/write logic
- [x] `src/westpa/core/sim_manager.py` - Add status writer hooks for live run progress
- [x] `src/westpa/cli/core/w_run.py` - Initialize and update run status during `w_run`
- [x] `src/westpa/core/binning/binless_manager.py` - Add sidecar progress updates for binless simulations
- [x] `src/westpa/core/binning/mab_manager.py` - Add sidecar progress updates for MAB simulations
- [x] `tests/test_tools/test_w_progress.py` - Add tests for the progress logic and CLI
- [x] `tests/test_core/test_run_status.py` - Add tests for sidecar status file behavior
- [x] `tests/test_sim_manager.py` - Add tests for simulation manager status updates
- [x] `doc/documentation/cli.rst` - Add `w_progress` to the CLI docs index
- [x] `doc/documentation/cli/w_progress.rst` - Add reference docs for `w_progress`
- [x] `doc/documentation/core/westpa.core.rst` - Add core API docs for run status
- [x] `doc/documentation/tools/westpa.tools.rst` - Add `progress_status` to the tools API/reference documentation
- [x] `doc/users_guide/command_line_tools.rst` - Add `w_progress` to the user guide
- [x] `doc/users_guide/command_line_tools/w_progress.rst` - Add the user-facing command page for `w_progress`
- [x] `doc/users_guide/west/running.rst` - Mention `w_progress` in the running simulations guide
- [x] `doc/users_guide/west_tools.rst` - Add `w_progress` to the WESTPA tools documentation

## Status
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have read the AI POLICY document.
- [x] This PR conforms to WESTPA's AI policy.
- [x] I have declared all usage of AI in the PR description.

## Additional context
## Tests

Created unit tests using PyTest to test `w_progress`

Results:
```
tests/test_tools/test_w_progress.py::Test_W_Progress::test_snapshot_completed_run PASSED       [ 14%]
tests/test_tools/test_w_progress.py::Test_W_Progress::test_snapshot_initialized_run PASSED     [ 28%]
tests/test_tools/test_w_progress.py::Test_W_Progress::test_missing_file_is_error_snapshot PASSED [ 42%]
tests/test_tools/test_w_progress.py::Test_W_Progress::test_render_progress PASSED              [ 57%]
tests/test_tools/test_w_progress.py::Test_W_Progress::test_format_duration PASSED              [ 71%]
tests/test_tools/test_w_progress.py::Test_W_Progress::test_parser PASSED                       [ 85%]
tests/test_tools/test_w_progress.py::Test_W_Progress::test_entry_point_renders_once PASSED     [100%]

7 passed in 0.55s 
```

Ran tests for files changed:
```
.venv/bin/python -m pytest tests/test_core/test_run_status.py tests/test_tools/test_w_progress.py tests/test_sim_manager.py
======================== 89 passed, 4 skipped in 4.81s =========================
```

## Showcase

```
WESTPA Progress
Data file: /Users/edisonlaw/Documents/GitHub/westpa_tutorials/tutorial7.1-basic-nacl/west.h5
Updated: 21:09:25    west.h5 modified: 21:09:10

Run Status
Run state:                  Running
Phase:                      Propagating
Live status updated:        21:09:10

Iterations
Current iteration:          23
Latest completed:           22
Requested total:            100
Progress:                   22 / 100 iterations (22.0%)

Current Iteration Segments
Complete:                   0 / 80
Prepared:                   80
Failed:                     0

Timing
Recent walltimes:           5m 22s, 3.9s, 5m 17s, 5m 21s, 5m 23s
Current iter elapsed:       14.5s
Avg iteration time:         4m 17s
Completed walltime:         1h 28m 15s
ETA:                        5h 34m 40s

Completed segments:         1385
Refresh Rate:               1.0s
Press Ctrl-C to close
```

## AI usage declaration


I used AI assistance only to review the existing WESTPA codebase, understand project patterns, and check my own implementation for possible issues. I wrote, reviewed, and tested the final changes myself, and I take responsibility for the submitted code and documentation.
