### PR TITLE
add nvc-specific flag to allow compilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def extensions():
     ]
 
     # Flag to prevent nvc from throwing `nvc-Error-Unknown switch` errors
-    common_cflags += ['-noswitcherror'] if os.environ.get("CC", "").rsplit('/', maxsplit=1)[-1] == 'nvc' else []
+    common_cflags += ['-noswitcherror'] if os.environ.get("CC", "").endswith('nvc') else []
 
     fasthist_module = Extension(
         'westpa.fasthist._fasthist',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from setuptools import setup, Extension
@@ -14,6 +15,9 @@ def extensions():
     common_cflags = [
         '-O3',
     ]
+
+    # Flag to prevent nvc from throwing `nvc-Error-Unknown switch` errors
+    common_cflags += ['-noswitcherror'] if os.environ.get("CC", "").rsplit('/', maxsplit=1)[-1] == 'nvc' else []
 
     fasthist_module = Extension(
         'westpa.fasthist._fasthist',


### PR DESCRIPTION
## Issue Number
<!--- Is this pull request related to any outstanding issues? If so, list the issue number. --->


## Describe the changes made
<!--- A clear and concise description of what the problem is and what you did to fix it. E.g. [...] was happening and I've changed [...] to fix it. -->
Conditionally add `-noswitcherror` during extension compilation if `CC` is set to `nvc`.

## Goals and Outstanding Issues
<!--- A clear and concise list of goals (to be) accomplished. --->
- [x] Allow compilation of westpa with nvc (The Nvidia HPC compiler) 

## Major files changed
<!--- Manually list files or include a diff link in the form of: https://github.com/user/westpa/compare/<initial SHA>..<final SHA> --->
- [x] setup.py

## Status
<!--- Delete bullet points that are not relevant. --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] I have read the AI POLICY document.
- [x] This PR conforms to WESTPA's AI policy.
- [x] I have declared all usage of AI in the PR description.

## Additional context
<!--- Add any other context or screenshots about the pull request here. --->


