### PR TITLE
Fix CI spontaneous failure

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,9 @@ on:
       - 'develop'
 
 concurrency:
-  # test runs from newer commits in PRs will cancel older, in-progress runs
-  # copied from https://stackoverflow.com/a/75403978/17047865
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  # test runs from newer commits in PRs will cancel older, in-progress runs if from same PR
+  # If a commit, it will not cancel anything
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
         # conda setup requires this special shell
         shell: bash -l {0}
         run: |
-          pytest -v --cov=westpa --cov-report=xml --color=yes tests
+          pytest -vvv --cov=westpa --cov-report=xml --color=yes tests
   
       - name: CodeCov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,9 @@ on:
       - 'develop'
 
 concurrency:
-  # test runs from newer commits in PRs will cancel older, in-progress runs if from same PR
-  # If a commit, it will not cancel anything
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # test runs from newer commits in PRs will cancel older, in-progress runs
+  # copied from https://stackoverflow.com/a/75403978/17047865
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,7 +17,7 @@ dependencies:
   - mdtraj
   - mdanalysis
   # testing
-  - pytest
+  - pytest <9.1.0
   - pytest-cov
   - pytest-rerunfailures
   - pytest-timeout

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,7 +17,7 @@ dependencies:
   - mdtraj
   - mdanalysis
   # testing
-  - pytest <9.1.0
+  - pytest
   - pytest-cov
   - pytest-rerunfailures
   - pytest-timeout


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
<strike>Recent runs have failed spontaneously with exit code 143. The "GitHub Copilot's explain this error" suggests that concurrency is somehow bugged. Trying it out now.  </strike>
https://github.com/westpa/westpa/actions/runs/30027058839

AI barking up the wrong tree as usual. Seems like Pytest 9.1.1 and Github runner 2.366.0 just doesn't like each other or something? Forcing pytest < 9.1.0 seemingly fixed the failure.

https://github.com/westpa/westpa/actions/runs/30028802921


## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Fix CI spontaneous failure

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] .github/workflows/test.yaml

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] I have read the AI POLICY document.
- [x] This PR conforms to WESTPA's AI policy.
- [x] I have declared all usage of AI in the PR description.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


